### PR TITLE
Feature/datahub nicify

### DIFF
--- a/.devcontainer/antigravity/devcontainer.json
+++ b/.devcontainer/antigravity/devcontainer.json
@@ -80,7 +80,7 @@
 				"jeff-hykin.better-dockerfile-syntax",
 				"ms-azuretools.vscode-docker",
 				"formulahendry.docker-explorer",
-				"shipitsmarter.sops-edit",
+				"signageos.signageos-vscode-sops",
 				"davidanson.vscode-markdownlint",
 				"samuelcolvin.jinjahtml",
 				"tamasfe.even-better-toml",

--- a/.devcontainer/cursor/README.md
+++ b/.devcontainer/cursor/README.md
@@ -45,6 +45,36 @@ These run once per devcontainer create (not on every shell):
 `scripts/load-env.sh` is sourced from `~/.bashrc` and only handles PATH, aliases, and
 environment variables (including SOPS decryption when needed).
 
+## SOPS in the editor
+
+Devcontainers install `signageos.signageos-vscode-sops` (`@signageos/vscode-sops`).
+It is published on Open VSX and works in both Cursor and VS Code. Encrypted files
+(see `.sops.yaml`) are edited in-place; the CLI `sops` binary is on `PATH` in the
+container image.
+
+## Ruff extension (Cursor)
+
+`charliermarsh.ruff` is **not** listed in `devcontainer.json` extensions because
+Cursor's marketplace UI can hang forever on "Installing" (dependency cycle between
+`ms-python.python`, Pylance, and `anysphere.cursorpyright`; see
+[astral-sh/ruff-vscode#943](https://github.com/astral-sh/ruff-vscode/issues/943)).
+
+`postCreateCommand` runs `scripts/install-cursor-ruff-extension.sh`, which installs
+Ruff via the Cursor remote CLI. If that fails, formatting and linting still work via:
+
+```bash
+uv run ruff check middleware/
+uv run ruff format middleware/
+# or
+./scripts/quality-fix.sh
+```
+
+Manual install (inside the container):
+
+```bash
+bash scripts/install-cursor-ruff-extension.sh
+```
+
 For a **local clone outside devcontainers**, run once after `uv sync`:
 
 ```bash

--- a/.devcontainer/cursor/devcontainer.json
+++ b/.devcontainer/cursor/devcontainer.json
@@ -27,7 +27,7 @@
 				"jeff-hykin.better-dockerfile-syntax",
 				"ms-azuretools.vscode-docker",
 				"formulahendry.docker-explorer",
-				"shipitsmarter.sops-edit",
+				"signageos.signageos-vscode-sops",
 				"davidanson.vscode-markdownlint",
 				"samuelcolvin.jinjahtml",
 				"tamasfe.even-better-toml",
@@ -42,7 +42,6 @@
 				"donjayamanne.githistory",
 				"codezombiech.gitignore",
 				"github.copilot-chat",
-				"charliermarsh.ruff",
 				"tim-koehler.helm-intellisense",
 				"vadzimnestsiarenka.helm-template-preview-and-more",
 				"jebbs.plantuml"
@@ -55,6 +54,7 @@
 		"install dev hooks": "bash ${containerWorkspaceFolder}/scripts/install-dev-hooks.sh",
 		"setup container gpg": "bash ${containerWorkspaceFolder}/scripts/setup-container-gpg.sh",
 		"setup container docker": "bash ${containerWorkspaceFolder}/scripts/setup-container-docker.sh",
+		"install ruff extension (cursor)": "bash ${containerWorkspaceFolder}/scripts/install-cursor-ruff-extension.sh",
 		"setup bashrc": "grep -qF 'source \\${containerWorkspaceFolder}/scripts/load-env.sh' ~/.bashrc || echo 'source \\${containerWorkspaceFolder}/scripts/load-env.sh' >> ~/.bashrc"
 	},
 	"remoteUser": "vscode"

--- a/.devcontainer/vscode/devcontainer.json
+++ b/.devcontainer/vscode/devcontainer.json
@@ -23,7 +23,7 @@
 				"jeff-hykin.better-dockerfile-syntax",
 				"ms-azuretools.vscode-docker",
 				"formulahendry.docker-explorer",
-				"shipitsmarter.sops-edit",
+				"signageos.signageos-vscode-sops",
 				"davidanson.vscode-markdownlint",
 				"samuelcolvin.jinjahtml",
 				"tamasfe.even-better-toml",

--- a/.env.integration.enc
+++ b/.env.integration.enc
@@ -1,8 +1,8 @@
 {
-	"data": "ENC[AES256_GCM,data:sMRHlAYh2PNdvyW6agZwq4F06AB8e6606bcxSv8HPCmUHxKRLhpOdMoZn1kUQ7EAgerl7ZpWoBj9u/2EEoyqkwGoGKeK76pwGiZb70bV3Nnq/2wlB3SQ8w3pDVxXFTNhDIm+w6xnjRqJhhyMyiOAz1QhtoKpNGDF9V1YHlOPLL082AxkefaNNanNowtWSw==,iv:fNIfHeB3W8t68g3w54QJicYepLw9tR0BF+6BsEXFvBk=,tag:yqVKHl3NzNxMN4ij6bk50g==,type:str]",
+	"data": "ENC[AES256_GCM,data:l2wGTlNAdjaraVvI8Yd3IRl9BOw1O0V8itZzFre3MK8CVANlNhbE9LTSnvaXPjvma8s6u/9+239G8Poz24wh1ZezSXcT4+FO+X/fQD1hjLrNDD75fDZ0GXjSgNcD4eQKmU46/9IJm9Cbrk0fyJ3NWlBkjmih6nZFyHiLrEniuAccrm03MvaKy1tGOPOZD9Em1Q==,iv:Ttv3YP/l/FGktrx6ciGlQvLu8hutm/9RLnGUMev/MhU=,tag:EWG8UgLNY3hxRsbOn/2zng==,type:str]",
 	"sops": {
-		"lastmodified": "2026-03-24T10:36:49Z",
-		"mac": "ENC[AES256_GCM,data:kWqd6tHjrH6kCO8H48h8PymkAHb1VuqSKs8lPWo9dtNz7bE5YkM0C9SbX7kMkAmmEApmNCpCMaScaEEG/BW8BoIVnm8T2rRs2Y5q5AvSGxmoQm1DN1afzmHo67pPP4j8H0ktvQl31wRneLEQANL3GjxrHfBfwk3f805SI6qwJkA=,iv:PUMQ8RV4rpIxLSBn5ceQ2Xj7KbyUBasbHWNrCsftbdI=,tag:9SjUfLhNRfZtqGFN10GTNw==,type:str]",
+		"lastmodified": "2026-06-18T16:56:26Z",
+		"mac": "ENC[AES256_GCM,data:k9AyI87KMGjWA6dZuhEouQWom0GRYfjSbgrlhAV9xp3fTcwHavj1NFjh5dIUy9DIpRpm7QwKmyfySWqeI8JOtmXIOaQmH0y1YvD4/LHaABPATg/XtbeLEW3AgDbv3IqfR+drn0l7rQ/+RA1vkQEg7ExZJRqBDbqJYcQivuCHlsg=,iv:ABZO2WwH90mTAUPLQREutiLlmAzpw0b/VlBmaW34OjE=,tag:6LmvO66FeCIDHjWVQWJHvg==,type:str]",
 		"pgp": [
 			{
 				"created_at": "2026-03-24T10:36:49Z",
@@ -15,6 +15,7 @@
 				"fp": "CC7B10CE8D78010ABB043F8DB1C462E90012ECFE"
 			}
 		],
+		"unencrypted_suffix": "_unencrypted",
 		"version": "3.11.0"
 	}
 }

--- a/.gitignore
+++ b/.gitignore
@@ -213,6 +213,7 @@ scratch/
 **/*.csv
 **/*.stats
 
+# Local decrypt artifacts (CLI or legacy editor temp files; do not commit)
 **/*.decrypted.*
 
 # Cryptographic keys and certificates for testing that are not meant to be committed

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,7 @@
     "jeff-hykin.better-dockerfile-syntax",
     "ms-azuretools.vscode-docker",
     "formulahendry.docker-explorer",
-    "shipitsmarter.sops-edit",
+    "signageos.signageos-vscode-sops",
     "davidanson.vscode-markdownlint",
     "samuelcolvin.jinjahtml",
     "tamasfe.even-better-toml",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,9 +10,6 @@
   "python.testing.pytestPath": ".venv/bin/pytest",
   "python.testing.cwd": "${workspaceFolder}",
   "python.defaultInterpreterPath": ".venv/bin/python",
-  "python.analysis.autoSearchPaths": true,
-  "python.analysis.useLibraryCodeForTypes": true,
-  "python-envs.pythonProjects": [],
 
   // Treat Helm templates as templating files instead of plain YAML
   "files.associations": {
@@ -37,8 +34,9 @@
     }
   },
 
-  "sops-edit.onlyUseButtons": false,
-  "sops-edit.tempFilePreExtension": "decrypted",
+  // @signageos/vscode-sops — Open VSX; VS Code Marketplace + Cursor
+  "sops.enabled": true,
+  "sops.binPath": "sops",
 
   "mypy.configFile": "pyproject.toml",
 
@@ -52,8 +50,6 @@
     "--rcfile=pyproject.toml"
   ],
   "pylint.importStrategy": "fromEnvironment",
-
-  "python-envs.defaultEnvManager": "ms-python.python:venv",
 
   "remote.autoForwardPortsSource": "process",
 

--- a/dev_environment/middleware-api-config.yaml
+++ b/dev_environment/middleware-api-config.yaml
@@ -9,6 +9,13 @@ git_repo:
   url: https://datahub-dev.ipk-gatersleben.de
   group: FAIRagro-advanced-middleware-dev
   max_workers: 10
+  rdi_gitlab_topics:
+    bonares: bonares
+    edal: "e!DAL"
+    edaphobase: edaphobase
+    openagrar: openagrar
+    publisso: publisso
+    thunen_atlas: thunen_atlas
 known_rdis:
 - bonares
 - edal

--- a/helmchart/fairagro-advanced-middleware-api-chart/templates/_helpers.tpl
+++ b/helmchart/fairagro-advanced-middleware-api-chart/templates/_helpers.tpl
@@ -25,9 +25,22 @@ If release name contains chart name it will be used as a full name.
 
 {{/*
 Create chart name and version as used by the chart label.
+
+Kubernetes label values are limited to 63 characters and must start/end with
+an alphanumeric character. The chart name alone is 38 characters, so long
+pre-release versions (e.g. 2.8.1-rc.datahub-nicify.1) exceed the limit when
+combined. Use a shorter chart alias only when the full label would overflow;
+never blind-truncate the combined string (that drops the run suffix and can
+leave a trailing '.').
 */}}
 {{- define "fairagro-advanced-middleware-api-chart.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- $version := .Chart.Version | replace "+" "_" -}}
+{{- $chartLabelName := .Chart.Name -}}
+{{- if gt (len (printf "%s-%s" $chartLabelName $version)) 63 -}}
+{{- $chartLabelName = "fairagro-amw-api-chart" -}}
+{{- end -}}
+{{- $label := printf "%s-%s" $chartLabelName $version -}}
+{{- $label | trunc 63 | trimSuffix "-" | trimSuffix "." | trimSuffix "_" | trimSuffix "-" | trimSuffix "." | trimSuffix "_" -}}
 {{- end }}
 
 {{/*

--- a/helmchart/fairagro-advanced-middleware-api-chart/values.yaml
+++ b/helmchart/fairagro-advanced-middleware-api-chart/values.yaml
@@ -13,6 +13,13 @@ config:
     url: https://datahub-dev.ipk-gatersleben.de
     group: FAIRagro-advanced-middleware-dev
     max_workers: 10
+    rdi_gitlab_topics:
+      bonares: bonares
+      edal: "e!DAL"
+      edaphobase: edaphobase
+      openagrar: openagrar
+      publisso: publisso
+      thunen_atlas: thunen_atlas
   known_rdis:
     - bonares
     - edal

--- a/helmchart/fairagro-advanced-middleware-api-chart/values.yaml
+++ b/helmchart/fairagro-advanced-middleware-api-chart/values.yaml
@@ -17,9 +17,9 @@ config:
       bonares: bonares
       edal: "e!DAL"
       edaphobase: edaphobase
-      openagrar: openagrar
-      publisso: publisso
-      thunen_atlas: thunen_atlas
+      openagrar: "OpenAgrar Repository"
+      publisso: Publisso
+      thunen_atlas: "Thunen Atlas"
   known_rdis:
     - bonares
     - edal

--- a/middleware/api/spec/arc-manager/design.md
+++ b/middleware/api/spec/arc-manager/design.md
@@ -13,13 +13,15 @@ arc-upload/               arc-harvest-upload/
     └─────────────┬─────────────┘
                   ▼
     ArcManager.create_or_update_arc(rdi, arc, client_id, harvest_id=None)
-        ├─→ extract_identifier(arc)              ← validation
+        ├─→ RoCratePayload validation              ← HTTP or parse_rocrate
         ├─→ DocumentStore.store_arc(...)         ← fast CouchDB write
         ├─→ DocumentStore.increment_harvest_statistics(...)  ← if harvest_id
         └─→ TaskDispatcher.dispatch_sync_arc(...)            ← if new or changed
 
 ArcManager also owns the worker-side counterpart (separate spec: arc-store/):
     └─→ ArcManager.sync_to_gitlab(rdi, arc)
+            ├─→ parse_rocrate (defence in depth for queued payloads)
+            └─→ ArcStore.create_or_update(..., rdi=rdi)
 ```
 
 ## Key Decisions
@@ -43,10 +45,11 @@ ArcManager also owns the worker-side counterpart (separate spec: arc-store/):
    Calling `create_or_update_arc` without a dispatcher raises `BusinessLogicError`
    immediately, making accidental misuse visible during development.
 
-4. **`identifier` extracted once before storage**
-   — `extract_identifier` traverses the RO-Crate JSON graph. The extracted
-   value is passed directly into `DocumentStore.store_arc`, avoiding a second
-   traversal inside the store.
+4. **`identifier` extracted once during RO-Crate validation**
+   — `RoCratePayload` validates the wire format (`@context`, `@graph`, root
+   dataset `./` with non-empty `identifier`). Validator functions read
+   `identifier`, `name`, and `description` from that root node; other root
+   properties remain in `@graph` unchanged.
 
 5. **Idempotency via content hash**
    — `DocumentStore.store_arc` computes a hash of the serialized ARC and sets
@@ -65,3 +68,10 @@ ArcManager also owns the worker-side counterpart (separate spec: arc-store/):
    ingestion pipeline dispatches the raw `dict` to Celery; the worker
    re-parses it with `ARC.from_rocrate_json_string`. This avoids serialization
    errors and keeps the Celery task payload simple JSON.
+
+8. **Display metadata derived inside `GitRepo`, not at ingest time**
+   — Human-readable GitLab labels (`name`, `description`, RDI topic) are built
+   by ``git_project_metadata_from_arc`` when ``GitRepo`` calls
+   ``GitlabGitProvider.ensure_repo_exists``. Ingest (`create_or_update_arc`) does
+   not need this metadata because CouchDB stores the full ARC document; only
+   ``rdi`` crosses into ``ArcStore`` as middleware context.

--- a/middleware/api/spec/arc-manager/design.md
+++ b/middleware/api/spec/arc-manager/design.md
@@ -8,19 +8,19 @@ resolve their preconditions (authorization, harvest lookup) before calling it,
 so the method itself is HTTP-agnostic and safe to call from a worker context.
 
 ```text
-arc-upload/               arc-harvest-upload/
+arc-upload/               harvest-arc-upload/
     │                           │
     └─────────────┬─────────────┘
                   ▼
     ArcManager.create_or_update_arc(rdi, arc, client_id, harvest_id=None)
         ├─→ RoCratePayload validation              ← HTTP or parse_rocrate
-        ├─→ DocumentStore.store_arc(...)         ← fast CouchDB write
-        ├─→ DocumentStore.increment_harvest_statistics(...)  ← if harvest_id
+        ├─→ DocumentStore.store_arc(...)         ← fast CouchDB write (+ harvest metadata if harvest_id)
         └─→ TaskDispatcher.dispatch_sync_arc(...)            ← if new or changed
 
-ArcManager also owns the worker-side counterpart (separate spec: arc-store/):
+ArcManager also owns the worker-side counterpart (separate spec: `arc-store/`):
     └─→ ArcManager.sync_to_gitlab(rdi, arc)
-            ├─→ parse_rocrate (defence in depth for queued payloads)
+            ├─→ parse_rocrate (lightweight re-validation of queued JSON)
+            ├─→ ARC.from_rocrate_json_string(...)   ← arctrl parse (worker only)
             └─→ ArcStore.create_or_update(..., rdi=rdi)
 ```
 
@@ -46,10 +46,11 @@ ArcManager also owns the worker-side counterpart (separate spec: arc-store/):
    immediately, making accidental misuse visible during development.
 
 4. **`identifier` extracted once during RO-Crate validation**
-   — `RoCratePayload` validates the wire format (`@context`, `@graph`, root
-   dataset `./` with non-empty `identifier`). Validator functions read
-   `identifier`, `name`, and `description` from that root node; other root
-   properties remain in `@graph` unchanged.
+   — `RoCratePayload` (`middleware/shared/api_models/common/rocrate.py`)
+   validates the wire format (`@context`, `@graph`, root dataset `./` with
+   non-empty `identifier`). Validator functions read `identifier`, `name`, and
+   `description` from that root node; other root properties remain in `@graph`
+   unchanged. The RoCrate wire contract is documented in `arc-manager/spec.md`.
 
 5. **Idempotency via content hash**
    — `DocumentStore.store_arc` computes a hash of the serialized ARC and sets
@@ -57,11 +58,12 @@ ArcManager also owns the worker-side counterpart (separate spec: arc-store/):
    prevents redundant Celery tasks and GitLab commits on re-submission of
    unchanged ARCs, making the pipeline safe to call repeatedly.
 
-6. **Harvest statistics incremented unconditionally when `harvest_id` is set**
-   — The counter is incremented regardless of whether the ARC content changed.
-   A re-submitted unchanged ARC still counts as a processed dataset from the
-   harvest's perspective. This keeps the counter semantics simple: one
-   increment per ARC received, not per ARC written.
+6. **Harvest statistics derived at finalize, not incremented per ARC**
+   — `store_arc` stamps harvest context on each ARC document (`last_harvest_id`,
+   `first_harvest_id`, `last_changed_harvest_id`). When a harvest transitions to a
+   terminal status, `HarvestManager` calls `DocumentStore.get_harvest_statistics`
+   to classify submitted ARCs as new, updated, or unchanged. There is no per-ARC
+   counter write on the harvest document during ingest.
 
 7. **ARC crosses process boundary as a `dict`, not an `ARC` object**
    — ARCtrl objects carry .NET interop state and must not be pickled. The
@@ -69,7 +71,14 @@ ArcManager also owns the worker-side counterpart (separate spec: arc-store/):
    re-parses it with `ARC.from_rocrate_json_string`. This avoids serialization
    errors and keeps the Celery task payload simple JSON.
 
-8. **Display metadata derived inside `GitRepo`, not at ingest time**
+8. **No arctrl parse on the API ingest path**
+   — `parse_rocrate` applies only `RoCratePayload` validation (cheap: `@context`,
+   `@graph`, root `./`, non-empty `identifier`). `ARC.from_rocrate_json_string`
+   is intentionally **not** called in `create_or_update_arc`; that step is
+   expensive and runs once in the Celery worker during `sync_to_gitlab`. The API
+   writes the JSON to CouchDB and returns immediately.
+
+9. **Display metadata derived inside `GitRepo`, not at ingest time**
    — Human-readable GitLab labels (`name`, `description`, RDI topic) are built
    by ``git_project_metadata_from_arc`` when ``GitRepo`` calls
    ``GitlabGitProvider.ensure_repo_exists``. Ingest (`create_or_update_arc`) does

--- a/middleware/api/spec/arc-manager/spec.md
+++ b/middleware/api/spec/arc-manager/spec.md
@@ -6,10 +6,20 @@ triggered by two HTTP endpoints (`arc-upload/` and `harvest-arc-upload/`) and
 must not assume it runs inside an HTTP request. The GitLab sync itself is
 specified in `arc-store/`.
 
+## RoCrate wire contract
+
+The `RoCratePayload` model (`middleware/shared/api_models/common/rocrate.py`) is
+the single source of truth for structural ARC validation: `@context`, `@graph`, a
+root data entity with `@id: "./"`, and a non-empty `identifier` (leading and
+trailing whitespace trimmed). Optional root fields `name` and `description` are
+exposed as read-only properties but remain in `@graph` unchanged. See
+`arc-manager/design.md` decision 4.
+
 ## Requirements
 
 - [ ] Accept only a validated `RoCratePayload` (or raw dict validated to the
-      same contract) with a non-empty root-dataset `identifier`.
+      RoCrate wire contract above). Validation is structural only — no arctrl
+      parse on this path.
 - [ ] Persist the validated ARC in the document store.
 - [ ] Report `CREATED` when no prior record exists for this ARC.
 - [ ] Report `UPDATED` when a prior record exists and the content has changed.
@@ -17,25 +27,48 @@ specified in `arc-store/`.
       identical to what is already stored — without writing to the store again.
 - [ ] Schedule a background GitLab sync if and only if the ARC is new or its
       content has changed.
-- [ ] During GitLab sync, derive human-readable display metadata from the ARC
-      payload (root dataset `name` and `description`, `identifier`, and `rdi`)
-      and pass it to the Git store (see `arc-store/`).
-- [ ] When a harvest context is provided, increment the harvest run's counters
-      (new-ARC and changed-ARC) in the document store after persisting, regardless
-      of whether a background sync was scheduled.
+- [ ] During GitLab sync, delegate persistence to `arc-store/`; human-readable
+      GitLab display metadata is derived there from the parsed arctrl ARC (see
+      `arc-store/`).
+- [ ] When a harvest context is provided, record harvest context on the ARC
+      document via `DocumentStore.store_arc` (`last_harvest_id`, and
+      `first_harvest_id` / `last_changed_harvest_id` when applicable). Per-harvest
+      counters are derived at finalize via `get_harvest_statistics` (see
+      `harvest-manager/`), not incremented on each ingest call.
 - [ ] Return an internal result to the caller containing the ARC identifier, its
       status (`CREATED` or `UPDATED`), a timestamp, the originating `rdi`, and
       the caller's `client_id`. The HTTP layer (see `arc-upload/` and
       `harvest-arc-upload/`) decides which of these fields to expose in the
       HTTP response.
 
+## HTTP caller contract
+
+Both `arc-upload/` and `harvest-arc-upload/` map outcomes as follows (unless an
+endpoint-specific rule overrides):
+
+| Condition | HTTP status |
+| --------- | ----------- |
+| Invalid RO-Crate structure (`RoCratePayload` / `InvalidJsonSemanticError`) | `422 Unprocessable Entity` |
+| Unexpected pipeline error (`BusinessLogicError`) | `500 Internal Server Error` |
+| ARC stored but metadata fetch returns `None` | `500 Internal Server Error` |
+
+`InvalidJsonSemanticError` is raised by `parse_rocrate` when Pydantic validation
+fails; it denotes structural wire-format errors, not arctrl semantic failures.
+
 ## Edge Cases
 
-Missing or invalid RO-Crate structure → `422` at the HTTP layer; worker path
-re-validates queued payloads and maps failures to `InvalidJsonSemanticError`.
+Missing or invalid RO-Crate structure → `422` at the HTTP layer (`RoCratePayload`
+validation). The worker re-validates queued JSON with `parse_rocrate`, then
+parses with arctrl during Git sync; arctrl failures surface as failed sync
+tasks / `GIT_PUSH_FAILED` events, not as HTTP `422` to the original caller.
 
-Unchanged ARC re-submitted → no write to the store, no background sync scheduled; harvest
-counters still incremented (the ARC was received and processed).
+RO-Crate JSON that passes API validation but cannot be parsed by arctrl →
+accepted and stored in CouchDB; Git sync fails permanently in the worker.
+
+Unchanged ARC re-submitted → no background sync scheduled; `store_arc` still
+updates `last_seen` / `last_harvest_id` on the ARC document. Re-submitting the
+same ARC twice within one harvest raises `DuplicateArcError` (HTTP `409` in
+`harvest-arc-upload/`).
 
 Harvest counter increment fails → error propagates to the caller; the ARC is already
 persisted at this point.

--- a/middleware/api/spec/arc-manager/spec.md
+++ b/middleware/api/spec/arc-manager/spec.md
@@ -11,7 +11,9 @@ specified in `arc-store/`.
 The `RoCratePayload` model (`middleware/shared/api_models/common/rocrate.py`) is
 the single source of truth for structural ARC validation: `@context`, `@graph`, a
 root data entity with `@id: "./"`, and a non-empty `identifier` (leading and
-trailing whitespace trimmed). Optional root fields `name` and `description` are
+trailing whitespace trimmed). Text fields (`identifier`, `name`, `description`)
+may be plain JSON strings, a single-element string array, or JSON-LD value
+objects (`{"@value": "..."}`). Optional root fields `name` and `description` are
 exposed as read-only properties but remain in `@graph` unchanged. See
 `arc-manager/design.md` decision 4.
 

--- a/middleware/api/spec/arc-manager/spec.md
+++ b/middleware/api/spec/arc-manager/spec.md
@@ -8,8 +8,8 @@ specified in `arc-store/`.
 
 ## Requirements
 
-- [ ] Reject an ARC payload that does not contain an `identifier` field; callers
-      map this rejection to a `422` response.
+- [ ] Accept only a validated `RoCratePayload` (or raw dict validated to the
+      same contract) with a non-empty root-dataset `identifier`.
 - [ ] Persist the validated ARC in the document store.
 - [ ] Report `CREATED` when no prior record exists for this ARC.
 - [ ] Report `UPDATED` when a prior record exists and the content has changed.
@@ -17,6 +17,9 @@ specified in `arc-store/`.
       identical to what is already stored — without writing to the store again.
 - [ ] Schedule a background GitLab sync if and only if the ARC is new or its
       content has changed.
+- [ ] During GitLab sync, derive human-readable display metadata from the ARC
+      payload (root dataset `name` and `description`, `identifier`, and `rdi`)
+      and pass it to the Git store (see `arc-store/`).
 - [ ] When a harvest context is provided, increment the harvest run's counters
       (new-ARC and changed-ARC) in the document store after persisting, regardless
       of whether a background sync was scheduled.
@@ -28,7 +31,8 @@ specified in `arc-store/`.
 
 ## Edge Cases
 
-Missing `identifier` in payload → reject with a descriptive error; callers map this to `422`.
+Missing or invalid RO-Crate structure → `422` at the HTTP layer; worker path
+re-validates queued payloads and maps failures to `InvalidJsonSemanticError`.
 
 Unchanged ARC re-submitted → no write to the store, no background sync scheduled; harvest
 counters still incremented (the ARC was received and processed).

--- a/middleware/api/spec/arc-store/design.md
+++ b/middleware/api/spec/arc-store/design.md
@@ -87,9 +87,15 @@ in the group project list, and the full text on the project overview page.
 ### RDI names and GitLab topics
 
 By the time `GitlabGitProvider` runs, `rdi` has already passed API validation
-(see `arc-upload/` and `harvest-arc-upload/`). `normalize_gitlab_topic` only
-adapts the name to GitLab's topic format (lowercase; map characters outside
-`a-z`, `0-9`, and `-` to hyphens).
+(see `arc-upload/` and `harvest-arc-upload/`). ``GitRepoConfig.rdi_gitlab_topics``
+maps middleware RDI names to instance topic labels when they differ (for example
+``edal`` → ``e!DAL``). Mapped values are sent to GitLab as-is. Unmapped RDIs use
+``normalize_gitlab_topic`` only when ``known_rdis`` is empty (tests); otherwise
+``Config`` and ``WorkerConfig`` require exactly one non-empty mapping entry per
+``known_rdis`` key at startup.
+
+Each sync sets the project ``topics`` list to exactly one resolved RDI topic,
+replacing any previous topics on that project.
 
 `ensure_repo_exists` applies metadata on project creation. For projects that
 already exist, `apply_gitlab_project_metadata` compares the current GitLab values

--- a/middleware/api/spec/arc-store/design.md
+++ b/middleware/api/spec/arc-store/design.md
@@ -57,16 +57,17 @@ project fields so operators can browse ARC repositories without decoding hashes.
 `GitProjectMetadata` (`remote_git_provider.py`) carries the display fields.
 `GitRepo` builds it via ``git_project_metadata_from_arc(arc, rdi, arc_id=...)``
 before calling ``GitlabGitProvider.ensure_repo_exists``. The GitLab project title
-uses ``arc.Identifier`` (stripped); ``calculate_arc_id`` applies the same
-normalization when deriving ``arc_id``. Display fields ``Title`` (RO-Crate
-``name``) and ``Description`` are read from the arctrl object. ``display_name``
-is always a string; when ``Title`` is absent, the helper passes ``""``.
+is ``{sanitized arc.Identifier} ({rdi})`` so the `name` stays unique within a
+group when the same ARC identifier appears under different RDIs; the repository
+path remains ``arc_id``. Display fields ``Title`` (RO-Crate ``name``) and
+``Description`` are read from the arctrl object. ``display_name`` is always a
+string; when ``Title`` is absent, the helper passes ``""``.
 Structural RO-Crate validation on ingest is specified in `arc-manager/`.
 
 | Field | Required | Source |
 | ----- | -------- | ------ |
 | `rdi` | yes | originating RDI name passed into the sync |
-| `identifier` | yes | ``arc.Identifier`` (stripped) |
+| `identifier` | yes | ``{sanitized arc.Identifier} ({rdi})`` — GitLab project `name` |
 | `display_name` | yes (`""` if absent) | ``arc.Title`` (RO-Crate ``name``) |
 | `description` | no | ``arc.Description`` |
 
@@ -75,7 +76,7 @@ Mapping to GitLab project attributes:
 | GitLab attribute | Where it appears | Value |
 | ---------------- | ---------------- | ----- |
 | `path` | clone URL / slug | `arc_id` (stable) |
-| `name` | project list title | `identifier` |
+| `name` | project list title | `identifier` (`{sanitized arc.Identifier} ({rdi})`) |
 | `description` | truncated preview in list; full text on project home | RO-Crate `name`, then `description` (when present) |
 | `topics` | tag chips in list | `rdi` in GitLab-topic form (lowercased; see below) |
 

--- a/middleware/api/spec/arc-store/design.md
+++ b/middleware/api/spec/arc-store/design.md
@@ -57,7 +57,7 @@ project fields so operators can browse ARC repositories without decoding hashes.
 `GitProjectMetadata` (`remote_git_provider.py`) carries the display fields.
 `GitRepo` builds it via ``git_project_metadata_from_arc(arc, rdi, arc_id=...)``
 before calling ``GitlabGitProvider.ensure_repo_exists``. The GitLab project title
-is ``{sanitized arc.Identifier} ({rdi})`` so the `name` stays unique within a
+is ``{sanitized arc.Identifier} - {rdi}`` so the `name` stays unique within a
 group when the same ARC identifier appears under different RDIs; the repository
 path remains ``arc_id``. Display fields ``Title`` (RO-Crate ``name``) and
 ``Description`` are read from the arctrl object. ``display_name`` is always a
@@ -67,7 +67,7 @@ Structural RO-Crate validation on ingest is specified in `arc-manager/`.
 | Field | Required | Source |
 | ----- | -------- | ------ |
 | `rdi` | yes | originating RDI name passed into the sync |
-| `identifier` | yes | ``{sanitized arc.Identifier} ({rdi})`` — GitLab project `name` |
+| `identifier` | yes | ``{sanitized arc.Identifier} - {rdi}`` — GitLab project `name` |
 | `display_name` | yes (`""` if absent) | ``arc.Title`` (RO-Crate ``name``) |
 | `description` | no | ``arc.Description`` |
 
@@ -76,7 +76,7 @@ Mapping to GitLab project attributes:
 | GitLab attribute | Where it appears | Value |
 | ---------------- | ---------------- | ----- |
 | `path` | clone URL / slug | `arc_id` (stable) |
-| `name` | project list title | `identifier` (`{sanitized arc.Identifier} ({rdi})`) |
+| `name` | project list title | `identifier` (`{sanitized arc.Identifier} - {rdi}`) |
 | `description` | truncated preview in list; full text on project home | RO-Crate `name`, then `description` (when present) |
 | `topics` | tag chips in list | `rdi` in GitLab-topic form (lowercased; see below) |
 

--- a/middleware/api/spec/arc-store/design.md
+++ b/middleware/api/spec/arc-store/design.md
@@ -20,8 +20,9 @@ itself only handles Git.
 ```text
 ArcManager.sync_to_gitlab(rdi, arc_json_string)
     ├─→ ARC.from_rocrate_json_string(arc_json_string)  ← arctrl parse
-    └─→ ArcStore.create_or_update(arc_id, arc_obj)
+    └─→ ArcStore.create_or_update(arc_id, arc_obj, rdi=...)
             └─→ GitRepo  (or GitlabApi — deprecated)
+                    ├─→ RemoteGitProvider.ensure_repo_exists(arc_id, metadata)
                     ├─→ clone / pull
                     ├─→ write ISA files via arctrl WriteAsync
                     └─→ commit + push
@@ -46,6 +47,63 @@ Git errors are classified at push time:
 - `is_soft_git_error(exc)` → repo or branch not found; treated as permanent
 - All other `GitCommandError` → permanent
 
+## GitLab Project Metadata
+
+When `GitRepo` talks to GitLab via `GitlabGitProvider`, repository creation is
+not limited to the hashed `arc_id`. The provider also sets human-readable GitLab
+project fields so operators can browse ARC repositories without decoding hashes.
+
+`GitProjectMetadata` (`remote_git_provider.py`) carries the display fields.
+`GitRepo` builds it via ``git_project_metadata_from_arc(arc, rdi)`` before calling
+``GitlabGitProvider.ensure_repo_exists``. The helper reads ``arc.Identifier``,
+``arc.Title`` (RO-Crate ``name``), and ``arc.Description`` directly from the
+arctrl object. ``display_name`` is always a string; when ``Title`` is absent,
+the helper passes ``""``.
+Root fields are validated on the root data entity (the ``@graph`` node with
+``@id: "./"``). ``RoCratePayload`` keeps that node as an open JSON-LD dict;
+``identifier``, ``name``, and ``description`` are extracted via validator
+functions and exposed as read-only properties. They are not duplicated at the
+document top level.
+
+| Field | Required | Source |
+| ----- | -------- | ------ |
+| `rdi` | yes | originating RDI name passed into the sync |
+| `identifier` | yes | ``arc.Identifier`` |
+| `display_name` | yes (`""` if absent) | ``arc.Title`` (RO-Crate ``name``) |
+| `description` | no | ``arc.Description`` |
+
+Mapping to GitLab project attributes:
+
+| GitLab attribute | Where it appears | Value |
+| ---------------- | ---------------- | ----- |
+| `path` | clone URL / slug | `arc_id` (stable) |
+| `name` | project list title | `identifier` |
+| `description` | truncated preview in list; full text on project home | RO-Crate `name`, then `description` (when present) |
+| `topics` | tag chips in list | `rdi` in GitLab-topic form (lowercased; see below) |
+
+GitLab has no separate subtitle field. The project `description` is the right
+place for the longer RO-Crate title and summary: operators see a one-line preview
+in the group project list, and the full text on the project overview page.
+
+### RDI names and GitLab topics
+
+RDI identifiers are not free-form strings. Deployments declare the allowed set in
+configuration (`known_rdis` on the API `Config` model — same identifiers used for
+client-certificate authorization). New RDIs are added by configuration change, not
+by code change; there is intentionally no hard-coded enum.
+
+By the time `GitlabGitProvider` runs, the `rdi` on `GitProjectMetadata` has
+already passed API validation. `normalize_gitlab_topic` only adapts the
+already-known name to GitLab's topic format (lowercase; map characters outside
+`a-z`, `0-9`, and `-` to hyphens). It is not a substitute for RDI allowlisting.
+
+`ensure_repo_exists` applies metadata on project creation. For projects that
+already exist, `apply_gitlab_project_metadata` compares the current GitLab values
+and calls `project.save()` only when something changed.
+
+Non-GitLab providers (`FileSystemGitProvider`) accept the same ``GitProjectMetadata``
+parameter for a uniform interface but ignore it when creating bare repos.
+
 ## Key Decisions
 
 1. **`ArcStoreTransientError` vs permanent errors**
@@ -69,3 +127,17 @@ Git errors are classified at push time:
    — Credential injection is isolated in `RemoteGitProvider` so that `GitRepo`
    itself has no knowledge of authentication schemes. SSH and HTTPS credential
    formats differ; the provider abstracts that difference.
+
+5. **Hashed `path`, `identifier` as GitLab title**
+   — GitLab project paths are part of clone URLs and must stay equal to `arc_id`
+   for idempotency. The project `name` shows the ARC `identifier` so the group
+   project list is scannable by dataset ID. Longer RO-Crate text (`name`,
+   `description`) goes into the GitLab `description` field, which is truncated
+   in the list but shown in full on the project home page. `rdi` is a topic tag,
+   not duplicated in the description. The `rdi` value is taken from the
+   deployment allowlist (`known_rdis`), not normalized as if it were arbitrary input.
+
+6. **GitLab metadata refreshed on every sync**
+   — Existing GitLab projects created before metadata support only stored the
+   hash as the project name. Re-syncing an ARC updates title, description, and
+   RDI topic when they differ, so operators do not need a one-off migration.

--- a/middleware/api/spec/arc-store/design.md
+++ b/middleware/api/spec/arc-store/design.md
@@ -18,8 +18,9 @@ JSON, selecting the configured backend, and recording CouchDB events. The store
 itself only handles Git.
 
 ```text
-ArcManager.sync_to_gitlab(rdi, arc_json_string)
-    ├─→ ARC.from_rocrate_json_string(arc_json_string)  ← arctrl parse
+ArcManager.sync_to_gitlab(rdi, arc)
+    ├─→ parse_rocrate(arc)
+    ├─→ ARC.from_rocrate_json_string(...)     ← arctrl parse (worker only)
     └─→ ArcStore.create_or_update(arc_id, arc_obj, rdi=...)
             └─→ GitRepo  (or GitlabApi — deprecated)
                     ├─→ RemoteGitProvider.ensure_repo_exists(arc_id, metadata)
@@ -54,21 +55,18 @@ not limited to the hashed `arc_id`. The provider also sets human-readable GitLab
 project fields so operators can browse ARC repositories without decoding hashes.
 
 `GitProjectMetadata` (`remote_git_provider.py`) carries the display fields.
-`GitRepo` builds it via ``git_project_metadata_from_arc(arc, rdi)`` before calling
-``GitlabGitProvider.ensure_repo_exists``. The helper reads ``arc.Identifier``,
-``arc.Title`` (RO-Crate ``name``), and ``arc.Description`` directly from the
-arctrl object. ``display_name`` is always a string; when ``Title`` is absent,
-the helper passes ``""``.
-Root fields are validated on the root data entity (the ``@graph`` node with
-``@id: "./"``). ``RoCratePayload`` keeps that node as an open JSON-LD dict;
-``identifier``, ``name``, and ``description`` are extracted via validator
-functions and exposed as read-only properties. They are not duplicated at the
-document top level.
+`GitRepo` builds it via ``git_project_metadata_from_arc(arc, rdi, arc_id=...)``
+before calling ``GitlabGitProvider.ensure_repo_exists``. The GitLab project title
+uses ``arc.Identifier`` (stripped); ``calculate_arc_id`` applies the same
+normalization when deriving ``arc_id``. Display fields ``Title`` (RO-Crate
+``name``) and ``Description`` are read from the arctrl object. ``display_name``
+is always a string; when ``Title`` is absent, the helper passes ``""``.
+Structural RO-Crate validation on ingest is specified in `arc-manager/`.
 
 | Field | Required | Source |
 | ----- | -------- | ------ |
 | `rdi` | yes | originating RDI name passed into the sync |
-| `identifier` | yes | ``arc.Identifier`` |
+| `identifier` | yes | ``arc.Identifier`` (stripped) |
 | `display_name` | yes (`""` if absent) | ``arc.Title`` (RO-Crate ``name``) |
 | `description` | no | ``arc.Description`` |
 
@@ -87,15 +85,10 @@ in the group project list, and the full text on the project overview page.
 
 ### RDI names and GitLab topics
 
-RDI identifiers are not free-form strings. Deployments declare the allowed set in
-configuration (`known_rdis` on the API `Config` model — same identifiers used for
-client-certificate authorization). New RDIs are added by configuration change, not
-by code change; there is intentionally no hard-coded enum.
-
-By the time `GitlabGitProvider` runs, the `rdi` on `GitProjectMetadata` has
-already passed API validation. `normalize_gitlab_topic` only adapts the
-already-known name to GitLab's topic format (lowercase; map characters outside
-`a-z`, `0-9`, and `-` to hyphens). It is not a substitute for RDI allowlisting.
+By the time `GitlabGitProvider` runs, `rdi` has already passed API validation
+(see `arc-upload/` and `harvest-arc-upload/`). `normalize_gitlab_topic` only
+adapts the name to GitLab's topic format (lowercase; map characters outside
+`a-z`, `0-9`, and `-` to hyphens).
 
 `ensure_repo_exists` applies metadata on project creation. For projects that
 already exist, `apply_gitlab_project_metadata` compares the current GitLab values
@@ -128,14 +121,9 @@ parameter for a uniform interface but ignore it when creating bare repos.
    itself has no knowledge of authentication schemes. SSH and HTTPS credential
    formats differ; the provider abstracts that difference.
 
-5. **Hashed `path`, `identifier` as GitLab title**
-   — GitLab project paths are part of clone URLs and must stay equal to `arc_id`
-   for idempotency. The project `name` shows the ARC `identifier` so the group
-   project list is scannable by dataset ID. Longer RO-Crate text (`name`,
-   `description`) goes into the GitLab `description` field, which is truncated
-   in the list but shown in full on the project home page. `rdi` is a topic tag,
-   not duplicated in the description. The `rdi` value is taken from the
-   deployment allowlist (`known_rdis`), not normalized as if it were arbitrary input.
+5. **Hashed `path`, identifier as GitLab title**
+   — See the GitLab Project Metadata table above. `rdi` is a topic tag, not
+   duplicated in the project description.
 
 6. **GitLab metadata refreshed on every sync**
    — Existing GitLab projects created before metadata support only stored the

--- a/middleware/api/spec/arc-store/spec.md
+++ b/middleware/api/spec/arc-store/spec.md
@@ -21,7 +21,7 @@ recording CouchDB events, and handling retry logic.
 - [ ] Keep the Git repository path (slug) equal to `arc_id` so clone URLs remain
       stable regardless of display metadata.
 - [ ] When the remote backend is GitLab via `GitRepo`, set the project title to
-      ``{sanitized Identifier} ({rdi})`` so the GitLab `name` stays unique within
+      ``{sanitized Identifier} - {rdi}`` so the GitLab `name` stays unique within
       the group namespace when the same ARC identifier is used across RDIs. The
       repository path remains ``arc_id`` (see above).
 - [ ] When the remote backend is GitLab via `GitRepo`, set the project description

--- a/middleware/api/spec/arc-store/spec.md
+++ b/middleware/api/spec/arc-store/spec.md
@@ -20,9 +20,10 @@ recording CouchDB events, and handling retry logic.
       specifically.
 - [ ] Keep the Git repository path (slug) equal to `arc_id` so clone URLs remain
       stable regardless of display metadata.
-- [ ] When the remote backend is GitLab via `GitRepo`, set the project title from
-      the parsed ARC's ``Identifier`` (stripped), matching the normalization used
-      by ``calculate_arc_id``.
+- [ ] When the remote backend is GitLab via `GitRepo`, set the project title to
+      ``{sanitized Identifier} ({rdi})`` so the GitLab `name` stays unique within
+      the group namespace when the same ARC identifier is used across RDIs. The
+      repository path remains ``arc_id`` (see above).
 - [ ] When the remote backend is GitLab via `GitRepo`, set the project description
       from the RO-Crate root dataset `name` and `description` when present. Do
       not repeat `identifier`, `rdi`, or `arc_id` in the description — those are

--- a/middleware/api/spec/arc-store/spec.md
+++ b/middleware/api/spec/arc-store/spec.md
@@ -18,6 +18,22 @@ recording CouchDB events, and handling retry logic.
       missing permissions, corrupt ARC data).
 - [ ] Support arbitrary Git servers — the backend must not be tied to GitLab
       specifically.
+- [ ] Keep the Git repository path (slug) equal to `arc_id` so clone URLs remain
+      stable regardless of display metadata.
+- [ ] When the remote backend is GitLab, set the project title to the ARC
+      `identifier`, falling back to `arc_id`.
+- [ ] When the remote backend is GitLab, set the project description from the
+      RO-Crate root dataset `name` and `description` when present. Do not repeat
+      `identifier`, `rdi`, or `arc_id` in the description — those are already
+      visible as the project title, topic tag, and repository path respectively.
+- [ ] When the remote backend is GitLab, set a project topic (tag) to the
+      originating `rdi` name so operators can filter repositories by RDI. The
+      `rdi` is already an allowed deployment identifier (see configuration
+      `known_rdis` and `arc-upload/` / `harvest-arc-upload/`); the Git store
+      does not accept arbitrary RDI strings.
+- [ ] When a GitLab project already exists for an `arc_id`, update its title,
+      description, and RDI topic on the next sync if they differ from the
+      values derived from the current ARC payload.
 
 ## Edge Cases
 
@@ -26,3 +42,11 @@ Transient network error → raise retryable error; caller decides whether to ret
 Permanent backend error (auth failure, forbidden) → raise permanent error; no retry.
 
 ARC identifier missing or malformed → raise permanent error before any Git operation.
+
+RO-Crate root dataset has no `name` → pass `display_name=""`; the GitLab project
+description omits the name line but may still include the RO-Crate `description`.
+
+Unknown or disallowed `rdi` → rejected by the API before Git sync (`known_rdis`
+in deployment configuration, intersected with client-certificate authorization
+in `arc-upload/` and `harvest-arc-upload/`). The Git store only receives
+already-validated `rdi` values.

--- a/middleware/api/spec/arc-store/spec.md
+++ b/middleware/api/spec/arc-store/spec.md
@@ -32,7 +32,11 @@ recording CouchDB events, and handling retry logic.
 - [ ] When the remote backend is GitLab via `GitRepo`, set a project topic (tag)
       to the originating `rdi` name so operators can filter repositories by RDI
       (RDI allowlisting is enforced by the API; see `arc-upload/` and
-      `harvest-arc-upload/`).
+      `harvest-arc-upload/`). Use ``git_repo.rdi_gitlab_topics`` when the GitLab
+      instance topic catalog uses a different label (for example ``edal`` →
+      ``e!DAL``). When ``known_rdis`` is non-empty, the mapping must contain
+      exactly one non-empty entry per known RDI. Each sync replaces the project
+      topic list with that single RDI topic.
 - [ ] When a GitLab project already exists for an `arc_id` (via `GitRepo`), update
       its title, description, and RDI topic on the next sync if they differ from
       the values derived from the current ARC payload.

--- a/middleware/api/spec/arc-store/spec.md
+++ b/middleware/api/spec/arc-store/spec.md
@@ -20,20 +20,21 @@ recording CouchDB events, and handling retry logic.
       specifically.
 - [ ] Keep the Git repository path (slug) equal to `arc_id` so clone URLs remain
       stable regardless of display metadata.
-- [ ] When the remote backend is GitLab, set the project title to the ARC
-      `identifier`, falling back to `arc_id`.
-- [ ] When the remote backend is GitLab, set the project description from the
-      RO-Crate root dataset `name` and `description` when present. Do not repeat
-      `identifier`, `rdi`, or `arc_id` in the description — those are already
-      visible as the project title, topic tag, and repository path respectively.
-- [ ] When the remote backend is GitLab, set a project topic (tag) to the
-      originating `rdi` name so operators can filter repositories by RDI. The
-      `rdi` is already an allowed deployment identifier (see configuration
-      `known_rdis` and `arc-upload/` / `harvest-arc-upload/`); the Git store
-      does not accept arbitrary RDI strings.
-- [ ] When a GitLab project already exists for an `arc_id`, update its title,
-      description, and RDI topic on the next sync if they differ from the
-      values derived from the current ARC payload.
+- [ ] When the remote backend is GitLab via `GitRepo`, set the project title from
+      the parsed ARC's ``Identifier`` (stripped), matching the normalization used
+      by ``calculate_arc_id``.
+- [ ] When the remote backend is GitLab via `GitRepo`, set the project description
+      from the RO-Crate root dataset `name` and `description` when present. Do
+      not repeat `identifier`, `rdi`, or `arc_id` in the description — those are
+      already visible as the project title, topic tag, and repository path
+      respectively.
+- [ ] When the remote backend is GitLab via `GitRepo`, set a project topic (tag)
+      to the originating `rdi` name so operators can filter repositories by RDI
+      (RDI allowlisting is enforced by the API; see `arc-upload/` and
+      `harvest-arc-upload/`).
+- [ ] When a GitLab project already exists for an `arc_id` (via `GitRepo`), update
+      its title, description, and RDI topic on the next sync if they differ from
+      the values derived from the current ARC payload.
 
 ## Edge Cases
 
@@ -46,7 +47,6 @@ ARC identifier missing or malformed → raise permanent error before any Git ope
 RO-Crate root dataset has no `name` → pass `display_name=""`; the GitLab project
 description omits the name line but may still include the RO-Crate `description`.
 
-Unknown or disallowed `rdi` → rejected by the API before Git sync (`known_rdis`
-in deployment configuration, intersected with client-certificate authorization
-in `arc-upload/` and `harvest-arc-upload/`). The Git store only receives
+Unknown or disallowed `rdi` → rejected by the API before Git sync (see
+`arc-upload/` and `harvest-arc-upload/`). The Git store only receives
 already-validated `rdi` values.

--- a/middleware/api/spec/arc-upload/spec.md
+++ b/middleware/api/spec/arc-upload/spec.md
@@ -7,30 +7,22 @@ Processing is delegated to `arc-manager/`.
 ## Requirements
 
 - [ ] Accept a JSON request body conforming to `CreateArcRequest` containing
-      `rdi` and `arc` as a `RoCratePayload` (RO-Crate JSON with `@context`,
-      `@graph`, root data entity `@id: "./"`, and non-empty `identifier`).
-- [ ] Reject structurally invalid RO-Crate JSON during request parsing with
-      `422 Unprocessable Entity` before calling business logic.
-- [ ] Validate that `rdi` is in the list of authorized RDIs for this client;
-      return `403` if not authorized.
+      `rdi` and `arc` as a `RoCratePayload` (see `arc-manager/` RoCrate wire
+      contract).
+- [ ] Validate that `rdi` is known to the deployment and authorized for this
+      client; return `400` if the RDI is not recognized, `403` if not authorized.
 - [ ] Delegate to the ARC ingestion pipeline (see `arc-manager/`)
       without a harvest context.
 - [ ] On success, fetch the updated ARC metadata from the document store and
       return an `ArcResponse` containing `client_id`, `arc_id`, `status`,
       `metadata` (hash, timestamps), and the current event log.
-- [ ] Return `500` when metadata cannot be retrieved after a successful store.
-- [ ] Map `InvalidJsonSemanticError` to `422 Unprocessable Entity`.
-- [ ] Map `BusinessLogicError` to `500 Internal Server Error`.
+- [ ] Apply HTTP status mapping per `arc-manager/` HTTP caller contract.
 
 ## Edge Cases
 
-`rdi` not in authorized list → `403` before calling business logic.
+`rdi` not in deployment `known_rdis` → `400` before calling business logic.
 
-ARC stored successfully but metadata fetch returns `None` → `500`; this indicates
-an internal inconsistency.
+`rdi` known but not authorized for this client → `403` before calling business logic.
 
-Invalid RO-Crate JSON (missing `@context`, `@graph`, root data entity, or
-non-empty `identifier`) → `422` from request validation.
-
-Semantically invalid RO-Crate JSON accepted by the HTTP layer but rejected in
-the worker queue → `422` via `InvalidJsonSemanticError` (defence in depth).
+For RO-Crate validation failures, arctrl parse failures in the worker, and
+generic pipeline errors, see `arc-manager/` edge cases and HTTP caller contract.

--- a/middleware/api/spec/arc-upload/spec.md
+++ b/middleware/api/spec/arc-upload/spec.md
@@ -7,7 +7,10 @@ Processing is delegated to `arc-manager/`.
 ## Requirements
 
 - [ ] Accept a JSON request body conforming to `CreateArcRequest` containing
-      `rdi` and `arc` (RO-Crate JSON).
+      `rdi` and `arc` as a `RoCratePayload` (RO-Crate JSON with `@context`,
+      `@graph`, root data entity `@id: "./"`, and non-empty `identifier`).
+- [ ] Reject structurally invalid RO-Crate JSON during request parsing with
+      `422 Unprocessable Entity` before calling business logic.
 - [ ] Validate that `rdi` is in the list of authorized RDIs for this client;
       return `403` if not authorized.
 - [ ] Delegate to the ARC ingestion pipeline (see `arc-manager/`)
@@ -26,5 +29,8 @@ Processing is delegated to `arc-manager/`.
 ARC stored successfully but metadata fetch returns `None` → `500`; this indicates
 an internal inconsistency.
 
-Invalid RO-Crate JSON (missing `identifier`) → `422`, business logic raises
-`InvalidJsonSemanticError`.
+Invalid RO-Crate JSON (missing `@context`, `@graph`, root data entity, or
+non-empty `identifier`) → `422` from request validation.
+
+Semantically invalid RO-Crate JSON accepted by the HTTP layer but rejected in
+the worker queue → `422` via `InvalidJsonSemanticError` (defence in depth).

--- a/middleware/api/spec/document-store/design.md
+++ b/middleware/api/spec/document-store/design.md
@@ -29,7 +29,10 @@ DocumentStore
 3. **Content hash for idempotency**
    — Comparing a SHA-256 hash of the serialized ARC JSON avoids unnecessary
    CouchDB writes and downstream Celery tasks when a client re-submits an
-   unchanged ARC. The hash is stored as a field on the document.
+   unchanged ARC. The hash is stored as a field on the document. Document keys
+   use `arc_id`, derived by `calculate_arc_id(identifier, rdi)` with leading and
+   trailing whitespace stripped from both inputs (same normalization as
+   `arc-store/`).
 
 4. **Concrete types for `_client` and `_db`**
    — Annotating `_client: CouchDB | None` and `_db: Database | None` (instead

--- a/middleware/api/spec/document-store/spec.md
+++ b/middleware/api/spec/document-store/spec.md
@@ -18,15 +18,17 @@ prefix, not by separate databases.
 ## Requirements
 
 - [ ] On initialization, ensure the application database exists before use.
-- [ ] On initialization, ensure CouchDB system databases (`_users`, `_replicator`)
-      exist if they do not yet exist.
+- [ ] On initialization, ensure CouchDB system databases (`_users`, `_replicator`,
+      `_global_changes`) exist if they do not yet exist.
 - [ ] Handle `412 Precondition Failed` (database already exists) as a success
       during initialization — parallel service startups must not cause crashes.
-- [ ] Store ARC documents keyed by `arc_id`; return flags indicating whether the
-      document was newly created and whether its content changed, based on content
-      hash comparison.
-- [ ] Support harvest run lifecycle operations: create, retrieve, increment
-      statistics counters, and finalize a harvest run.
+- [ ] Store ARC documents keyed by `arc_id` (derived from the RO-Crate root
+      `identifier` and `rdi` via `calculate_arc_id`; see `document-store/design.md`);
+      return flags indicating whether the document was newly created and whether
+      its content changed, based on content hash comparison.
+- [ ] Support harvest run lifecycle operations: create, retrieve, compute statistics
+      (`get_harvest_statistics`), and update harvest documents (including terminal
+      status transitions).
 - [ ] Append event records to an ARC document's event log.
 - [ ] Release the underlying HTTP session and database client on shutdown.
 

--- a/middleware/api/spec/harvest-arc-upload/spec.md
+++ b/middleware/api/spec/harvest-arc-upload/spec.md
@@ -9,29 +9,28 @@ to `arc-manager/`; harvest statistics tracking is part of that layer.
 
 - [ ] Accept `harvest_id` as a path parameter and a JSON request body conforming
       to `SubmitHarvestArcRequest` containing `arc` as a `RoCratePayload` but
-      **not** `rdi`.
-- [ ] Reject structurally invalid RO-Crate JSON during request parsing with
-      `422 Unprocessable Entity` before calling business logic.
+      **not** `rdi` (see `arc-manager/` RoCrate wire contract).
 - [ ] Fetch the harvest document by `harvest_id`; return `404` if it does not exist.
 - [ ] Resolve `rdi` from the harvest document.
-- [ ] Validate that the resolved `rdi` is in the list of authorized RDIs for this
-      client; return `403` if not authorized.
+- [ ] Validate that the resolved `rdi` is known to the deployment and authorized
+      for this client; return `400` if not recognized, `403` if not authorized.
 - [ ] Delegate to the ARC ingestion pipeline (see `arc-manager/`)
       with the resolved `rdi` and `harvest_id`.
 - [ ] On success, fetch the updated ARC metadata from the document store and
       return an `ArcResponse` containing `client_id`, `arc_id`, `status`,
       `metadata` (hash, timestamps), and the current event log.
-- [ ] Return `500` when metadata cannot be retrieved after a successful store.
-- [ ] Map `InvalidJsonSemanticError` to `422 Unprocessable Entity`.
-- [ ] Map `BusinessLogicError` to `500 Internal Server Error`.
+- [ ] Apply HTTP status mapping per `arc-manager/` HTTP caller contract.
 
 ## Edge Cases
 
 `harvest_id` not found → `404` before calling business logic; `rdi` is never resolved.
 
-Resolved `rdi` not authorized for this client → `403`.
+Resolved `rdi` not in deployment `known_rdis` → `400`.
 
-ARC stored successfully but metadata fetch returns `None` → `500`; internal inconsistency.
+Resolved `rdi` known but not authorized for this client → `403`.
 
-Invalid RO-Crate JSON (missing `@context`, `@graph`, root data entity, or
-non-empty `identifier`) → `422` from request validation.
+Same ARC submitted twice in one harvest → `409 Conflict` (`DuplicateArcInHarvestError`).
+
+For RO-Crate validation failures, arctrl parse failures in the worker, metadata
+fetch failures, and generic pipeline errors, see `arc-manager/` edge cases and
+HTTP caller contract.

--- a/middleware/api/spec/harvest-arc-upload/spec.md
+++ b/middleware/api/spec/harvest-arc-upload/spec.md
@@ -8,8 +8,10 @@ to `arc-manager/`; harvest statistics tracking is part of that layer.
 ## Requirements
 
 - [ ] Accept `harvest_id` as a path parameter and a JSON request body conforming
-      to `SubmitHarvestArcRequest` containing `arc` (RO-Crate JSON) but **not**
-      `rdi`.
+      to `SubmitHarvestArcRequest` containing `arc` as a `RoCratePayload` but
+      **not** `rdi`.
+- [ ] Reject structurally invalid RO-Crate JSON during request parsing with
+      `422 Unprocessable Entity` before calling business logic.
 - [ ] Fetch the harvest document by `harvest_id`; return `404` if it does not exist.
 - [ ] Resolve `rdi` from the harvest document.
 - [ ] Validate that the resolved `rdi` is in the list of authorized RDIs for this
@@ -31,4 +33,5 @@ Resolved `rdi` not authorized for this client → `403`.
 
 ARC stored successfully but metadata fetch returns `None` → `500`; internal inconsistency.
 
-Invalid RO-Crate JSON (missing `identifier`) → `422`.
+Invalid RO-Crate JSON (missing `@context`, `@graph`, root data entity, or
+non-empty `identifier`) → `422` from request validation.

--- a/middleware/api/spec/harvest-manager/design.md
+++ b/middleware/api/spec/harvest-manager/design.md
@@ -11,9 +11,8 @@ API endpoint
     └─→ HarvestManager
             ├─→ DocumentStore.create_harvest
             ├─→ DocumentStore.get_harvest
-            ├─→ DocumentStore.update_harvest          (transition_harvest)
-            ├─→ DocumentStore.increment_harvest_statistics
-            └─→ DocumentStore.finalize_harvest
+            ├─→ DocumentStore.get_harvest_statistics  (at terminal transition)
+            └─→ DocumentStore.update_harvest          (transition_harvest)
 ```
 
 ## Key Decisions

--- a/middleware/api/spec/harvest-manager/spec.md
+++ b/middleware/api/spec/harvest-manager/spec.md
@@ -12,8 +12,11 @@ finalization — and enforce client ownership of harvest resources.
 - [ ] Validate that the requesting `client_id` matches the `client_id` stored in
       the harvest document; raise `AccessDeniedError` on mismatch.
 - [ ] Raise `ResourceNotFoundError` when a `harvest_id` does not exist in CouchDB.
-- [ ] Increment per-harvest statistics (new-ARC counter and changed-ARC counter)
-      via `increment_harvest_statistics` for each processed ARC.
+- [ ] Derive per-harvest statistics at finalize time via
+      `DocumentStore.get_harvest_statistics`, classifying ARCs whose
+      `metadata.last_harvest_id` matches the harvest as submitted and bucketing
+      them into new / updated / unchanged using `first_harvest_id` and
+      `last_changed_harvest_id` (see `document-store/`).
 - [ ] Finalize a harvest run, marking it complete and recording the final statistics.
 - [ ] Transition a harvest run to a target terminal status (`COMPLETED`, `CANCELLED`,
       or `FAILED`) via an explicit state-transition operation.
@@ -31,3 +34,5 @@ finalization — and enforce client ownership of harvest resources.
 Finalize called before all ARCs arrive → harvest is marked complete with whatever statistics are current; no enforcement of `expected_datasets`.
 
 Transition called on a non-`RUNNING` harvest → raise `ConflictError` with the current status in the message.
+
+Same ARC submitted twice within one harvest → rejected at ingest with `DuplicateArcError` (see `arc-manager/` and `harvest-arc-upload/`).

--- a/middleware/api/src/middleware/api/arc_store/__init__.py
+++ b/middleware/api/src/middleware/api/arc_store/__init__.py
@@ -1,5 +1,7 @@
 """Contains the ArcStore interface and its implementations."""
 
+from __future__ import annotations
+
 import logging
 from abc import ABC, abstractmethod
 
@@ -38,7 +40,13 @@ class ArcStore(ABC):
         return calculate_arc_id(identifier, rdi)
 
     @abstractmethod
-    async def _create_or_update(self, arc_id: str, arc: ARC) -> None:
+    async def _create_or_update(
+        self,
+        arc_id: str,
+        arc: ARC,
+        *,
+        rdi: str,
+    ) -> None:
         """Create or updates an ARC."""
         raise NotImplementedError("`ArcStore._create_or_update` is not implemented")
 
@@ -70,12 +78,19 @@ class ArcStore(ABC):
         """
         return  # no-op default; subclasses (e.g. GitRepo) override
 
-    async def create_or_update(self, arc_id: str, arc: ARC) -> None:
+    async def create_or_update(
+        self,
+        arc_id: str,
+        arc: ARC,
+        *,
+        rdi: str,
+    ) -> None:
         """_Create or update an ARC.
 
         Args:
             arc_id (str): ID of the ARC to create or update.
             arc (ARC): ARC object to create or update.
+            rdi: Originating Research Data Infrastructure identifier.
 
         Raises:
             ArcStoreError: If an error occurs during the operation.
@@ -86,10 +101,10 @@ class ArcStore(ABC):
         """
         with self._tracer.start_as_current_span(
             "api.ArcStore.create_or_update",
-            attributes={"arc_id": arc_id},
+            attributes={"arc_id": arc_id, "rdi": rdi},
         ) as span:
             try:
-                return await self._create_or_update(arc_id, arc)
+                return await self._create_or_update(arc_id, arc, rdi=rdi)
             except ArcStoreError as e:
                 span.record_exception(e)
                 raise

--- a/middleware/api/src/middleware/api/arc_store/config.py
+++ b/middleware/api/src/middleware/api/arc_store/config.py
@@ -1,6 +1,7 @@
 """Configuration models for ARC store components."""
 
 import tempfile
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Annotated
 
@@ -27,6 +28,64 @@ class GitRepoConfig(BaseModel):
             validate_default=True,
         ),
     ] = None  # type: ignore[assignment]
+    rdi_gitlab_topics: Annotated[
+        dict[str, str],
+        Field(
+            description=(
+                "Map from middleware RDI name to GitLab project topic. When "
+                "known_rdis is configured, must contain exactly one non-empty "
+                "entry per known RDI (e.g. edal -> e!DAL)."
+            ),
+        ),
+    ] = {}
+
+    @staticmethod
+    def validate_rdi_gitlab_topics_for_known_rdis(
+        known_rdis: Sequence[str],
+        rdi_gitlab_topics: Mapping[str, str],
+    ) -> dict[str, str]:
+        """Ensure GitLab topic mapping covers ``known_rdis`` exactly.
+
+        Raises:
+            ValueError: When mapping keys diverge from ``known_rdis`` or values are empty.
+        """
+        if not known_rdis:
+            return dict(rdi_gitlab_topics)
+
+        known_set = set(known_rdis)
+        topic_keys = set(rdi_gitlab_topics)
+        extra_keys = topic_keys - known_set
+        if extra_keys:
+            msg = f"rdi_gitlab_topics contains keys that are not in known_rdis: {sorted(extra_keys)}"
+            raise ValueError(msg)
+
+        missing_keys = known_set - topic_keys
+        if missing_keys:
+            msg = f"known_rdis entries missing from rdi_gitlab_topics: {sorted(missing_keys)}"
+            raise ValueError(msg)
+
+        validated: dict[str, str] = {}
+        for rdi in known_rdis:
+            topic = rdi_gitlab_topics[rdi].strip()
+            if not topic:
+                msg = f"rdi_gitlab_topics[{rdi!r}] must not be empty"
+                raise ValueError(msg)
+            validated[rdi] = topic
+        return validated
+
+    @field_validator("rdi_gitlab_topics")
+    @classmethod
+    def validate_rdi_gitlab_topics(cls, topics: Mapping[str, str]) -> dict[str, str]:
+        """Ensure topic mapping keys and values are non-empty."""
+        validated: dict[str, str] = {}
+        for key, value in topics.items():
+            rdi_key = key.strip()
+            topic = value.strip()
+            if not rdi_key or not topic:
+                msg = "rdi_gitlab_topics entries must have non-empty keys and values"
+                raise ValueError(msg)
+            validated[rdi_key] = topic
+        return validated
 
     @field_validator("url")
     @classmethod

--- a/middleware/api/src/middleware/api/arc_store/git_repo.py
+++ b/middleware/api/src/middleware/api/arc_store/git_repo.py
@@ -19,6 +19,7 @@ from . import ArcStore, ArcStoreTransientError
 from .config import GitRepoConfig
 from .remote_git_provider import (
     RemoteGitProvider,
+    git_project_metadata_from_arc,
 )
 
 logger = logging.getLogger(__name__)
@@ -284,18 +285,25 @@ class GitRepo(ArcStore):
             http_low_speed_time=self._config.http_low_speed_time,
         )
 
-    async def _create_or_update(self, arc_id: str, arc: ARC) -> None:
+    async def _create_or_update(
+        self,
+        arc_id: str,
+        arc: ARC,
+        *,
+        rdi: str,
+    ) -> None:
         """Create or update ARC using Git CLI."""
         logger.debug("Creating/updating ARC %s via Git CLI", arc_id)
 
         def _task() -> None:
             with self._tracer.start_as_current_span(
                 "api.GitRepo._create_or_update",
-                attributes={"arc_id": arc_id},
+                attributes={"arc_id": arc_id, "rdi": rdi},
                 set_status_on_exception=False,
             ) as span:
                 # Ensure remote exists before doing anything else (if manager is configured)
-                self._remote_provider.ensure_repo_exists(arc_id)
+                git_metadata = git_project_metadata_from_arc(arc, rdi)
+                self._remote_provider.ensure_repo_exists(arc_id, metadata=git_metadata)
 
                 ctx_config = self._get_context_config(arc_id)
                 try:

--- a/middleware/api/src/middleware/api/arc_store/git_repo.py
+++ b/middleware/api/src/middleware/api/arc_store/git_repo.py
@@ -302,7 +302,11 @@ class GitRepo(ArcStore):
                 set_status_on_exception=False,
             ) as span:
                 # Ensure remote exists before doing anything else (if manager is configured)
-                git_metadata = git_project_metadata_from_arc(arc, rdi)
+                git_metadata = git_project_metadata_from_arc(
+                    arc,
+                    rdi,
+                    arc_id=arc_id,
+                )
                 self._remote_provider.ensure_repo_exists(arc_id, metadata=git_metadata)
 
                 ctx_config = self._get_context_config(arc_id)

--- a/middleware/api/src/middleware/api/arc_store/git_repo.py
+++ b/middleware/api/src/middleware/api/arc_store/git_repo.py
@@ -306,6 +306,7 @@ class GitRepo(ArcStore):
                     arc,
                     rdi,
                     arc_id=arc_id,
+                    rdi_gitlab_topics=self._config.rdi_gitlab_topics,
                 )
                 self._remote_provider.ensure_repo_exists(arc_id, metadata=git_metadata)
 

--- a/middleware/api/src/middleware/api/arc_store/gitlab_api.py
+++ b/middleware/api/src/middleware/api/arc_store/gitlab_api.py
@@ -312,7 +312,13 @@ class GitlabApi(ArcStore):
                     )
 
     # -------------------------- Create/Update --------------------------
-    async def _create_or_update(self, arc_id: str, arc: ARC) -> None:
+    async def _create_or_update(
+        self,
+        arc_id: str,
+        arc: ARC,
+        *,
+        rdi: str,  # noqa: ARG002
+    ) -> None:
         logger.debug("Creating/updating ARC %s in GitLab", arc_id)
 
         project = await self._run_in_executor(self._get_or_create_project, arc_id)

--- a/middleware/api/src/middleware/api/arc_store/remote_git_provider.py
+++ b/middleware/api/src/middleware/api/arc_store/remote_git_provider.py
@@ -22,6 +22,8 @@ from . import ArcStoreError
 logger = logging.getLogger(__name__)
 
 _GITLAB_TOPIC_RE = re.compile(r"[^a-z0-9-]+")
+_GITLAB_NAME_MAX_LEN = 255
+_GITLAB_NAME_UNSAFE_RE = re.compile(r"[\r\n\t]+")
 
 
 @dataclass(frozen=True)
@@ -29,30 +31,63 @@ class GitProjectMetadata:
     """Human-readable GitLab project fields alongside the hashed repository path."""
 
     rdi: str
+    arc_id: str
     identifier: str
     display_name: str
     description: str | None = None
 
-    def __post_init__(self) -> None:
-        """Reject empty identifiers — ARC sync cannot proceed without one."""
-        if not self.identifier:
-            msg = "GitProjectMetadata.identifier must not be empty"
-            raise ValueError(msg)
+
+def sanitize_gitlab_project_name(name: str) -> str:
+    """Normalize a RO-Crate identifier for GitLab project titles."""
+    collapsed = _GITLAB_NAME_UNSAFE_RE.sub(" ", name.strip())
+    collapsed = " ".join(collapsed.split())
+    collapsed = collapsed.replace("/", "-").replace("\\", "-")
+    if not collapsed:
+        msg = "GitLab project name cannot be empty after sanitization"
+        raise ValueError(msg)
+    if len(collapsed) > _GITLAB_NAME_MAX_LEN:
+        return collapsed[:_GITLAB_NAME_MAX_LEN].rstrip()
+    return collapsed
 
 
-def git_project_metadata_from_arc(arc: ARC, rdi: str) -> GitProjectMetadata:
+def git_project_metadata_from_arc(
+    arc: ARC,
+    rdi: str,
+    *,
+    arc_id: str,
+) -> GitProjectMetadata:
     """Build GitLab project metadata from an arctrl ARC and the originating RDI."""
+    canonical = (arc.Identifier or "").strip()
+    if not canonical:
+        msg = "ARC identifier is required for GitLab project metadata"
+        raise ValueError(msg)
     return GitProjectMetadata(
         rdi=rdi,
-        identifier=arc.Identifier,
+        arc_id=arc_id,
+        identifier=sanitize_gitlab_project_name(canonical),
         display_name=arc.Title or "",
         description=arc.Description,
     )
 
 
-def normalize_gitlab_topic(rdi: str) -> str:
+def normalize_gitlab_topic(rdi: str) -> str | None:
     """Normalize an RDI name for GitLab project topics (lowercase alphanumeric + hyphens)."""
-    return _GITLAB_TOPIC_RE.sub("-", rdi.strip().lower()).strip("-")
+    normalized = _GITLAB_TOPIC_RE.sub("-", rdi.strip().lower()).strip("-")
+    if normalized:
+        return normalized
+    alnum = re.sub(r"[^a-z0-9]", "", rdi.lower())
+    return alnum or None
+
+
+def merge_rdi_gitlab_topic(existing_topics: list[str] | None, rdi: str) -> list[str] | None:
+    """Return updated topics with the RDI tag present, or None when unchanged."""
+    rdi_topic = normalize_gitlab_topic(rdi)
+    if rdi_topic is None:
+        return None
+    topics = list(existing_topics or [])
+    if rdi_topic in topics:
+        return None
+    return [*topics, rdi_topic]
 
 
 def build_gitlab_project_description(metadata: GitProjectMetadata) -> str:
@@ -81,9 +116,8 @@ def apply_gitlab_project_metadata(
         project.description = description
         changed = True
 
-    topics = [normalize_gitlab_topic(metadata.rdi)]
-    current_topics = sorted(project.topics or [])
-    if current_topics != sorted(topics):
+    topics = merge_rdi_gitlab_topic(project.topics, metadata.rdi)
+    if topics is not None:
         project.topics = topics
         changed = True
 
@@ -219,7 +253,9 @@ class GitlabGitProvider(RemoteGitProvider):
                     project_description = build_gitlab_project_description(metadata)
                     if project_description:
                         create_attrs["description"] = project_description
-                    create_attrs["topics"] = [normalize_gitlab_topic(metadata.rdi)]
+                    rdi_topic = normalize_gitlab_topic(metadata.rdi)
+                    if rdi_topic is not None:
+                        create_attrs["topics"] = [rdi_topic]
                     self._gl.projects.create(create_attrs)
             except GitlabError as e:
                 msg = f"GitLab API error: {e}"

--- a/middleware/api/src/middleware/api/arc_store/remote_git_provider.py
+++ b/middleware/api/src/middleware/api/arc_store/remote_git_provider.py
@@ -2,27 +2,101 @@
 
 import http
 import logging
+import re
 import urllib.error
 import urllib.request
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import quote, unquote, urlparse
 
 import gitlab
+from arctrl import ARC  # type: ignore[import-untyped]
 from git import Repo
 from gitlab.exceptions import GitlabError, GitlabGetError
+from gitlab.v4.objects import Project
 from opentelemetry import trace
 
 from . import ArcStoreError
 
 logger = logging.getLogger(__name__)
 
+_GITLAB_TOPIC_RE = re.compile(r"[^a-z0-9-]+")
+
+
+@dataclass(frozen=True)
+class GitProjectMetadata:
+    """Human-readable GitLab project fields alongside the hashed repository path."""
+
+    rdi: str
+    identifier: str
+    display_name: str
+    description: str | None = None
+
+    def __post_init__(self) -> None:
+        """Reject empty identifiers — ARC sync cannot proceed without one."""
+        if not self.identifier:
+            msg = "GitProjectMetadata.identifier must not be empty"
+            raise ValueError(msg)
+
+
+def git_project_metadata_from_arc(arc: ARC, rdi: str) -> GitProjectMetadata:
+    """Build GitLab project metadata from an arctrl ARC and the originating RDI."""
+    return GitProjectMetadata(
+        rdi=rdi,
+        identifier=arc.Identifier,
+        display_name=arc.Title or "",
+        description=arc.Description,
+    )
+
+
+def normalize_gitlab_topic(rdi: str) -> str:
+    """Normalize an RDI name for GitLab project topics (lowercase alphanumeric + hyphens)."""
+    return _GITLAB_TOPIC_RE.sub("-", rdi.strip().lower()).strip("-")
+
+
+def build_gitlab_project_description(metadata: GitProjectMetadata) -> str:
+    """Build the GitLab project description shown in list preview and on the project home page."""
+    lines: list[str] = []
+    if metadata.display_name:
+        lines.append(metadata.display_name)
+    if metadata.description:
+        lines.append(metadata.description)
+    return "\n".join(lines)
+
+
+def apply_gitlab_project_metadata(
+    project: Project,
+    arc_id: str,
+    metadata: GitProjectMetadata,
+) -> None:
+    """Update GitLab project title, description, and RDI topic."""
+    changed = False
+    if project.name != metadata.identifier:
+        project.name = metadata.identifier
+        changed = True
+
+    description = build_gitlab_project_description(metadata)
+    if project.description != description:
+        project.description = description
+        changed = True
+
+    topics = [normalize_gitlab_topic(metadata.rdi)]
+    current_topics = sorted(project.topics or [])
+    if current_topics != sorted(topics):
+        project.topics = topics
+        changed = True
+
+    if changed:
+        logger.info("Updating GitLab project metadata for %s", arc_id)
+        project.save()
+
 
 class RemoteGitProvider(ABC):
     """Base class for managing remote git repositories."""
 
     @abstractmethod
-    def ensure_repo_exists(self, arc_id: str) -> None:
+    def ensure_repo_exists(self, arc_id: str, metadata: GitProjectMetadata) -> None:
         """Ensure the remote repository exists."""
         pass
 
@@ -79,7 +153,7 @@ class FileSystemGitProvider(RemoteGitProvider):
         self.base_url = base_url.rstrip("/")
         self.group = group.strip("/")
 
-    def ensure_repo_exists(self, arc_id: str) -> None:
+    def ensure_repo_exists(self, arc_id: str, _metadata: GitProjectMetadata) -> None:
         """Create a bare repository on the local filesystem if it doesn't exist."""
         parsed_url = urlparse(self.base_url)
         if parsed_url.scheme.lower() != "file":
@@ -95,7 +169,7 @@ class FileSystemGitProvider(RemoteGitProvider):
             remote_path.parent.mkdir(parents=True, exist_ok=True)
             Repo.init(remote_path, bare=True)
 
-    def get_repo_url(self, arc_id: str, authenticated: bool = True) -> str:  # noqa: ARG002
+    def get_repo_url(self, arc_id: str, _authenticated: bool = True) -> str:
         """Return the file:// URL for the repository."""
         return f"{self.base_url}/{self.group}/{arc_id}.git"
 
@@ -117,8 +191,8 @@ class GitlabGitProvider(RemoteGitProvider):
             self._gl = gitlab.Gitlab(url=url, private_token=token)
         self._tracer = trace.get_tracer(__name__)
 
-    def ensure_repo_exists(self, arc_id: str) -> None:
-        """Ensure the project exists in the GitLab group."""
+    def ensure_repo_exists(self, arc_id: str, metadata: GitProjectMetadata) -> None:
+        """Ensure the project exists in the GitLab group and apply human-readable metadata."""
         if not self._gl:
             logger.debug("Skipping project creation check (no GitLab token provided)")
             return
@@ -128,26 +202,27 @@ class GitlabGitProvider(RemoteGitProvider):
             attributes={"arc_id": arc_id, "group": self.group_name},
         ):
             try:
-                # 1. Get the group
                 group = self._gl.groups.get(self.group_name)
-
-                # 2. Check if project exists
                 project_path = f"{group.full_path}/{arc_id}"
                 try:
-                    self._gl.projects.get(project_path)
+                    project = self._gl.projects.get(project_path)
                     logger.debug("GitLab project %s already exists", project_path)
+                    apply_gitlab_project_metadata(project, arc_id, metadata)
                 except GitlabGetError:
-                    # 3. Create project if it doesn't exist
                     logger.info("Creating new GitLab project: %s in group %s", arc_id, self.group_name)
-                    self._gl.projects.create({
-                        "name": arc_id,
+                    create_attrs: dict[str, object] = {
+                        "name": metadata.identifier,
                         "path": arc_id,
                         "namespace_id": group.id,
                         "visibility": "private",
-                    })
+                    }
+                    project_description = build_gitlab_project_description(metadata)
+                    if project_description:
+                        create_attrs["description"] = project_description
+                    create_attrs["topics"] = [normalize_gitlab_topic(metadata.rdi)]
+                    self._gl.projects.create(create_attrs)
             except GitlabError as e:
                 msg = f"GitLab API error: {e}"
-                # Handle 401 specifically to help users find the cause (wrong token)
                 if hasattr(e, "response_code") and e.response_code == http.HTTPStatus.UNAUTHORIZED:
                     msg = (
                         "GitLab API 401 Unauthorized: Please check your token and its permissions (API scope required)."
@@ -178,7 +253,11 @@ class GitlabGitProvider(RemoteGitProvider):
             except GitlabError:
                 return False
 
-        # Fallback for when no token is provided but we still want to check reachability
+        # Fallback for when no token is provided but we still want to check reachability.
+        # URL is admin-configured; reject non-http(s) schemes before opening.
+        if not self.url.lower().startswith(("http://", "https://")):
+            return False
+
         try:
             with urllib.request.urlopen(self.url, timeout=5) as response:  # nosec B310
                 return bool(response.status < http.HTTPStatus.BAD_REQUEST)

--- a/middleware/api/src/middleware/api/arc_store/remote_git_provider.py
+++ b/middleware/api/src/middleware/api/arc_store/remote_git_provider.py
@@ -25,6 +25,7 @@ _GITLAB_TOPIC_RE = re.compile(r"[^a-z0-9-]+")
 GITLAB_PROJECT_NAME_MAX_LEN = 255
 _GITLAB_NAME_MAX_LEN = GITLAB_PROJECT_NAME_MAX_LEN
 _GITLAB_NAME_UNSAFE_RE = re.compile(r"[\r\n\t]+")
+_GITLAB_API_NAME_INVALID_RE = re.compile(r"[^a-zA-Z0-9_.+ \-]+", re.UNICODE)
 
 
 @dataclass(frozen=True)
@@ -43,18 +44,28 @@ def sanitize_gitlab_project_name(name: str) -> str:
     collapsed = _GITLAB_NAME_UNSAFE_RE.sub(" ", name.strip())
     collapsed = " ".join(collapsed.split())
     collapsed = collapsed.replace("/", "-").replace("\\", "-")
-    if not collapsed:
+    return sanitize_gitlab_api_project_name(collapsed)
+
+
+def sanitize_gitlab_api_project_name(name: str) -> str:
+    """Normalize a value for GitLab's project ``name`` field."""
+    collapsed = _GITLAB_NAME_UNSAFE_RE.sub(" ", name.strip())
+    cleaned = _GITLAB_API_NAME_INVALID_RE.sub(" ", collapsed)
+    cleaned = " ".join(cleaned.split())
+    if not cleaned:
         msg = "GitLab project name cannot be empty after sanitization"
         raise ValueError(msg)
-    if len(collapsed) > _GITLAB_NAME_MAX_LEN:
-        return collapsed[:_GITLAB_NAME_MAX_LEN].rstrip()
-    return collapsed
+    if not (cleaned[0].isalnum() or cleaned[0] == "_"):
+        cleaned = f"_{cleaned}"
+    if len(cleaned) > _GITLAB_NAME_MAX_LEN:
+        return cleaned[:_GITLAB_NAME_MAX_LEN].rstrip()
+    return cleaned
 
 
 def build_gitlab_project_name(sanitized_identifier: str, rdi: str) -> str:
     """Build a GitLab project title that is unique per RDI within a group namespace."""
     rdi_label = rdi.strip()
-    suffix = f" ({rdi_label})"
+    suffix = f" - {rdi_label}"
     max_base_len = _GITLAB_NAME_MAX_LEN - len(suffix)
     if max_base_len < 1:
         msg = "RDI is too long for GitLab project name"
@@ -62,7 +73,7 @@ def build_gitlab_project_name(sanitized_identifier: str, rdi: str) -> str:
     base = sanitized_identifier
     if len(base) > max_base_len:
         base = base[:max_base_len].rstrip()
-    return f"{base}{suffix}"
+    return sanitize_gitlab_api_project_name(f"{base}{suffix}")
 
 
 def git_project_metadata_from_arc(
@@ -123,8 +134,9 @@ def apply_gitlab_project_metadata(
 ) -> None:
     """Update GitLab project title, description, and RDI topic."""
     changed = False
-    if project.name != metadata.identifier:
-        project.name = metadata.identifier
+    project_name = sanitize_gitlab_api_project_name(metadata.identifier)
+    if project.name != project_name:
+        project.name = project_name
         changed = True
 
     description = build_gitlab_project_description(metadata)

--- a/middleware/api/src/middleware/api/arc_store/remote_git_provider.py
+++ b/middleware/api/src/middleware/api/arc_store/remote_git_provider.py
@@ -6,6 +6,7 @@ import re
 import urllib.error
 import urllib.request
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import quote, unquote, urlparse
@@ -37,6 +38,7 @@ class GitProjectMetadata:
     identifier: str
     display_name: str
     description: str | None = None
+    gitlab_topic: str | None = None
 
 
 def sanitize_gitlab_project_name(name: str) -> str:
@@ -81,6 +83,7 @@ def git_project_metadata_from_arc(
     rdi: str,
     *,
     arc_id: str,
+    rdi_gitlab_topics: Mapping[str, str] | None = None,
 ) -> GitProjectMetadata:
     """Build GitLab project metadata from an arctrl ARC and the originating RDI."""
     canonical = (arc.Identifier or "").strip()
@@ -94,7 +97,28 @@ def git_project_metadata_from_arc(
         identifier=build_gitlab_project_name(sanitized_name, rdi),
         display_name=arc.Title or "",
         description=arc.Description,
+        gitlab_topic=resolve_gitlab_topic(rdi, rdi_gitlab_topics),
     )
+
+
+def resolve_gitlab_topic(
+    rdi: str,
+    topic_mapping: Mapping[str, str] | None = None,
+) -> str | None:
+    """Resolve the GitLab project topic for an RDI.
+
+    Mapped values are used as-is (e.g. ``e!DAL``). Unmapped RDIs fall back to
+    ``normalize_gitlab_topic``.
+    """
+    rdi_key = rdi.strip()
+    if topic_mapping:
+        if rdi_key in topic_mapping:
+            return topic_mapping[rdi_key].strip()
+        rdi_lower = rdi_key.lower()
+        for key, value in topic_mapping.items():
+            if key.lower() == rdi_lower:
+                return value.strip()
+    return normalize_gitlab_topic(rdi)
 
 
 def normalize_gitlab_topic(rdi: str) -> str | None:
@@ -106,15 +130,11 @@ def normalize_gitlab_topic(rdi: str) -> str | None:
     return alnum or None
 
 
-def merge_rdi_gitlab_topic(existing_topics: list[str] | None, rdi: str) -> list[str] | None:
-    """Return updated topics with the RDI tag present, or None when unchanged."""
-    rdi_topic = normalize_gitlab_topic(rdi)
-    if rdi_topic is None:
+def desired_gitlab_topics(metadata: GitProjectMetadata) -> list[str] | None:
+    """Return the sole GitLab topic list for an ARC project, or None when unset."""
+    if metadata.gitlab_topic is None:
         return None
-    topics = list(existing_topics or [])
-    if rdi_topic in topics:
-        return None
-    return [*topics, rdi_topic]
+    return [metadata.gitlab_topic]
 
 
 def build_gitlab_project_description(metadata: GitProjectMetadata) -> str:
@@ -145,7 +165,7 @@ def apply_gitlab_project_metadata(
         changed = True
 
     current_topics = list(project.topics or [])
-    topics = merge_rdi_gitlab_topic(project.topics, metadata.rdi)
+    topics = desired_gitlab_topics(metadata)
     if topics is not None and topics != current_topics:
         project.topics = topics
         changed = True
@@ -285,7 +305,7 @@ class GitlabGitProvider(RemoteGitProvider):
                     project_description = build_gitlab_project_description(metadata)
                     if project_description:
                         create_attrs["description"] = project_description
-                    rdi_topic = normalize_gitlab_topic(metadata.rdi)
+                    rdi_topic = metadata.gitlab_topic
                     if rdi_topic is not None:
                         create_attrs["topics"] = [rdi_topic]
                     self._gl.projects.create(create_attrs)

--- a/middleware/api/src/middleware/api/arc_store/remote_git_provider.py
+++ b/middleware/api/src/middleware/api/arc_store/remote_git_provider.py
@@ -128,12 +128,13 @@ def apply_gitlab_project_metadata(
         changed = True
 
     description = build_gitlab_project_description(metadata)
-    if project.description != description:
+    if (project.description or "") != description:
         project.description = description
         changed = True
 
+    current_topics = list(project.topics or [])
     topics = merge_rdi_gitlab_topic(project.topics, metadata.rdi)
-    if topics is not None:
+    if topics is not None and topics != current_topics:
         project.topics = topics
         changed = True
 

--- a/middleware/api/src/middleware/api/arc_store/remote_git_provider.py
+++ b/middleware/api/src/middleware/api/arc_store/remote_git_provider.py
@@ -22,7 +22,8 @@ from . import ArcStoreError
 logger = logging.getLogger(__name__)
 
 _GITLAB_TOPIC_RE = re.compile(r"[^a-z0-9-]+")
-_GITLAB_NAME_MAX_LEN = 255
+GITLAB_PROJECT_NAME_MAX_LEN = 255
+_GITLAB_NAME_MAX_LEN = GITLAB_PROJECT_NAME_MAX_LEN
 _GITLAB_NAME_UNSAFE_RE = re.compile(r"[\r\n\t]+")
 
 
@@ -50,6 +51,20 @@ def sanitize_gitlab_project_name(name: str) -> str:
     return collapsed
 
 
+def build_gitlab_project_name(sanitized_identifier: str, rdi: str) -> str:
+    """Build a GitLab project title that is unique per RDI within a group namespace."""
+    rdi_label = rdi.strip()
+    suffix = f" ({rdi_label})"
+    max_base_len = _GITLAB_NAME_MAX_LEN - len(suffix)
+    if max_base_len < 1:
+        msg = "RDI is too long for GitLab project name"
+        raise ValueError(msg)
+    base = sanitized_identifier
+    if len(base) > max_base_len:
+        base = base[:max_base_len].rstrip()
+    return f"{base}{suffix}"
+
+
 def git_project_metadata_from_arc(
     arc: ARC,
     rdi: str,
@@ -61,10 +76,11 @@ def git_project_metadata_from_arc(
     if not canonical:
         msg = "ARC identifier is required for GitLab project metadata"
         raise ValueError(msg)
+    sanitized_name = sanitize_gitlab_project_name(canonical)
     return GitProjectMetadata(
         rdi=rdi,
         arc_id=arc_id,
-        identifier=sanitize_gitlab_project_name(canonical),
+        identifier=build_gitlab_project_name(sanitized_name, rdi),
         display_name=arc.Title or "",
         description=arc.Description,
     )
@@ -187,8 +203,11 @@ class FileSystemGitProvider(RemoteGitProvider):
         self.base_url = base_url.rstrip("/")
         self.group = group.strip("/")
 
-    def ensure_repo_exists(self, arc_id: str, _metadata: GitProjectMetadata) -> None:
-        """Create a bare repository on the local filesystem if it doesn't exist."""
+    def ensure_repo_exists(self, arc_id: str, metadata: GitProjectMetadata) -> None:  # noqa: ARG002
+        """Create a bare repository on the local filesystem if it doesn't exist.
+
+        ``metadata`` is accepted for a uniform ``RemoteGitProvider`` interface but not used.
+        """
         parsed_url = urlparse(self.base_url)
         if parsed_url.scheme.lower() != "file":
             return
@@ -203,7 +222,7 @@ class FileSystemGitProvider(RemoteGitProvider):
             remote_path.parent.mkdir(parents=True, exist_ok=True)
             Repo.init(remote_path, bare=True)
 
-    def get_repo_url(self, arc_id: str, _authenticated: bool = True) -> str:
+    def get_repo_url(self, arc_id: str, authenticated: bool = True) -> str:  # noqa: ARG002
         """Return the file:// URL for the repository."""
         return f"{self.base_url}/{self.group}/{arc_id}.git"
 

--- a/middleware/api/src/middleware/api/business_logic/arc_manager.py
+++ b/middleware/api/src/middleware/api/business_logic/arc_manager.py
@@ -86,15 +86,14 @@ class ArcManager:
         if not self._dispatcher:
             raise BusinessLogicError("create_or_update_arc can only be called in API mode")
 
-        rocrate = parse_rocrate(arc)
-        arc_content = rocrate.model_dump(by_alias=True)
-
         with self._tracer.start_as_current_span(
             "api.ArcManager.create_or_update_arc",
             attributes={"rdi": rdi, "client_id": client_id if client_id is not None else ""},
         ) as span:
             logger.info("[%s] Starting ARC creation/update: rdi=%s", client_id, rdi)
             try:
+                rocrate = parse_rocrate(arc)
+                arc_content = rocrate.model_dump(by_alias=True)
                 doc_result = await self._doc_store.store_arc(
                     rdi,
                     arc_content,
@@ -173,16 +172,18 @@ class ArcManager:
         if self._dispatcher:
             raise BusinessLogicError("sync_to_gitlab must not be called in API mode")
 
-        rocrate = parse_rocrate(arc)
-        arc_id = calculate_arc_id(rocrate.identifier, rdi)
-        arc_content = rocrate.model_dump(by_alias=True)
-
         with self._tracer.start_as_current_span(
             "api.ArcManager.sync_to_gitlab",
-            attributes={"rdi": rdi, "arc_id": arc_id},
+            attributes={"rdi": rdi},
         ) as span:
             logger.info("Starting GitLab sync for RDI: %s", rdi)
+            arc_id: str | None = None
             try:
+                rocrate = parse_rocrate(arc)
+                arc_id = calculate_arc_id(rocrate.identifier, rdi)
+                arc_content = rocrate.model_dump(by_alias=True)
+                span.set_attribute("arc_id", arc_id)
+
                 arc_json = json.dumps(arc_content)
                 arc_obj = ARC.from_rocrate_json_string(arc_json)
 
@@ -206,7 +207,7 @@ class ArcManager:
                 logger.info("Successfully synced ARC %s to GitLab", arc_id)
 
             except ArcStoreTransientError as e:
-                logger.info("Transient error during GitLab sync for ARC %s: %s", arc_id, e)
+                logger.info("Transient error during GitLab sync for ARC %s: %s", arc_id or "unknown", e)
                 span.record_exception(e)
                 raise TransientError(str(e)) from e
 
@@ -214,17 +215,18 @@ class ArcManager:
                 logger.error("Unexpected error while syncing ARC to GitLab: %s", e, exc_info=True)
                 span.record_exception(e)
 
-                try:
-                    await self._doc_store.add_event(
-                        arc_id,
-                        ArcEvent(
-                            timestamp=datetime.now(UTC),
-                            type=ArcEventType.GIT_PUSH_FAILED,
-                            message=f"GitLab sync failed: {str(e)}",
-                        ),
-                    )
-                except Exception as log_error:  # noqa: BLE001
-                    logger.warning("Could not log sync failure to CouchDB: %s", log_error)
+                if arc_id is not None:
+                    try:
+                        await self._doc_store.add_event(
+                            arc_id,
+                            ArcEvent(
+                                timestamp=datetime.now(UTC),
+                                type=ArcEventType.GIT_PUSH_FAILED,
+                                message=f"GitLab sync failed: {str(e)}",
+                            ),
+                        )
+                    except Exception as log_error:  # noqa: BLE001
+                        logger.warning("Could not log sync failure to CouchDB: %s", log_error)
 
                 if isinstance(e, InvalidJsonSemanticError):
                     raise

--- a/middleware/api/src/middleware/api/business_logic/arc_manager.py
+++ b/middleware/api/src/middleware/api/business_logic/arc_manager.py
@@ -187,7 +187,11 @@ class ArcManager:
                 arc_obj = ARC.from_rocrate_json_string(arc_json)
 
                 logger.info("Triggering Git storage for ARC %s", arc_id)
-                await self._store.create_or_update(arc_id, arc_obj, rdi=rdi)
+                await self._store.create_or_update(
+                    arc_id,
+                    arc_obj,
+                    rdi=rdi,
+                )
 
                 await self._doc_store.add_event(
                     arc_id,

--- a/middleware/api/src/middleware/api/business_logic/arc_manager.py
+++ b/middleware/api/src/middleware/api/business_logic/arc_manager.py
@@ -11,8 +11,10 @@ from opentelemetry import trace
 from middleware.api.arc_store import ArcStore, ArcStoreTransientError
 from middleware.api.document_store import DocumentStore, DuplicateArcError
 from middleware.api.document_store.arc_document import ArcEvent, ArcEventType
-from middleware.api.utils import calculate_arc_id, extract_identifier
+from middleware.api.rocrate import parse_rocrate
+from middleware.api.utils import calculate_arc_id
 from middleware.shared.api_models.common.models import ArcOperationResult, ArcResponse, ArcStatus
+from middleware.shared.api_models.common.rocrate import RoCratePayload
 
 from .exceptions import BusinessLogicError, DuplicateArcInHarvestError, InvalidJsonSemanticError, TransientError
 from .ports import TaskDispatcher
@@ -57,7 +59,11 @@ class ArcManager:
         await self._store.shutdown()
 
     async def create_or_update_arc(
-        self, rdi: str, arc: dict[str, Any], client_id: str | None, harvest_id: str | None = None
+        self,
+        rdi: str,
+        arc: RoCratePayload | dict[str, Any],
+        client_id: str | None,
+        harvest_id: str | None = None,
     ) -> ArcOperationResult:
         """Create or update an ARC with fast CouchDB storage and async GitLab sync.
 
@@ -66,7 +72,7 @@ class ArcManager:
 
         Args:
             rdi: Research Data Infrastructure identifier.
-            arc: ARC definition.
+            arc: Validated or raw RO-Crate payload.
             client_id: The client identifier.
             harvest_id: Optional harvest run identifier.
 
@@ -80,20 +86,21 @@ class ArcManager:
         if not self._dispatcher:
             raise BusinessLogicError("create_or_update_arc can only be called in API mode")
 
+        rocrate = parse_rocrate(arc)
+        arc_content = rocrate.model_dump(by_alias=True)
+
         with self._tracer.start_as_current_span(
             "api.ArcManager.create_or_update_arc",
             attributes={"rdi": rdi, "client_id": client_id if client_id is not None else ""},
         ) as span:
             logger.info("[%s] Starting ARC creation/update: rdi=%s", client_id, rdi)
             try:
-                # Fast validation: Ensure identifier is present
-                identifier = extract_identifier(arc)
-                if identifier is None:
-                    raise InvalidJsonSemanticError("RO-Crate JSON must contain an 'identifier' (e.g. in ISA object).")
-
-                # Store in CouchDB (fast) - pass the already-extracted identifier to
-                # avoid a second graph traversal inside the document store.
-                doc_result = await self._doc_store.store_arc(rdi, arc, harvest_id=harvest_id, identifier=identifier)
+                doc_result = await self._doc_store.store_arc(
+                    rdi,
+                    arc_content,
+                    rocrate.identifier,
+                    harvest_id=harvest_id,
+                )
                 arc_id = doc_result.arc_id
                 span.set_attribute("arc_id", arc_id)
 
@@ -110,10 +117,15 @@ class ArcManager:
                     should_trigger_git,
                 )
 
-                # Enqueue GitLab sync if needed
                 if should_trigger_git:
                     logger.info("[%s] Enqueueing GitLab sync task for ARC %s", client_id, arc_id)
-                    self._dispatcher.dispatch_sync_arc(ArcSyncTask(rdi=rdi, arc=arc, client_id=client_id))
+                    self._dispatcher.dispatch_sync_arc(
+                        ArcSyncTask(
+                            rdi=rdi,
+                            arc=arc_content,
+                            client_id=client_id,
+                        )
+                    )
                 else:
                     logger.info("[%s] Skipping GitLab sync for ARC %s (unchanged)", client_id, arc_id)
 
@@ -144,7 +156,7 @@ class ArcManager:
                     raise DuplicateArcInHarvestError(str(e)) from e
                 raise BusinessLogicError(f"unexpected error encountered: {str(e)}") from e
 
-    async def sync_to_gitlab(self, rdi: str, arc: dict[str, Any]) -> None:
+    async def sync_to_gitlab(self, rdi: str, arc: RoCratePayload | dict[str, Any]) -> None:
         """Synchronize ARC to GitLab storage.
 
         This method performs the slow GitLab sync operation. It must only be
@@ -152,7 +164,7 @@ class ArcManager:
 
         Args:
             rdi: Research Data Infrastructure identifier.
-            arc: ARC definition.
+            arc: Validated or raw RO-Crate payload.
 
         Raises:
             InvalidJsonSemanticError: If the JSON is semantically incorrect.
@@ -161,31 +173,22 @@ class ArcManager:
         if self._dispatcher:
             raise BusinessLogicError("sync_to_gitlab must not be called in API mode")
 
-        arc_id: str | None = None
-        identifier: str | None = None
+        rocrate = parse_rocrate(arc)
+        arc_id = calculate_arc_id(rocrate.identifier, rdi)
+        arc_content = rocrate.model_dump(by_alias=True)
 
         with self._tracer.start_as_current_span(
             "api.ArcManager.sync_to_gitlab",
-            attributes={"rdi": rdi},
+            attributes={"rdi": rdi, "arc_id": arc_id},
         ) as span:
             logger.info("Starting GitLab sync for RDI: %s", rdi)
             try:
-                identifier = extract_identifier(arc)
-                if identifier is None:
-                    raise InvalidJsonSemanticError("RO-Crate JSON must contain an 'identifier' (e.g. in ISA object).")
-
-                arc_id = calculate_arc_id(identifier, rdi)
-                span.set_attribute("arc_id", arc_id)
-
-                # Parse ARC for storage (slow, but fine in worker)
-                arc_json = json.dumps(arc)
+                arc_json = json.dumps(arc_content)
                 arc_obj = ARC.from_rocrate_json_string(arc_json)
 
-                # Store in Git
                 logger.info("Triggering Git storage for ARC %s", arc_id)
-                await self._store.create_or_update(arc_id, arc_obj)
+                await self._store.create_or_update(arc_id, arc_obj, rdi=rdi)
 
-                # Record success in CouchDB
                 await self._doc_store.add_event(
                     arc_id,
                     ArcEvent(
@@ -207,19 +210,15 @@ class ArcManager:
                 logger.error("Unexpected error while syncing ARC to GitLab: %s", e, exc_info=True)
                 span.record_exception(e)
 
-                # Try to record failure in CouchDB if we have an arc_id
                 try:
-                    identifier = identifier or extract_identifier(arc)
-                    if identifier:
-                        arc_id = arc_id or calculate_arc_id(identifier, rdi)
-                        await self._doc_store.add_event(
-                            arc_id,
-                            ArcEvent(
-                                timestamp=datetime.now(UTC),
-                                type=ArcEventType.GIT_PUSH_FAILED,
-                                message=f"GitLab sync failed: {str(e)}",
-                            ),
-                        )
+                    await self._doc_store.add_event(
+                        arc_id,
+                        ArcEvent(
+                            timestamp=datetime.now(UTC),
+                            type=ArcEventType.GIT_PUSH_FAILED,
+                            message=f"GitLab sync failed: {str(e)}",
+                        ),
+                    )
                 except Exception as log_error:  # noqa: BLE001
                     logger.warning("Could not log sync failure to CouchDB: %s", log_error)
 

--- a/middleware/api/src/middleware/api/business_logic/business_logic.py
+++ b/middleware/api/src/middleware/api/business_logic/business_logic.py
@@ -18,6 +18,7 @@ from middleware.api.arc_store import ArcStore
 from middleware.api.document_store import DocumentStore
 from middleware.api.document_store.arc_document import ArcMetadata
 from middleware.shared.api_models.common.models import ArcOperationResult
+from middleware.shared.api_models.common.rocrate import RoCratePayload
 
 from .arc_manager import ArcManager
 from .config import BusinessLogicConfig
@@ -155,7 +156,7 @@ class BusinessLogic:
         await self.shutdown()
 
     async def create_or_update_arc(
-        self, rdi: str, arc: dict[str, Any], client_id: str | None, harvest_id: str | None = None
+        self, rdi: str, arc: RoCratePayload | dict[str, Any], client_id: str | None, harvest_id: str | None = None
     ) -> ArcOperationResult:
         """Create or update an ARC with fast CouchDB storage and async GitLab sync.
 
@@ -181,7 +182,7 @@ class BusinessLogic:
 
         return await self._arc_manager.create_or_update_arc(rdi, arc, client_id, harvest_id)
 
-    async def sync_to_gitlab(self, rdi: str, arc: dict[str, Any]) -> None:
+    async def sync_to_gitlab(self, rdi: str, arc: RoCratePayload | dict[str, Any]) -> None:
         """Synchronize ARC to GitLab storage.
 
         This method performs the slow GitLab sync operation. It must only be

--- a/middleware/api/src/middleware/api/config.py
+++ b/middleware/api/src/middleware/api/config.py
@@ -93,9 +93,15 @@ class Config(ConfigBase):
 
     @model_validator(mode="after")
     def validate_mutual_exclusivity(self) -> Self:
-        """Validate that exactly one backend is configured."""
+        """Validate storage backend and GitLab topic mapping."""
         if self.git_repo is None and self.gitlab_api is None:
             raise ValueError("Either git_repo or gitlab_api must be configured")
         if self.git_repo is not None and self.gitlab_api is not None:
             raise ValueError("Only one of git_repo or gitlab_api can be configured")
+        if self.git_repo is not None and self.known_rdis:
+            validated_topics = GitRepoConfig.validate_rdi_gitlab_topics_for_known_rdis(
+                self.known_rdis,
+                self.git_repo.rdi_gitlab_topics,
+            )
+            self.git_repo = self.git_repo.model_copy(update={"rdi_gitlab_topics": validated_topics})
         return self

--- a/middleware/api/src/middleware/api/document_store/__init__.py
+++ b/middleware/api/src/middleware/api/document_store/__init__.py
@@ -45,8 +45,8 @@ class DocumentStore(ABC):
         self,
         rdi: str,
         arc_content: dict[str, Any],
+        identifier: str,
         harvest_id: str | None = None,
-        identifier: str | None = None,
     ) -> ArcStoreResult:
         """Store ARC with change detection.
 
@@ -54,8 +54,7 @@ class DocumentStore(ABC):
             rdi: Research Data Infrastructure identifier
             arc_content: RO-Crate JSON content
             harvest_id: Optional harvest run identifier
-            identifier: Pre-extracted RO-Crate identifier to avoid re-parsing.
-                        Extracted from arc_content when omitted.
+            identifier: Pre-extracted RO-Crate identifier (required).
 
         Returns:
             ArcStoreResult containing status and flags

--- a/middleware/api/src/middleware/api/document_store/couchdb.py
+++ b/middleware/api/src/middleware/api/document_store/couchdb.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from middleware.api.document_store.config import CouchDBConfig
 from middleware.api.document_store.couchdb_client import CouchDBClient
-from middleware.api.utils import calculate_arc_id, extract_identifier
+from middleware.api.utils import calculate_arc_id
 from middleware.shared.api_models.common.models import ArcEventType, ArcLifecycleStatus, HarvestStatus
 
 from . import ArcStoreResult, DocumentStore, DuplicateArcError
@@ -55,16 +55,14 @@ class CouchDB(DocumentStore):
         self,
         rdi: str,
         arc_content: dict[str, Any],
+        identifier: str,
         harvest_id: str | None = None,
-        identifier: str | None = None,
     ) -> ArcStoreResult:
         """Store ARC with change detection."""
-        # Re-use pre-extracted identifier when available (avoids a second graph traversal).
-        resolved_identifier = identifier or extract_identifier(arc_content)
-        if not resolved_identifier:
+        if not identifier:
             raise ValueError("ARC content must contain a valid identifier")
 
-        arc_id = calculate_arc_id(resolved_identifier, rdi)
+        arc_id = calculate_arc_id(identifier, rdi)
         doc_id = f"arc_{arc_id}"
 
         content_hash = self._calculate_content_hash(arc_content)
@@ -98,7 +96,7 @@ class CouchDB(DocumentStore):
             is_new = False
             # Reject duplicate submissions within the same harvest run.
             if harvest_id and existing_doc.metadata.last_harvest_id == harvest_id:
-                raise DuplicateArcError(f"ARC '{resolved_identifier}' was already submitted in harvest '{harvest_id}'.")
+                raise DuplicateArcError(f"ARC '{identifier}' was already submitted in harvest '{harvest_id}'.")
             # Check for changes
             has_changes = existing_doc.metadata.arc_hash != content_hash
 
@@ -170,7 +168,7 @@ class CouchDB(DocumentStore):
         # last_harvest_id before writing.
         def _check_duplicate_on_retry(fresh_doc: dict[str, Any]) -> None:
             if harvest_id and fresh_doc.get("metadata", {}).get("last_harvest_id") == harvest_id:
-                raise DuplicateArcError(f"ARC '{resolved_identifier}' was already submitted in harvest '{harvest_id}'.")
+                raise DuplicateArcError(f"ARC '{identifier}' was already submitted in harvest '{harvest_id}'.")
 
         await self._client.save_document(
             doc_id,

--- a/middleware/api/src/middleware/api/document_store/couchdb.py
+++ b/middleware/api/src/middleware/api/document_store/couchdb.py
@@ -220,7 +220,7 @@ class CouchDB(DocumentStore):
         # We assume connect() has been called before setup()
         # Create indices for common queries
         await self._client.create_index(["type", "rdi"], name="idx_type_rdi")
-        await self._client.create_index(["type", "metadata.last_harvest_id"], name="idx_type_harvest")
+        await self._client.create_index(["doc_type", "metadata.last_harvest_id"], name="idx_doc_type_harvest")
         logger.info("CouchDB document store indices initialized")
 
     async def connect(self) -> None:
@@ -301,7 +301,7 @@ class CouchDB(DocumentStore):
 
     async def get_harvest_statistics(self, harvest_id: str) -> HarvestStatistics:
         """Calculate and return statistics for a specific harvest run."""
-        selector = {"type": "arc", "metadata.last_harvest_id": harvest_id}
+        selector = {"doc_type": "arc", "metadata.last_harvest_id": harvest_id}
         docs = await self._client.find_projected(
             selector,
             fields=["metadata.first_harvest_id", "metadata.last_changed_harvest_id"],

--- a/middleware/api/src/middleware/api/document_store/couchdb_client.py
+++ b/middleware/api/src/middleware/api/document_store/couchdb_client.py
@@ -399,15 +399,10 @@ class CouchDBClient:
     def _get_session(self) -> aiohttp.ClientSession:
         """Return the shared aiohttp session, creating it on first call."""
         if self._session is None:
-            auth = (
-                aiohttp.BasicAuth(self._user, self._password)
-                if self._user is not None and self._password is not None
-                else None
-            )
-            self._session = aiohttp.ClientSession(
-                auth=auth,
-                headers={"Content-Type": "application/json"},
-            )
+            headers: dict[str, str] = {"Content-Type": "application/json"}
+            if self._user is not None and self._password is not None:
+                headers["Authorization"] = aiohttp.encode_basic_auth(self._user, self._password)
+            self._session = aiohttp.ClientSession(headers=headers)
         return self._session
 
     async def create_index(self, fields: list[str], name: str | None = None) -> None:

--- a/middleware/api/src/middleware/api/rocrate.py
+++ b/middleware/api/src/middleware/api/rocrate.py
@@ -1,0 +1,27 @@
+"""RO-Crate parsing helpers for business logic."""
+
+from typing import Any
+
+from pydantic import ValidationError
+
+from middleware.api.business_logic.exceptions import InvalidJsonSemanticError
+from middleware.shared.api_models.common.rocrate import RoCratePayload
+
+
+def parse_rocrate(arc: RoCratePayload | dict[str, Any]) -> RoCratePayload:
+    """Parse and validate a RO-Crate payload, mapping schema errors to domain errors."""
+    if isinstance(arc, RoCratePayload):
+        return arc
+    try:
+        return RoCratePayload.model_validate(arc)
+    except ValidationError as exc:
+        message = _first_validation_message(exc)
+        raise InvalidJsonSemanticError(message) from exc
+
+
+def _first_validation_message(exc: ValidationError) -> str:
+    for error in exc.errors():
+        msg = error.get("msg")
+        if isinstance(msg, str) and msg:
+            return msg
+    return "RO-Crate JSON is invalid"

--- a/middleware/api/src/middleware/api/rocrate.py
+++ b/middleware/api/src/middleware/api/rocrate.py
@@ -9,7 +9,12 @@ from middleware.shared.api_models.common.rocrate import RoCratePayload
 
 
 def parse_rocrate(arc: RoCratePayload | dict[str, Any]) -> RoCratePayload:
-    """Parse and validate a RO-Crate payload, mapping schema errors to domain errors."""
+    """Parse and validate a RO-Crate payload, mapping schema errors to domain errors.
+
+    Lightweight structural validation only (``RoCratePayload`` / Pydantic). Does
+    not call arctrl — that parse is deferred to the Celery worker (see
+    ``arc-manager`` spec).
+    """
     if isinstance(arc, RoCratePayload):
         return arc
     try:

--- a/middleware/api/src/middleware/api/utils.py
+++ b/middleware/api/src/middleware/api/utils.py
@@ -1,7 +1,6 @@
 """Utility functions for the FAIRagro Middleware API."""
 
 import hashlib
-from typing import Any
 
 
 def calculate_arc_id(identifier: str, rdi: str) -> str:
@@ -16,31 +15,3 @@ def calculate_arc_id(identifier: str, rdi: str) -> str:
     """
     input_str = f"{identifier}:{rdi}"
     return hashlib.sha256(input_str.encode("utf-8")).hexdigest()
-
-
-def extract_identifier(arc_content: dict[str, Any]) -> str | None:
-    """Extract identifier from RO-Crate content.
-
-    Following the RO-Crate/ARC specification, the identifier is located
-    in the Root Data Entity (marked with "@id": "./") within the @graph.
-    Also ensures the basic RO-Crate structure (e.g., @context) is present.
-
-    Args:
-        arc_content: The ARC/RO-Crate content as a dictionary.
-
-    Returns:
-        The extracted identifier or None if not found or invalid structure.
-    """
-    if "@context" not in arc_content:
-        return None
-
-    graph = arc_content.get("@graph")
-    if isinstance(graph, list):
-        for item in graph:
-            if item.get("@id") == "./":
-                identifier = item.get("identifier")
-                if isinstance(identifier, list):
-                    identifier = identifier[0] if identifier else None
-                return str(identifier) if identifier else None
-
-    return None

--- a/middleware/api/src/middleware/api/utils.py
+++ b/middleware/api/src/middleware/api/utils.py
@@ -13,5 +13,5 @@ def calculate_arc_id(identifier: str, rdi: str) -> str:
     Returns:
         A SHA256 hash string.
     """
-    input_str = f"{identifier}:{rdi}"
+    input_str = f"{identifier.strip()}:{rdi.strip()}"
     return hashlib.sha256(input_str.encode("utf-8")).hexdigest()

--- a/middleware/api/src/middleware/api/worker/config.py
+++ b/middleware/api/src/middleware/api/worker/config.py
@@ -1,8 +1,8 @@
 """Configuration models for worker-related components."""
 
-from typing import Annotated
+from typing import Annotated, Self
 
-from pydantic import BaseModel, Field, SecretStr
+from pydantic import BaseModel, Field, SecretStr, model_validator
 
 from middleware.shared.config.config_base import ConfigBase
 
@@ -32,6 +32,10 @@ class CeleryConfig(BaseModel):
 class WorkerConfig(ConfigBase):
     """Worker runtime configuration projection from the shared flat config file."""
 
+    known_rdis: Annotated[
+        list[str],
+        Field(description="Known RDI identifiers (used to validate GitLab topic mapping)"),
+    ] = []
     git_repo: Annotated[GitRepoConfig | None, Field(description="GitRepo storage backend configuration")] = None
     gitlab_api: Annotated[
         GitlabApiConfig | None,
@@ -40,3 +44,14 @@ class WorkerConfig(ConfigBase):
     couchdb: Annotated[CouchDBConfig, Field(description="CouchDB configuration")]
     celery: Annotated[CeleryConfig, Field(description="Celery configuration")]
     harvest: Annotated[HarvestConfig, Field(description="Default harvest configuration")] = HarvestConfig()
+
+    @model_validator(mode="after")
+    def validate_git_repo_rdi_gitlab_topics(self) -> Self:
+        """Validate GitLab topic mapping against known_rdis when using GitRepo."""
+        if self.git_repo is not None and self.known_rdis:
+            validated_topics = GitRepoConfig.validate_rdi_gitlab_topics_for_known_rdis(
+                self.known_rdis,
+                self.git_repo.rdi_gitlab_topics,
+            )
+            self.git_repo = self.git_repo.model_copy(update={"rdi_gitlab_topics": validated_topics})
+        return self

--- a/middleware/api/tests/integration/test_system_git_repo.py
+++ b/middleware/api/tests/integration/test_system_git_repo.py
@@ -51,6 +51,7 @@ def git_repo_config(git_server_root: Path, git_repo_cache_dir: Path, oid: x509.O
             "group": "test-group",
             "branch": "main",
             "cache_dir": str(git_repo_cache_dir),
+            "rdi_gitlab_topics": {"rdi-1": "rdi-1"},
         },
         "celery": {
             "broker_url": "memory://",

--- a/middleware/api/tests/system_external/conftest.py
+++ b/middleware/api/tests/system_external/conftest.py
@@ -97,8 +97,8 @@ def config(
         },
         "require_client_cert": False,
         "gitlab_api": {
-            "url": "https://datahub-dev.ipk-gatersleben.de",
-            "group": "FAIRagro-advanced-middleware-integration-tests",
+            "url": "https://datahub.ipk-gatersleben.de",
+            "group": "FAIRagro-advanced-middleware-dev-test",
             "token": gitlab_token,
         },
         "celery": {

--- a/middleware/api/tests/unit/conftest.py
+++ b/middleware/api/tests/unit/conftest.py
@@ -21,8 +21,9 @@ from middleware.api.business_logic.ports import BusinessLogicPorts
 from middleware.api.config import Config
 from middleware.api.document_store import ArcStoreResult
 from middleware.api.document_store.config import CouchDBConfig
-from middleware.api.utils import calculate_arc_id, extract_identifier
+from middleware.api.utils import calculate_arc_id
 from middleware.api.worker.config import CeleryConfig
+from middleware.shared.api_models.common.rocrate import RoCratePayload
 from middleware.shared.config.config_base import OtelConfig
 
 
@@ -120,11 +121,11 @@ def service(config: Config) -> BusinessLogic:
     async def mock_store_arc(
         rdi: str,
         arc: dict,
-        harvest_id: str | None = None,  # noqa: ARG001
         identifier: str | None = None,  # noqa: ARG001
+        harvest_id: str | None = None,  # noqa: ARG001
     ) -> ArcStoreResult:
-        identifier = extract_identifier(arc)
-        arc_id = calculate_arc_id(identifier, rdi) if identifier else "mock-arc-id"
+        resolved = identifier or RoCratePayload.model_validate(arc).identifier
+        arc_id = calculate_arc_id(resolved, rdi)
         return ArcStoreResult(arc_id=arc_id, is_new=True, has_changes=True)
 
     doc_store.store_arc = AsyncMock(side_effect=mock_store_arc)

--- a/middleware/api/tests/unit/conftest.py
+++ b/middleware/api/tests/unit/conftest.py
@@ -67,6 +67,7 @@ def config(oid: x509.ObjectIdentifier, known_rdis: list[str]) -> Config:
             url="http://localhost:8080",
             group="test-group",
             branch="main",
+            rdi_gitlab_topics={"rdi-1": "rdi-1", "rdi-2": "rdi-2"},
         ),
         celery=CeleryConfig(
             broker_url=SecretStr("amqp://guest:guest@localhost:5672//"),

--- a/middleware/api/tests/unit/rocrate_fixtures.py
+++ b/middleware/api/tests/unit/rocrate_fixtures.py
@@ -1,0 +1,30 @@
+"""RO-Crate wire-format helpers for API unit tests."""
+
+from typing import Any
+
+_ARCTRL_METADATA_ENTITY: dict[str, Any] = {
+    "@id": "ro-crate-metadata.json",
+    "@type": "CreativeWork",
+    "conformsTo": {"@id": "https://w3id.org/ro/crate/1.1"},
+    "about": {"@id": "./"},
+}
+
+
+def arctrl_metadata_descriptor() -> dict[str, Any]:
+    """Return the RO-Crate metadata descriptor node required by arctrl."""
+    return dict(_ARCTRL_METADATA_ENTITY)
+
+
+def minimal_rocrate_dict(identifier: str, **root_fields: Any) -> dict[str, Any]:
+    """Build a minimal RO-Crate wire document (arctrl-compatible for worker-path tests)."""
+    root: dict[str, Any] = {
+        "@id": "./",
+        "@type": "Dataset",
+        "additionalType": "Investigation",
+        "identifier": identifier,
+        **root_fields,
+    }
+    return {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [root, arctrl_metadata_descriptor()],
+    }

--- a/middleware/api/tests/unit/test_arc_store.py
+++ b/middleware/api/tests/unit/test_arc_store.py
@@ -59,7 +59,7 @@ class TestArcStoreWrapperMethods:
         with patch.object(store, "_create_or_update") as mock_impl:
             mock_impl.side_effect = ArcStoreError("Test error")
             with pytest.raises(ArcStoreError):
-                await store.create_or_update("test_id", MagicMock())
+                await store.create_or_update("test_id", MagicMock(), rdi="test-rdi")
 
     @pytest.mark.asyncio
     @staticmethod

--- a/middleware/api/tests/unit/test_business_logic.py
+++ b/middleware/api/tests/unit/test_business_logic.py
@@ -203,10 +203,9 @@ async def test_worker_mode_sync_to_gitlab_success(worker_logic: BusinessLogic, m
 
     # Verify store called
     mock_store.create_or_update.assert_called_once()
-    args, _ = mock_store.create_or_update.call_args
+    args, kwargs = mock_store.create_or_update.call_args
     assert args[0] == "arc_id"
-    # Can't check isinstance ARC because we mocked it
-    # assert isinstance(args[1], ARC)
+    assert kwargs["rdi"] == rdi
 
 
 @pytest.mark.asyncio
@@ -298,7 +297,7 @@ def test_factory_create_api_mode() -> None:
 async def test_create_or_update_arc_parse_failure(api_logic: BusinessLogic) -> None:
     """Test create_or_update_arc with missing identifier."""
     # Since we now use fast validation, an empty dict fails the identifier check
-    with pytest.raises(InvalidJsonSemanticError, match="must contain an 'identifier'"):
+    with pytest.raises(InvalidJsonSemanticError):
         await api_logic.create_or_update_arc("test_rdi", {}, "client_1")
 
 
@@ -308,7 +307,7 @@ async def test_create_or_update_missing_identifier(api_logic: BusinessLogic) -> 
     # Data has @graph but no "@id": "./" element with identifier
     arc_data = {"@context": "https://w3id.org/ro/crate/1.1/context", "@graph": [{"@id": "not-root"}]}
 
-    with pytest.raises(InvalidJsonSemanticError, match="must contain an 'identifier'"):
+    with pytest.raises(InvalidJsonSemanticError):
         await api_logic.create_or_update_arc("test_rdi", arc_data, "client_1")
 
 
@@ -328,7 +327,7 @@ async def test_sync_to_gitlab_missing_identifier(worker_logic: BusinessLogic) ->
     """Test sync_to_gitlab with missing Identifier."""
     arc_data = {"@context": "https://w3id.org/ro/crate/1.1/context", "@graph": [{"@id": "arc"}]}
 
-    with pytest.raises(InvalidJsonSemanticError, match="must contain an 'identifier'"):
+    with pytest.raises(InvalidJsonSemanticError):
         await worker_logic.sync_to_gitlab("test_rdi", arc_data)
 
 

--- a/middleware/api/tests/unit/test_business_logic.py
+++ b/middleware/api/tests/unit/test_business_logic.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from unit.rocrate_fixtures import minimal_rocrate_dict
 
 from middleware.api.business_logic import (
     BusinessLogic,
@@ -105,7 +106,7 @@ async def test_api_mode_create_or_update_success(
 ) -> None:
     """Test create_or_update_arc in API mode."""
     rdi = "test-rdi"
-    arc_data = {"@context": "https://w3id.org/ro/crate/1.1/context", "@graph": [{"@id": "./", "identifier": "ABC"}]}
+    arc_data = minimal_rocrate_dict("ABC")
     client_id = "test-client"
 
     # Mock doc_store result
@@ -191,7 +192,7 @@ async def test_setup_failure(api_logic: BusinessLogic, mock_doc_store: MagicMock
 async def test_worker_mode_sync_to_gitlab_success(worker_logic: BusinessLogic, mock_store: MagicMock) -> None:
     """Test sync_to_gitlab in Worker mode."""
     rdi = "test-rdi"
-    arc_data = {"@context": "https://w3id.org/ro/crate/1.1/context", "@graph": [{"@id": "./", "identifier": "ABC"}]}
+    arc_data = minimal_rocrate_dict("ABC")
 
     with patch("middleware.api.business_logic.arc_manager.ARC") as mock_arc_class:
         mock_arc_instance = MagicMock()
@@ -223,7 +224,7 @@ async def test_api_mode_skips_sync_if_no_changes(
     mock_doc_store.store_arc.return_value = ArcStoreResult(arc_id="arc_id", is_new=False, has_changes=False)
 
     rdi = "test-rdi"
-    arc_data = {"@context": "https://w3id.org/ro/crate/1.1/context", "@graph": [{"@id": "./", "identifier": "ABC"}]}
+    arc_data = minimal_rocrate_dict("ABC")
 
     with patch("middleware.api.business_logic.arc_manager.ARC") as mock_arc_class:
         mock_arc_instance = MagicMock()
@@ -263,7 +264,7 @@ async def test_api_mode_dispatches_sync_arc_based_on_arc_status(
 
     rdi = "test-rdi"
     harvest_id = "harvest-1"
-    arc_data = {"@context": "https://w3id.org/ro/crate/1.1/context", "@graph": [{"@id": "./", "identifier": "ABC"}]}
+    arc_data = minimal_rocrate_dict("ABC")
 
     await api_logic.create_or_update_arc(rdi, arc_data, "client", harvest_id=harvest_id)
 
@@ -316,7 +317,7 @@ async def test_create_or_update_generic_exception(api_logic: BusinessLogic, mock
     """Test create_or_update_arc with unexpected exception."""
     mock_doc_store.store_arc.side_effect = Exception("Unexpected failure")
     # Valid data to pass the fast identifier check
-    arc_data = {"@context": "https://w3id.org/ro/crate/1.1/context", "@graph": [{"@id": "./", "identifier": "test"}]}
+    arc_data = minimal_rocrate_dict("test")
 
     with pytest.raises(BusinessLogicError, match="unexpected error encountered"):
         await api_logic.create_or_update_arc("test_rdi", arc_data, "client_1")
@@ -335,7 +336,7 @@ async def test_sync_to_gitlab_missing_identifier(worker_logic: BusinessLogic) ->
 async def test_sync_to_gitlab_generic_exception(worker_logic: BusinessLogic, mock_store: MagicMock) -> None:
     """Test sync_to_gitlab with unexpected exception."""
     mock_store.create_or_update.side_effect = Exception("Git failure")
-    arc_data = {"@context": "https://w3id.org/ro/crate/1.1/context", "@graph": [{"@id": "./", "identifier": "test"}]}
+    arc_data = minimal_rocrate_dict("test")
 
     with patch("middleware.api.business_logic.arc_manager.ARC") as mock_arc_class:
         mock_arc_obj = MagicMock()

--- a/middleware/api/tests/unit/test_business_logic.py
+++ b/middleware/api/tests/unit/test_business_logic.py
@@ -3,7 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from unit.rocrate_fixtures import minimal_rocrate_dict
+from rocrate_fixtures import minimal_rocrate_dict
 
 from middleware.api.business_logic import (
     BusinessLogic,

--- a/middleware/api/tests/unit/test_config.py
+++ b/middleware/api/tests/unit/test_config.py
@@ -20,10 +20,49 @@ from middleware.api.config import Config
 pytestmark = pytest.mark.filterwarnings("ignore:gitlab_api configuration is deprecated.*:DeprecationWarning")
 
 
-def _git_repo(tmp_path: Path, group: str = "g") -> dict[str, str]:
+def _git_repo(tmp_path: Path, group: str = "g") -> dict[str, str | dict[str, str]]:
     repo_dir = tmp_path / "repo"
     repo_dir.mkdir(exist_ok=True)
-    return {"url": repo_dir.as_uri(), "group": group, "path": str(repo_dir)}
+    return {
+        "url": repo_dir.as_uri(),
+        "group": group,
+        "path": str(repo_dir),
+        "rdi_gitlab_topics": {
+            "valid-rdi": "valid-rdi",
+            "rdi.123": "rdi.123",
+            "under_score": "under_score",
+        },
+    }
+
+
+def test_config_validate_rdi_gitlab_topics_requires_full_mapping(tmp_path: Path) -> None:
+    """Every known RDI must have a GitLab topic mapping when git_repo is configured."""
+    config_data = {
+        "known_rdis": ["bonares", "edal"],
+        "git_repo": {
+            **_git_repo(tmp_path),
+            "rdi_gitlab_topics": {"edal": "e!DAL"},
+        },
+        "couchdb": {"url": "http://localhost:5984"},
+        "celery": {"broker_url": "memory://", "result_backend": "cache+memory://"},
+    }
+    with pytest.raises(ValidationError, match="missing from rdi_gitlab_topics"):
+        Config.model_validate(config_data)
+
+
+def test_config_validate_rdi_gitlab_topics_rejects_unknown_keys(tmp_path: Path) -> None:
+    """GitLab topic mapping keys must be a subset of known_rdis."""
+    config_data = {
+        "known_rdis": ["edal"],
+        "git_repo": {
+            **_git_repo(tmp_path),
+            "rdi_gitlab_topics": {"edal": "e!DAL", "bonares": "bonares"},
+        },
+        "couchdb": {"url": "http://localhost:5984"},
+        "celery": {"broker_url": "memory://", "result_backend": "cache+memory://"},
+    }
+    with pytest.raises(ValidationError, match="not in known_rdis"):
+        Config.model_validate(config_data)
 
 
 def test_config_validate_known_rdis_valid(tmp_path: Path) -> None:

--- a/middleware/api/tests/unit/test_couchdb_store.py
+++ b/middleware/api/tests/unit/test_couchdb_store.py
@@ -60,7 +60,7 @@ async def test_store_arc_new(store: CouchDB, mock_client_instance: MagicMock) ->
     mock_client_instance.save_document.return_value = {"id": "arc_...", "rev": "1-..."}
 
     # Execute
-    result = await store.store_arc(rdi, arc_content)
+    result = await store.store_arc(rdi, arc_content, "arc_123")
 
     # Verify
     assert result.is_new is True
@@ -166,7 +166,7 @@ async def test_store_arc_update_changed(store: CouchDB, mock_client_instance: Ma
     mock_client_instance.save_document.return_value = {"ok": True}
 
     # Execute
-    result = await store.store_arc(rdi, arc_content)
+    result = await store.store_arc(rdi, arc_content, "arc_123")
 
     # Verify
     assert result.is_new is False
@@ -214,7 +214,7 @@ async def test_store_arc_no_change(store: CouchDB, mock_client_instance: MagicMo
     mock_client_instance.save_document.return_value = {"ok": True}
 
     # Execute
-    result = await store.store_arc(rdi, arc_content)
+    result = await store.store_arc(rdi, arc_content, "arc_123")
 
     # Verify
     assert result.is_new is False
@@ -259,7 +259,7 @@ async def test_store_arc_duplicate_in_same_harvest_raises(store: CouchDB, mock_c
     )
 
     with pytest.raises(DuplicateArcError, match="arc_dup"):
-        await store.store_arc(rdi, arc_content, harvest_id=harvest_id)
+        await store.store_arc(rdi, arc_content, "arc_dup", harvest_id=harvest_id)
 
     mock_client_instance.save_document.assert_not_called()
 
@@ -289,7 +289,7 @@ async def test_store_arc_concurrent_duplicate_detected_via_validator(
     )
     mock_client_instance.save_document.return_value = {"ok": True}
 
-    await store.store_arc(rdi, arc_content, harvest_id=harvest_id)
+    await store.store_arc(rdi, arc_content, "arc_concurrent", harvest_id=harvest_id)
 
     # Extract the validator that was passed to save_document
     _, kwargs = mock_client_instance.save_document.call_args
@@ -318,7 +318,7 @@ async def test_store_arc_same_arc_different_harvest_is_allowed(store: CouchDB, m
     )
     mock_client_instance.save_document.return_value = {"ok": True}
 
-    result = await store.store_arc(rdi, arc_content, harvest_id="harvest-new")
+    result = await store.store_arc(rdi, arc_content, "arc_dup", harvest_id="harvest-new")
 
     assert result.is_new is False
     mock_client_instance.save_document.assert_called_once()
@@ -337,7 +337,7 @@ async def test_store_arc_no_harvest_context_allows_resubmit(store: CouchDB, mock
     )
     mock_client_instance.save_document.return_value = {"ok": True}
 
-    result = await store.store_arc(rdi, arc_content, harvest_id=None)
+    result = await store.store_arc(rdi, arc_content, "arc_dup", harvest_id=None)
 
     assert result.is_new is False
     mock_client_instance.save_document.assert_called_once()

--- a/middleware/api/tests/unit/test_couchdb_store.py
+++ b/middleware/api/tests/unit/test_couchdb_store.py
@@ -134,6 +134,11 @@ async def test_couchdb_store_setup(store: CouchDB, mock_client_instance: MagicMo
     """Test setup calls client.create_index."""
     await store.setup()
     assert mock_client_instance.create_index.call_count == 2  # noqa: PLR2004
+    mock_client_instance.create_index.assert_any_call(["type", "rdi"], name="idx_type_rdi")
+    mock_client_instance.create_index.assert_any_call(
+        ["doc_type", "metadata.last_harvest_id"],
+        name="idx_doc_type_harvest",
+    )
 
 
 @pytest.mark.asyncio
@@ -425,6 +430,11 @@ async def test_get_harvest_statistics(  # noqa: PLR0913, PLR0917
     mock_client_instance.find_projected = AsyncMock(return_value=[{"metadata": meta_patch}])
 
     stats = await store.get_harvest_statistics(harvest_id)
+
+    mock_client_instance.find_projected.assert_awaited_once_with(
+        {"doc_type": "arc", "metadata.last_harvest_id": harvest_id},
+        fields=["metadata.first_harvest_id", "metadata.last_changed_harvest_id"],
+    )
 
     assert stats.arcs_submitted == 1
     assert stats.arcs_new == expected_new

--- a/middleware/api/tests/unit/test_git_repo.py
+++ b/middleware/api/tests/unit/test_git_repo.py
@@ -16,7 +16,12 @@ from middleware.api.arc_store.config import GitRepoConfig
 from middleware.api.arc_store.git_repo import GitContext, GitContextConfig, GitRepo, is_soft_git_error
 from middleware.api.arc_store.remote_git_provider import GitProjectMetadata
 
-_TEST_GIT_METADATA = GitProjectMetadata(rdi="test-rdi", identifier="test_arc", display_name="")
+_TEST_GIT_METADATA = GitProjectMetadata(
+    rdi="test-rdi",
+    arc_id="test_arc_id",
+    identifier="test_arc",
+    display_name="",
+)
 _TEST_RDI = "test-rdi"
 
 

--- a/middleware/api/tests/unit/test_git_repo.py
+++ b/middleware/api/tests/unit/test_git_repo.py
@@ -14,6 +14,10 @@ from pydantic import SecretStr
 
 from middleware.api.arc_store.config import GitRepoConfig
 from middleware.api.arc_store.git_repo import GitContext, GitContextConfig, GitRepo, is_soft_git_error
+from middleware.api.arc_store.remote_git_provider import GitProjectMetadata
+
+_TEST_GIT_METADATA = GitProjectMetadata(rdi="test-rdi", identifier="test_arc", display_name="")
+_TEST_RDI = "test-rdi"
 
 
 @pytest.fixture
@@ -196,7 +200,11 @@ async def test_create_or_update(git_repo: GitRepo, tmp_path: Path) -> None:
             # Ensure path property mocks correctly
             type(mock_ctx_instance).path = PropertyMock(return_value=str(fake_repo_path))
 
-            await git_repo._create_or_update(arc_id, arc)
+            with patch(
+                "middleware.api.arc_store.git_repo.git_project_metadata_from_arc",
+                return_value=_TEST_GIT_METADATA,
+            ):
+                await git_repo._create_or_update(arc_id, arc, rdi=_TEST_RDI)
 
             # Check cleanup
             assert not (fake_repo_path / "junk.txt").exists()

--- a/middleware/api/tests/unit/test_persistence_gitlab_api.py
+++ b/middleware/api/tests/unit/test_persistence_gitlab_api.py
@@ -60,7 +60,7 @@ async def test_create_or_update_no_changes(gitlab_api: Any) -> None:
     gitlab_api._get_or_create_project = lambda _arc_id: project  # noqa: SLF001
     gitlab_api._compute_arc_hash = lambda _path: "dummyhash"  # noqa: SLF001
 
-    await gitlab_api.create_or_update("arc1", arc)
+    await gitlab_api.create_or_update("arc1", arc, rdi="test-rdi")
     project.commits.create.assert_not_called()
 
 
@@ -80,7 +80,7 @@ async def test_create_or_update_with_changes(gitlab_api: Any) -> None:
     gitlab_api._get_or_create_project = lambda _arc_id: project  # noqa: SLF001
     gitlab_api._compute_arc_hash = lambda _path: "newhash"  # noqa: SLF001
 
-    await gitlab_api.create_or_update("arc1", arc)
+    await gitlab_api.create_or_update("arc1", arc, rdi="test-rdi")
     project.commits.create.assert_called_once()
     args, _kwargs = project.commits.create.call_args
     actions = args[0]["actions"]

--- a/middleware/api/tests/unit/test_remote_repo_manager.py
+++ b/middleware/api/tests/unit/test_remote_repo_manager.py
@@ -17,8 +17,12 @@ from middleware.api.arc_store import ArcStoreError
 from middleware.api.arc_store.remote_git_provider import (
     FileSystemGitProvider,
     GitlabGitProvider,
+    GitProjectMetadata,
     RemoteGitProvider,
+    git_project_metadata_from_arc,
 )
+
+_TEST_GIT_METADATA = GitProjectMetadata(rdi="test-rdi", identifier="test-arc", display_name="")
 
 
 @pytest.fixture
@@ -38,7 +42,7 @@ class TestFileSystemGitProvider:
         provider = FileSystemGitProvider(base_url=f"file://{temp_remote_dir}", group="my-group")
         arc_id = "test-arc"
 
-        provider.ensure_repo_exists(arc_id)
+        provider.ensure_repo_exists(arc_id, _TEST_GIT_METADATA)
 
         expected_path = temp_remote_dir / "my-group" / f"{arc_id}.git"
         assert expected_path.exists()
@@ -87,14 +91,78 @@ class TestGitlabGitProvider:
         provider = GitlabGitProvider(url="https://gitlab.com", group_name="my-group", token="secret")  # nosec
         arc_id = "test-arc"
 
-        provider.ensure_repo_exists(arc_id)
+        provider.ensure_repo_exists(arc_id, metadata=_TEST_GIT_METADATA)
 
         mock_gl.groups.get.assert_called_with("my-group")
         mock_gl.projects.get.assert_called_with("my-group-path/test-arc")
         mock_gl.projects.create.assert_called_once()
         args = mock_gl.projects.create.call_args[0][0]
-        assert args["name"] == arc_id
+        assert args["name"] == "test-arc"
+        assert args["path"] == arc_id
         assert args["namespace_id"] == NAMESPACE_ID
+
+    @staticmethod
+    @patch("middleware.api.arc_store.remote_git_provider.gitlab.Gitlab")
+    def test_ensure_repo_exists_sets_gitlab_metadata(mock_gitlab_class: MagicMock) -> None:
+        """Test that human-readable metadata is applied when creating a project."""
+        NAMESPACE_ID = 123  # noqa: N806
+
+        mock_gl = MagicMock()
+        mock_gitlab_class.return_value = mock_gl
+
+        mock_group = MagicMock()
+        mock_group.full_path = "my-group-path"
+        mock_group.id = NAMESPACE_ID
+        mock_gl.groups.get.return_value = mock_group
+        mock_gl.projects.get.side_effect = GitlabGetError("Not Found", response_code=HTTPStatus.NOT_FOUND)
+
+        provider = GitlabGitProvider(url="https://gitlab.com", group_name="my-group", token="secret")  # nosec
+        metadata = GitProjectMetadata(
+            rdi="rdi-1",
+            display_name="Arabidopsis thaliana cold acclimation",
+            identifier="AthalianaColdStressSugar",
+            description="Cold stress experiment",
+        )
+
+        provider.ensure_repo_exists("abc123hash", metadata=metadata)
+
+        args = mock_gl.projects.create.call_args[0][0]
+        assert args["name"] == "AthalianaColdStressSugar"
+        assert args["path"] == "abc123hash"
+        assert args["topics"] == ["rdi-1"]
+        assert args["description"] == "Arabidopsis thaliana cold acclimation\nCold stress experiment"
+
+    @staticmethod
+    @patch("middleware.api.arc_store.remote_git_provider.gitlab.Gitlab")
+    def test_ensure_repo_exists_updates_existing_project_metadata(mock_gitlab_class: MagicMock) -> None:
+        """Test that metadata is refreshed when the GitLab project already exists."""
+        mock_gl = MagicMock()
+        mock_gitlab_class.return_value = mock_gl
+
+        mock_group = MagicMock()
+        mock_group.full_path = "my-group-path"
+        mock_gl.groups.get.return_value = mock_group
+
+        mock_project = MagicMock()
+        mock_project.name = "old-hash-name"
+        mock_project.description = "old description"
+        mock_project.topics = []
+        mock_gl.projects.get.return_value = mock_project
+
+        provider = GitlabGitProvider(url="https://gitlab.com", group_name="my-group", token="secret")  # nosec
+        metadata = GitProjectMetadata(
+            rdi="rdi-2",
+            display_name="Readable title",
+            identifier="dataset-42",
+        )
+
+        provider.ensure_repo_exists("abc123hash", metadata=metadata)
+
+        mock_gl.projects.create.assert_not_called()
+        assert mock_project.name == "dataset-42"
+        assert mock_project.description == "Readable title"
+        assert mock_project.topics == ["rdi-2"]
+        mock_project.save.assert_called_once()
 
     @staticmethod
     @patch("middleware.api.arc_store.remote_git_provider.gitlab.Gitlab")
@@ -110,7 +178,7 @@ class TestGitlabGitProvider:
         provider = GitlabGitProvider(url="https://gitlab.com", group_name="my-group", token="invalid")  # nosec
 
         with pytest.raises(ArcStoreError, match="401 Unauthorized"):
-            provider.ensure_repo_exists("some-arc")
+            provider.ensure_repo_exists("some-arc", metadata=_TEST_GIT_METADATA)
 
     @staticmethod
     def test_get_repo_url() -> None:
@@ -142,6 +210,20 @@ class TestGitlabGitProvider:
         mock_gl.auth.side_effect = GitlabAuthenticationError()
         assert provider.check_health() is False
 
+    @staticmethod
+    @patch("urllib.request.urlopen")
+    def test_check_health_without_token(mock_urlopen: MagicMock) -> None:
+        """Test reachability fallback when no GitLab token is configured."""
+        mock_response = MagicMock()
+        mock_response.status = HTTPStatus.OK
+        mock_response.__enter__.return_value = mock_response
+        mock_urlopen.return_value = mock_response
+
+        provider = GitlabGitProvider(url="https://gitlab.com", group_name="g", token=None)
+
+        assert provider.check_health() is True
+        mock_urlopen.assert_called_once_with("https://gitlab.com", timeout=5)
+
 
 class TestRemoteGitProviderFactory:
     """Tests for RemoteGitProvider factory method."""
@@ -169,3 +251,24 @@ class TestRemoteGitProviderFactory:
         """Test that unknown protocols fail."""
         with pytest.raises(ValueError, match="Could not determine git provider"):
             RemoteGitProvider.from_url("ftp://server.local", "group")
+
+
+def test_git_project_metadata_rejects_empty_identifier() -> None:
+    """GitProjectMetadata requires a non-empty identifier."""
+    with pytest.raises(ValueError, match="identifier must not be empty"):
+        GitProjectMetadata(rdi="rdi-1", identifier="", display_name="")
+
+
+def test_git_project_metadata_from_arc() -> None:
+    """git_project_metadata_from_arc derives display fields from the ARC object."""
+    arc = MagicMock()
+    arc.Identifier = "ARC-001"
+    arc.Title = "My Study"
+    arc.Description = "A test"
+
+    metadata = git_project_metadata_from_arc(arc, rdi="my-rdi")
+
+    assert metadata.rdi == "my-rdi"
+    assert metadata.identifier == "ARC-001"
+    assert metadata.display_name == "My Study"
+    assert metadata.description == "A test"

--- a/middleware/api/tests/unit/test_remote_repo_manager.py
+++ b/middleware/api/tests/unit/test_remote_repo_manager.py
@@ -24,6 +24,7 @@ from middleware.api.arc_store.remote_git_provider import (
     build_gitlab_project_name,
     git_project_metadata_from_arc,
     normalize_gitlab_topic,
+    resolve_gitlab_topic,
     sanitize_gitlab_api_project_name,
     sanitize_gitlab_project_name,
 )
@@ -134,6 +135,7 @@ class TestGitlabGitProvider:
             display_name="Arabidopsis thaliana cold acclimation",
             identifier="AthalianaColdStressSugar",
             description="Cold stress experiment",
+            gitlab_topic="rdi-1",
         )
 
         provider.ensure_repo_exists("abc123hash", metadata=metadata)
@@ -167,6 +169,7 @@ class TestGitlabGitProvider:
             arc_id="abc123hash",
             display_name="Readable title",
             identifier="dataset-42",
+            gitlab_topic="rdi-2",
         )
 
         provider.ensure_repo_exists("abc123hash", metadata=metadata)
@@ -174,7 +177,7 @@ class TestGitlabGitProvider:
         mock_gl.projects.create.assert_not_called()
         assert mock_project.name == "dataset-42"
         assert mock_project.description == "Readable title"
-        assert mock_project.topics == ["existing", "rdi-2"]
+        assert mock_project.topics == ["rdi-2"]
         mock_project.save.assert_called_once()
 
     @staticmethod
@@ -190,6 +193,7 @@ class TestGitlabGitProvider:
             identifier="dataset-42 - rdi-1",
             display_name="",
             description="",
+            gitlab_topic="rdi-1",
         )
 
         apply_gitlab_project_metadata(mock_project, "abc123hash", metadata)
@@ -301,8 +305,29 @@ def test_git_project_metadata_from_arc() -> None:
     assert metadata.rdi == "my-rdi"
     assert metadata.arc_id == "hash123"
     assert metadata.identifier == "ARC-001 - my-rdi"
-    assert metadata.display_name == "My Study"
-    assert metadata.description == "A test"
+    assert metadata.gitlab_topic == "my-rdi"
+
+
+def test_git_project_metadata_from_arc_uses_topic_mapping() -> None:
+    """Configured topic mapping overrides normalized RDI names."""
+    arc = MagicMock()
+    arc.Identifier = "ARC-001"
+    arc.Title = ""
+    arc.Description = None
+
+    metadata = git_project_metadata_from_arc(
+        arc,
+        rdi="edal",
+        arc_id="hash123",
+        rdi_gitlab_topics={"edal": "e!DAL"},
+    )
+
+    assert metadata.gitlab_topic == "e!DAL"
+
+
+def test_resolve_gitlab_topic_uses_mapping_case_insensitively() -> None:
+    """Topic mapping keys match RDIs case-insensitively."""
+    assert resolve_gitlab_topic("Edal", {"edal": "e!DAL"}) == "e!DAL"
 
 
 def test_build_gitlab_project_name_appends_rdi() -> None:

--- a/middleware/api/tests/unit/test_remote_repo_manager.py
+++ b/middleware/api/tests/unit/test_remote_repo_manager.py
@@ -15,10 +15,12 @@ from gitlab.exceptions import GitlabAuthenticationError, GitlabGetError
 
 from middleware.api.arc_store import ArcStoreError
 from middleware.api.arc_store.remote_git_provider import (
+    GITLAB_PROJECT_NAME_MAX_LEN,
     FileSystemGitProvider,
     GitlabGitProvider,
     GitProjectMetadata,
     RemoteGitProvider,
+    build_gitlab_project_name,
     git_project_metadata_from_arc,
     normalize_gitlab_topic,
     sanitize_gitlab_project_name,
@@ -277,9 +279,23 @@ def test_git_project_metadata_from_arc() -> None:
 
     assert metadata.rdi == "my-rdi"
     assert metadata.arc_id == "hash123"
-    assert metadata.identifier == "ARC-001"
+    assert metadata.identifier == "ARC-001 (my-rdi)"
     assert metadata.display_name == "My Study"
     assert metadata.description == "A test"
+
+
+def test_build_gitlab_project_name_appends_rdi() -> None:
+    """GitLab project titles include RDI so names stay unique within a group."""
+    assert build_gitlab_project_name("study-2024", "my-rdi") == "study-2024 (my-rdi)"
+
+
+def test_build_gitlab_project_name_truncates_long_identifier() -> None:
+    """Very long ARC identifiers are truncated before the RDI suffix is appended."""
+    long_id = "x" * 300
+    rdi = "rdi-1"
+    result = build_gitlab_project_name(long_id, rdi)
+    assert result.endswith(f" ({rdi})")
+    assert len(result) <= GITLAB_PROJECT_NAME_MAX_LEN
 
 
 def test_sanitize_gitlab_project_name_replaces_slashes() -> None:

--- a/middleware/api/tests/unit/test_remote_repo_manager.py
+++ b/middleware/api/tests/unit/test_remote_repo_manager.py
@@ -20,9 +20,16 @@ from middleware.api.arc_store.remote_git_provider import (
     GitProjectMetadata,
     RemoteGitProvider,
     git_project_metadata_from_arc,
+    normalize_gitlab_topic,
+    sanitize_gitlab_project_name,
 )
 
-_TEST_GIT_METADATA = GitProjectMetadata(rdi="test-rdi", identifier="test-arc", display_name="")
+_TEST_GIT_METADATA = GitProjectMetadata(
+    rdi="test-rdi",
+    arc_id="abc123hash",
+    identifier="test-arc",
+    display_name="",
+)
 
 
 @pytest.fixture
@@ -119,6 +126,7 @@ class TestGitlabGitProvider:
         provider = GitlabGitProvider(url="https://gitlab.com", group_name="my-group", token="secret")  # nosec
         metadata = GitProjectMetadata(
             rdi="rdi-1",
+            arc_id="abc123hash",
             display_name="Arabidopsis thaliana cold acclimation",
             identifier="AthalianaColdStressSugar",
             description="Cold stress experiment",
@@ -146,12 +154,13 @@ class TestGitlabGitProvider:
         mock_project = MagicMock()
         mock_project.name = "old-hash-name"
         mock_project.description = "old description"
-        mock_project.topics = []
+        mock_project.topics = ["existing"]
         mock_gl.projects.get.return_value = mock_project
 
         provider = GitlabGitProvider(url="https://gitlab.com", group_name="my-group", token="secret")  # nosec
         metadata = GitProjectMetadata(
             rdi="rdi-2",
+            arc_id="abc123hash",
             display_name="Readable title",
             identifier="dataset-42",
         )
@@ -161,7 +170,7 @@ class TestGitlabGitProvider:
         mock_gl.projects.create.assert_not_called()
         assert mock_project.name == "dataset-42"
         assert mock_project.description == "Readable title"
-        assert mock_project.topics == ["rdi-2"]
+        assert mock_project.topics == ["existing", "rdi-2"]
         mock_project.save.assert_called_once()
 
     @staticmethod
@@ -253,12 +262,6 @@ class TestRemoteGitProviderFactory:
             RemoteGitProvider.from_url("ftp://server.local", "group")
 
 
-def test_git_project_metadata_rejects_empty_identifier() -> None:
-    """GitProjectMetadata requires a non-empty identifier."""
-    with pytest.raises(ValueError, match="identifier must not be empty"):
-        GitProjectMetadata(rdi="rdi-1", identifier="", display_name="")
-
-
 def test_git_project_metadata_from_arc() -> None:
     """git_project_metadata_from_arc derives display fields from the ARC object."""
     arc = MagicMock()
@@ -266,9 +269,42 @@ def test_git_project_metadata_from_arc() -> None:
     arc.Title = "My Study"
     arc.Description = "A test"
 
-    metadata = git_project_metadata_from_arc(arc, rdi="my-rdi")
+    metadata = git_project_metadata_from_arc(
+        arc,
+        rdi="my-rdi",
+        arc_id="hash123",
+    )
 
     assert metadata.rdi == "my-rdi"
+    assert metadata.arc_id == "hash123"
     assert metadata.identifier == "ARC-001"
     assert metadata.display_name == "My Study"
     assert metadata.description == "A test"
+
+
+def test_sanitize_gitlab_project_name_replaces_slashes() -> None:
+    """Slashes in identifiers are replaced for GitLab project titles."""
+    assert sanitize_gitlab_project_name("study/2024") == "study-2024"
+
+
+def test_sanitize_gitlab_project_name_rejects_empty() -> None:
+    """Whitespace-only identifiers cannot become GitLab project titles."""
+    with pytest.raises(ValueError, match="cannot be empty"):
+        sanitize_gitlab_project_name("   ")
+
+
+def test_git_project_metadata_rejects_empty_identifier() -> None:
+    """git_project_metadata_from_arc requires a non-empty ARC identifier."""
+    arc = MagicMock()
+    arc.Identifier = "   "
+    arc.Title = ""
+    arc.Description = None
+
+    with pytest.raises(ValueError, match="identifier is required"):
+        git_project_metadata_from_arc(arc, rdi="my-rdi", arc_id="hash123")
+
+
+def test_normalize_gitlab_topic_empty_rdi_alnum_fallback() -> None:
+    """RDI names with only stripped characters yield no GitLab topic."""
+    assert normalize_gitlab_topic("---") is None
+    assert normalize_gitlab_topic("rdi-1") == "rdi-1"

--- a/middleware/api/tests/unit/test_remote_repo_manager.py
+++ b/middleware/api/tests/unit/test_remote_repo_manager.py
@@ -24,6 +24,7 @@ from middleware.api.arc_store.remote_git_provider import (
     build_gitlab_project_name,
     git_project_metadata_from_arc,
     normalize_gitlab_topic,
+    sanitize_gitlab_api_project_name,
     sanitize_gitlab_project_name,
 )
 
@@ -180,13 +181,13 @@ class TestGitlabGitProvider:
     def test_apply_gitlab_project_metadata_skips_save_when_gitlab_values_match() -> None:
         """GitLab API may return None for empty description/topics; treat as already in sync."""
         mock_project = MagicMock()
-        mock_project.name = "dataset-42 (rdi-1)"
+        mock_project.name = "dataset-42 - rdi-1"
         mock_project.description = None
         mock_project.topics = ["rdi-1"]
         metadata = GitProjectMetadata(
             rdi="rdi-1",
             arc_id="abc123hash",
-            identifier="dataset-42 (rdi-1)",
+            identifier="dataset-42 - rdi-1",
             display_name="",
             description="",
         )
@@ -299,14 +300,14 @@ def test_git_project_metadata_from_arc() -> None:
 
     assert metadata.rdi == "my-rdi"
     assert metadata.arc_id == "hash123"
-    assert metadata.identifier == "ARC-001 (my-rdi)"
+    assert metadata.identifier == "ARC-001 - my-rdi"
     assert metadata.display_name == "My Study"
     assert metadata.description == "A test"
 
 
 def test_build_gitlab_project_name_appends_rdi() -> None:
     """GitLab project titles include RDI so names stay unique within a group."""
-    assert build_gitlab_project_name("study-2024", "my-rdi") == "study-2024 (my-rdi)"
+    assert build_gitlab_project_name("study-2024", "my-rdi") == "study-2024 - my-rdi"
 
 
 def test_build_gitlab_project_name_truncates_long_identifier() -> None:
@@ -314,13 +315,23 @@ def test_build_gitlab_project_name_truncates_long_identifier() -> None:
     long_id = "x" * 300
     rdi = "rdi-1"
     result = build_gitlab_project_name(long_id, rdi)
-    assert result.endswith(f" ({rdi})")
+    assert result.endswith(f" - {rdi}")
     assert len(result) <= GITLAB_PROJECT_NAME_MAX_LEN
 
 
 def test_sanitize_gitlab_project_name_replaces_slashes() -> None:
     """Slashes in identifiers are replaced for GitLab project titles."""
     assert sanitize_gitlab_project_name("study/2024") == "study-2024"
+
+
+def test_sanitize_gitlab_api_project_name_rejects_parentheses() -> None:
+    """GitLab project names cannot contain parentheses."""
+    assert sanitize_gitlab_api_project_name("study (edal)") == "study edal"
+
+
+def test_sanitize_gitlab_api_project_name_prefixes_invalid_start() -> None:
+    """GitLab project names must start with a letter, digit, or underscore."""
+    assert sanitize_gitlab_api_project_name("-leading-dash") == "_-leading-dash"
 
 
 def test_sanitize_gitlab_project_name_rejects_empty() -> None:

--- a/middleware/api/tests/unit/test_remote_repo_manager.py
+++ b/middleware/api/tests/unit/test_remote_repo_manager.py
@@ -20,6 +20,7 @@ from middleware.api.arc_store.remote_git_provider import (
     GitlabGitProvider,
     GitProjectMetadata,
     RemoteGitProvider,
+    apply_gitlab_project_metadata,
     build_gitlab_project_name,
     git_project_metadata_from_arc,
     normalize_gitlab_topic,
@@ -174,6 +175,25 @@ class TestGitlabGitProvider:
         assert mock_project.description == "Readable title"
         assert mock_project.topics == ["existing", "rdi-2"]
         mock_project.save.assert_called_once()
+
+    @staticmethod
+    def test_apply_gitlab_project_metadata_skips_save_when_gitlab_values_match() -> None:
+        """GitLab API may return None for empty description/topics; treat as already in sync."""
+        mock_project = MagicMock()
+        mock_project.name = "dataset-42 (rdi-1)"
+        mock_project.description = None
+        mock_project.topics = ["rdi-1"]
+        metadata = GitProjectMetadata(
+            rdi="rdi-1",
+            arc_id="abc123hash",
+            identifier="dataset-42 (rdi-1)",
+            display_name="",
+            description="",
+        )
+
+        apply_gitlab_project_metadata(mock_project, "abc123hash", metadata)
+
+        mock_project.save.assert_not_called()
 
     @staticmethod
     @patch("middleware.api.arc_store.remote_git_provider.gitlab.Gitlab")

--- a/middleware/api/tests/unit/test_rocrate_parse.py
+++ b/middleware/api/tests/unit/test_rocrate_parse.py
@@ -1,0 +1,11 @@
+"""Unit tests for API-layer RO-Crate parsing."""
+
+from unit.rocrate_fixtures import minimal_rocrate_dict
+
+from middleware.api.rocrate import parse_rocrate
+
+
+def test_parse_rocrate_validates_wire_format() -> None:
+    """parse_rocrate applies RoCratePayload validation without arctrl parsing."""
+    payload = parse_rocrate(minimal_rocrate_dict("ARC-001"))
+    assert payload.identifier == "ARC-001"

--- a/middleware/api/tests/unit/test_rocrate_parse.py
+++ b/middleware/api/tests/unit/test_rocrate_parse.py
@@ -1,6 +1,6 @@
 """Unit tests for API-layer RO-Crate parsing."""
 
-from unit.rocrate_fixtures import minimal_rocrate_dict
+from rocrate_fixtures import minimal_rocrate_dict
 
 from middleware.api.rocrate import parse_rocrate
 

--- a/middleware/api/tests/unit/test_utils.py
+++ b/middleware/api/tests/unit/test_utils.py
@@ -1,0 +1,11 @@
+"""Unit tests for middleware.api.utils."""
+
+from middleware.api.utils import calculate_arc_id
+
+
+def test_calculate_arc_id_strips_whitespace() -> None:
+    """Leading and trailing whitespace in identifier and rdi does not change arc_id."""
+    base = calculate_arc_id("my-arc", "my-rdi")
+    assert calculate_arc_id("  my-arc  ", "my-rdi") == base
+    assert calculate_arc_id("my-arc", "  my-rdi  ") == base
+    assert calculate_arc_id("  my-arc  ", "  my-rdi  ") == base

--- a/middleware/api/tests/unit/test_v3_arcs.py
+++ b/middleware/api/tests/unit/test_v3_arcs.py
@@ -42,13 +42,7 @@ def test_create_or_update_arc_v3_success(client: TestClient, cert: str, middlewa
 
     rocrate = {
         "@context": "https://w3id.org/ro/crate/1.1/context",
-        "@graph": [
-            {
-                "@id": "./",
-                "@type": "Dataset",
-                "identifier": "ARC-001",
-            }
-        ],
+        "@graph": [{"@id": "./", "identifier": "ARC-001"}],
     }
 
     with (
@@ -103,7 +97,13 @@ def test_create_or_update_arc_v3_rdi_not_authorized(client: TestClient, cert: st
                 "content-type": "application/json",
                 "accept": "application/json",
             },
-            json={"rdi": "rdi-1", "arc": {"dummy": "crate"}},
+            json={
+                "rdi": "rdi-1",
+                "arc": {
+                    "@context": "https://w3id.org/ro/crate/1.1/context",
+                    "@graph": [{"@id": "./", "identifier": "ARC-001"}],
+                },
+            },
         )
         assert r.status_code == http.HTTPStatus.FORBIDDEN
 

--- a/middleware/api_client/src/middleware/api_client/api_client.py
+++ b/middleware/api_client/src/middleware/api_client/api_client.py
@@ -15,6 +15,7 @@ import httpx
 from pydantic import BaseModel, ValidationError
 
 from middleware.shared.api_models.common.models import HarvestStatus as SharedHarvestStatus
+from middleware.shared.api_models.common.rocrate import RoCratePayload
 from middleware.shared.api_models.v3.models import (
     CreateArcRequest,
     CreateHarvestRequest,
@@ -295,7 +296,7 @@ class ApiClient:
         seen_identifiers: set[str] = set()
 
         async def submit_one(arc_item: dict[str, Any]) -> None:
-            request = SubmitHarvestArcRequest(arc=arc_item)
+            request = SubmitHarvestArcRequest(arc=self._validate_rocrate(arc_item))
             await self._post(f"v3/harvests/{harvest_id}/arcs", request)
 
         async for arc in arcs:
@@ -504,23 +505,20 @@ class ApiClient:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _extract_identifier_from_rocrate(arc_content: dict[str, Any]) -> str | None:
-        """Extract the RO-Crate identifier from a serialized ARC dict.
+    def _validate_rocrate(arc_content: dict[str, Any]) -> RoCratePayload:
+        """Validate a RO-Crate dict before sending it to the API."""
+        try:
+            return RoCratePayload.model_validate(arc_content)
+        except ValidationError as e:
+            raise ApiClientError(f"Invalid RO-Crate JSON: {e}") from e
 
-        Looks for the Root Data Entity (``@id == "./"``), then returns its
-        ``identifier`` field.  Returns ``None`` when the field is absent or
-        the dict does not follow the RO-Crate structure — validation is left
-        to the server.
-        """
-        graph = arc_content.get("@graph")
-        if isinstance(graph, list):
-            for item in graph:
-                if isinstance(item, dict) and item.get("@id") == "./":
-                    identifier = item.get("identifier")
-                    if isinstance(identifier, list):
-                        identifier = identifier[0] if identifier else None
-                    return str(identifier) if identifier else None
-        return None
+    @staticmethod
+    def _extract_identifier_from_rocrate(arc_content: dict[str, Any]) -> str | None:
+        """Return the RO-Crate identifier when the payload is structurally valid."""
+        try:
+            return RoCratePayload.model_validate(arc_content).identifier
+        except ValidationError:
+            return None
 
     @classmethod
     def _serialize_arc(cls, arc: "ARC | dict[str, Any] | str") -> dict[str, Any]:
@@ -575,7 +573,7 @@ class ApiClient:
         """
         logger.info("Creating/updating ARC for RDI: %s", rdi)
         serialized = self._serialize_arc(arc)
-        request = CreateArcRequest(rdi=rdi, arc=serialized)
+        request = CreateArcRequest(rdi=rdi, arc=self._validate_rocrate(serialized))
         data = await self._post("v3/arcs", request)
         return self._parse_arc_response(data)
 
@@ -710,7 +708,7 @@ class ApiClient:
             :class:`ArcResult` with the result of the operation.
         """
         serialized = self._serialize_arc(arc)
-        request = SubmitHarvestArcRequest(arc=serialized)
+        request = SubmitHarvestArcRequest(arc=self._validate_rocrate(serialized))
         data = await self._post(f"v3/harvests/{harvest_id}/arcs", request)
         return self._parse_arc_response(data)
 

--- a/middleware/api_client/src/middleware/api_client/api_client.py
+++ b/middleware/api_client/src/middleware/api_client/api_client.py
@@ -471,7 +471,7 @@ class ApiClient:
         return await self._request_with_retries(
             "POST",
             path,
-            content=body.model_dump_json(),
+            content=body.model_dump_json(by_alias=True),
             headers={"content-type": "application/json"},
         )
 
@@ -496,7 +496,7 @@ class ApiClient:
         return await self._request_with_retries(
             "PATCH",
             path,
-            content=body.model_dump_json(),
+            content=body.model_dump_json(by_alias=True),
             headers={"content-type": "application/json"},
         )
 

--- a/middleware/api_client/tests/unit/test_client.py
+++ b/middleware/api_client/tests/unit/test_client.py
@@ -327,6 +327,40 @@ async def test_create_or_update_arc_sends_correct_headers(client_config: Config)
     assert req.headers["content-type"] == "application/json"
 
 
+@pytest.mark.asyncio
+@respx.mock
+async def test_create_or_update_arc_serializes_rocrate_wire_aliases(client_config: Config) -> None:
+    """ARC upload JSON must use @context and @graph, not Python field names."""
+    route = respx.post(f"{client_config.api_url}v3/arcs").mock(
+        return_value=httpx.Response(http.HTTPStatus.OK, json=_ARC_RESPONSE)
+    )
+    async with ApiClient(client_config) as client:
+        await client.create_or_update_arc(rdi="test-rdi", arc=_rocrate_dict())
+
+    body = json.loads(route.calls.last.request.content.decode())
+    assert "@context" in body["arc"]
+    assert "@graph" in body["arc"]
+    assert "context" not in body["arc"]
+    assert "graph" not in body["arc"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_submit_arc_in_harvest_serializes_rocrate_wire_aliases(client_config: Config) -> None:
+    """Harvest ARC upload JSON must use @context and @graph wire aliases."""
+    route = respx.post(f"{client_config.api_url}v3/harvests/harvest-456/arcs").mock(
+        return_value=httpx.Response(http.HTTPStatus.OK, json=_ARC_RESPONSE)
+    )
+    async with ApiClient(client_config) as client:
+        await client.submit_arc_in_harvest("harvest-456", arc=_rocrate_dict())
+
+    body = json.loads(route.calls.last.request.content.decode())
+    assert "@context" in body["arc"]
+    assert "@graph" in body["arc"]
+    assert "context" not in body["arc"]
+    assert "graph" not in body["arc"]
+
+
 # ---------------------------------------------------------------------------
 # Generic _get / error paths
 # ---------------------------------------------------------------------------

--- a/middleware/api_client/tests/unit/test_client.py
+++ b/middleware/api_client/tests/unit/test_client.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import http
+import json
 import ssl
 from collections.abc import AsyncGenerator
 from pathlib import Path
@@ -39,6 +40,15 @@ _ARC_RESPONSE = {
     },
     "events": [],
 }
+
+
+def _rocrate_dict(identifier: str = "mock-arc") -> dict[str, Any]:
+    """Minimal valid RO-Crate payload for client tests."""
+    return {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [{"@id": "./", "identifier": identifier}],
+    }
+
 
 _HARVEST_RESPONSE: dict[str, str | None | dict] = {
     "client_id": "test-client",
@@ -229,7 +239,7 @@ async def test_create_or_update_arc_with_dict(client_config: Config) -> None:
         return_value=httpx.Response(http.HTTPStatus.OK, json=_ARC_RESPONSE)
     )
     async with ApiClient(client_config) as client:
-        response = await client.create_or_update_arc(rdi="test-rdi", arc={"id": "mock-arc"})
+        response = await client.create_or_update_arc(rdi="test-rdi", arc=_rocrate_dict())
     assert isinstance(response, ArcResult)
 
 
@@ -241,7 +251,7 @@ async def test_create_or_update_arc_with_json_string(client_config: Config) -> N
         return_value=httpx.Response(http.HTTPStatus.OK, json=_ARC_RESPONSE)
     )
     async with ApiClient(client_config) as client:
-        response = await client.create_or_update_arc(rdi="test-rdi", arc='{"id": "mock-arc"}')
+        response = await client.create_or_update_arc(rdi="test-rdi", arc=json.dumps(_rocrate_dict()))
     assert route.called
     assert isinstance(response, ArcResult)
     assert response.arc_id == "arc-123"
@@ -252,7 +262,7 @@ async def test_create_or_update_arc_with_invalid_json_string(client_config: Conf
     """Test create_or_update_arc with an invalid JSON string."""
     async with ApiClient(client_config) as client:
         with pytest.raises(ApiClientError, match="Invalid JSON string provided for ARC"):
-            await client.create_or_update_arc(rdi="test-rdi", arc='{"id": "mock-arc"')
+            await client.create_or_update_arc(rdi="test-rdi", arc='{"@context":')
 
 
 @pytest.mark.asyncio
@@ -290,6 +300,14 @@ async def test_create_or_update_arc_invalid_response(client_config: Config) -> N
     )
     async with ApiClient(client_config) as client:
         with pytest.raises(ApiClientError, match="Invalid ARC response"):
+            await client.create_or_update_arc(rdi="test-rdi", arc=_rocrate_dict("mock"))
+
+
+@pytest.mark.asyncio
+async def test_create_or_update_arc_invalid_rocrate(client_config: Config) -> None:
+    """Test create_or_update_arc rejects structurally invalid RO-Crate JSON."""
+    async with ApiClient(client_config) as client:
+        with pytest.raises(ApiClientError, match="Invalid RO-Crate JSON"):
             await client.create_or_update_arc(rdi="test-rdi", arc={"id": "mock"})
 
 
@@ -301,7 +319,7 @@ async def test_create_or_update_arc_sends_correct_headers(client_config: Config)
         return_value=httpx.Response(http.HTTPStatus.OK, json=_ARC_RESPONSE)
     )
     async with ApiClient(client_config) as client:
-        await client.create_or_update_arc(rdi="test", arc={"id": "mock-arc"})
+        await client.create_or_update_arc(rdi="test", arc=_rocrate_dict())
 
     assert route.called
     req = route.calls.last.request
@@ -499,7 +517,7 @@ async def test_submit_arc_in_harvest(client_config: Config) -> None:
         return_value=httpx.Response(http.HTTPStatus.OK, json=_ARC_RESPONSE)
     )
     async with ApiClient(client_config) as client:
-        response = await client.submit_arc_in_harvest("harvest-456", arc={"id": "mock-arc"})
+        response = await client.submit_arc_in_harvest("harvest-456", arc=_rocrate_dict())
     assert isinstance(response, ArcResult)
     assert response.arc_id == "arc-123"
 
@@ -513,6 +531,14 @@ async def test_submit_arc_in_harvest_invalid_response(client_config: Config) -> 
     )
     async with ApiClient(client_config) as client:
         with pytest.raises(ApiClientError, match="Invalid ARC response"):
+            await client.submit_arc_in_harvest("harvest-456", arc=_rocrate_dict("mock"))
+
+
+@pytest.mark.asyncio
+async def test_submit_arc_in_harvest_invalid_rocrate(client_config: Config) -> None:
+    """Test submit_arc_in_harvest rejects structurally invalid RO-Crate JSON."""
+    async with ApiClient(client_config) as client:
+        with pytest.raises(ApiClientError, match="Invalid RO-Crate JSON"):
             await client.submit_arc_in_harvest("harvest-456", arc={"id": "mock"})
 
 
@@ -524,7 +550,7 @@ async def test_submit_arc_in_harvest_with_json_string(client_config: Config) -> 
         return_value=httpx.Response(http.HTTPStatus.OK, json=_ARC_RESPONSE)
     )
     async with ApiClient(client_config) as client:
-        response = await client.submit_arc_in_harvest("harvest-456", arc='{"id": "mock-arc"}')
+        response = await client.submit_arc_in_harvest("harvest-456", arc=json.dumps(_rocrate_dict()))
     assert route.called
     assert isinstance(response, ArcResult)
     assert response.arc_id == "arc-123"
@@ -535,7 +561,7 @@ async def test_submit_arc_in_harvest_with_invalid_json_string(client_config: Con
     """Test submit_arc_in_harvest with an invalid JSON string."""
     async with ApiClient(client_config) as client:
         with pytest.raises(ApiClientError, match="Invalid JSON string provided for ARC"):
-            await client.submit_arc_in_harvest("harvest-456", arc='{"id": "mock-arc"')
+            await client.submit_arc_in_harvest("harvest-456", arc='{"@context":')
 
 
 # ---------------------------------------------------------------------------
@@ -564,7 +590,7 @@ async def test_harvest_arcs_success(client_config: Config) -> None:
         return_value=httpx.Response(http.HTTPStatus.OK, json=completed_response)
     )
 
-    arcs = _arc_gen({"id": "arc-1"}, {"id": "arc-2"}, {"id": "arc-3"})
+    arcs = _arc_gen(_rocrate_dict("arc-1"), _rocrate_dict("arc-2"), _rocrate_dict("arc-3"))
     async with ApiClient(client_config) as client:
         result = await client.harvest_arcs("test-rdi", arcs, expected_datasets=3)
 
@@ -589,7 +615,7 @@ async def test_harvest_arcs_success_with_parallelism(client_config: Config) -> N
         return_value=httpx.Response(http.HTTPStatus.OK, json=completed_response)
     )
 
-    arcs = _arc_gen({"id": "arc-1"}, {"id": "arc-2"}, {"id": "arc-3"})
+    arcs = _arc_gen(_rocrate_dict("arc-1"), _rocrate_dict("arc-2"), _rocrate_dict("arc-3"))
     async with ApiClient(client_config) as client:
         result = await client.harvest_arcs("test-rdi", arcs)
 
@@ -614,7 +640,7 @@ async def test_harvest_arcs_uses_config_default_concurrency(client_config: Confi
         return_value=httpx.Response(http.HTTPStatus.OK, json=completed_response)
     )
 
-    arcs = _arc_gen({"id": "arc-1"}, {"id": "arc-2"}, {"id": "arc-3"})
+    arcs = _arc_gen(_rocrate_dict("arc-1"), _rocrate_dict("arc-2"), _rocrate_dict("arc-3"))
     async with ApiClient(client_config) as client:
         result = await client.harvest_arcs("test-rdi", arcs)
 
@@ -664,7 +690,8 @@ async def test_harvest_arcs_continues_on_item_error(client_config: Config) -> No
     )
 
     async with ApiClient(client_config) as client:
-        result = await client.harvest_arcs("test-rdi", _arc_gen({"id": "arc-1"}, {"id": "arc-2"}, {"id": "arc-3"}))
+        arcs = _arc_gen(_rocrate_dict("arc-1"), _rocrate_dict("arc-2"), _rocrate_dict("arc-3"))
+        result = await client.harvest_arcs("test-rdi", arcs)
 
     assert isinstance(result, HarvestResult)
     assert route_submit.call_count == EXPECTED_ARC_UPLOADS
@@ -672,7 +699,7 @@ async def test_harvest_arcs_continues_on_item_error(client_config: Config) -> No
     assert not cancel_route.called
     assert len(result.errors) == 1
     assert result.errors[0].error_type == HarvestErrorType.SUBMISSION_FAILED
-    assert result.errors[0].arc_id is None
+    assert result.errors[0].arc_id == "arc-1"
     assert "HTTP error 400" in result.errors[0].message
 
 
@@ -698,7 +725,7 @@ async def test_harvest_arcs_cancels_on_catastrophic_error(client_config: Config)
 
     async with ApiClient(client_config) as client:
         with pytest.raises(ApiClientError, match="HTTP error 409"):
-            await client.harvest_arcs("test-rdi", _arc_gen({"id": "arc-1"}))
+            await client.harvest_arcs("test-rdi", _arc_gen(_rocrate_dict("arc-1")))
 
     assert fail_route.called
 
@@ -760,8 +787,8 @@ async def test_harvest_arcs_with_json_string(client_config: Config) -> None:
     )
 
     arcs = _arc_gen(
-        '{"id": "arc-1-string"}',
-        {"id": "arc-2-dict"},
+        json.dumps(_rocrate_dict("arc-1-string")),
+        _rocrate_dict("arc-2-dict"),
         ARC.from_arc_investigation(ArcInvestigation.create(identifier="test", title="Test")),
     )
     async with ApiClient(client_config) as client:
@@ -807,7 +834,7 @@ async def test_harvest_arcs_cancel_failure_does_not_mask_original_error(client_c
 
     async with ApiClient(client_config) as client:
         with pytest.raises(ApiClientError, match="HTTP error 409"):
-            await client.harvest_arcs("test-rdi", _arc_gen({"id": "arc-1"}))
+            await client.harvest_arcs("test-rdi", _arc_gen(_rocrate_dict("arc-1")))
 
 
 @pytest.mark.asyncio
@@ -855,7 +882,7 @@ async def test_harvest_arcs_all_exceptions_retrieved_when_multiple_tasks_catastr
         with pytest.raises(ApiClientError, match="HTTP error 409"):
             await client.harvest_arcs(
                 "test-rdi",
-                _arc_gen({"id": "arc-1"}, {"id": "arc-2"}, {"id": "arc-3"}),
+                _arc_gen(_rocrate_dict("arc-1"), _rocrate_dict("arc-2"), _rocrate_dict("arc-3")),
             )
 
     assert fail_route.called
@@ -892,7 +919,7 @@ async def test_harvest_arcs_500_is_submission_failed(client_config: Config) -> N
     async with ApiClient(client_config) as client:
         result = await client.harvest_arcs(
             "test-rdi",
-            _arc_gen({"id": "arc-1"}, {"id": "arc-2"}, {"id": "arc-3"}),
+            _arc_gen(_rocrate_dict("arc-1"), _rocrate_dict("arc-2"), _rocrate_dict("arc-3")),
         )
 
     assert complete_route.called
@@ -929,7 +956,7 @@ async def test_harvest_arcs_502_is_submission_failed(client_config: Config) -> N
     )
 
     async with ApiClient(client_config) as client:
-        result = await client.harvest_arcs("test-rdi", _arc_gen({"id": "arc-1"}, {"id": "arc-2"}))
+        result = await client.harvest_arcs("test-rdi", _arc_gen(_rocrate_dict("arc-1"), _rocrate_dict("arc-2")))
 
     assert complete_route.called
     assert not fail_route.called

--- a/middleware/shared/src/middleware/shared/api_models/common/rocrate.py
+++ b/middleware/shared/src/middleware/shared/api_models/common/rocrate.py
@@ -17,6 +17,8 @@ def _root_dataset_entity(graph: list[dict[str, Any]]) -> dict[str, Any] | None:
 def _normalize_text_field(value: object) -> str | None:
     if isinstance(value, list):
         value = value[0] if value else None
+    if isinstance(value, dict):
+        value = value.get("@value")
     if value is None:
         return None
     text = str(value).strip()

--- a/middleware/shared/src/middleware/shared/api_models/common/rocrate.py
+++ b/middleware/shared/src/middleware/shared/api_models/common/rocrate.py
@@ -1,0 +1,86 @@
+"""RO-Crate payload validation for ARC upload requests."""
+
+from functools import cached_property
+from typing import Annotated, Any, Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+def _root_dataset_entity(graph: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Return the RO-Crate root data entity (``@id``: ``./``) from ``@graph``."""
+    for item in graph:
+        if isinstance(item, dict) and item.get("@id") == "./":
+            return item
+    return None
+
+
+def _normalize_text_field(value: object) -> str | None:
+    if isinstance(value, list):
+        value = value[0] if value else None
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _extract_identifier(root: dict[str, Any]) -> str:
+    """Extract and normalize the required ``identifier`` from the root data entity."""
+    identifier = _normalize_text_field(root.get("identifier"))
+    if not identifier:
+        msg = "RO-Crate root data entity must contain a non-empty identifier"
+        raise ValueError(msg)
+    return identifier
+
+
+def _extract_optional_text(root: dict[str, Any], field: str) -> str | None:
+    """Extract an optional text field from the root data entity."""
+    return _normalize_text_field(root.get(field))
+
+
+def validate_root_dataset(graph: list[dict[str, Any]]) -> dict[str, Any]:
+    """Validate ``@graph`` contains a root data entity with a non-empty ``identifier``."""
+    root = _root_dataset_entity(graph)
+    if root is None:
+        msg = "RO-Crate must contain a root data entity with @id './'"
+        raise ValueError(msg)
+    _extract_identifier(root)
+    return root
+
+
+class RoCratePayload(BaseModel):
+    """RO-Crate metadata document as received on the API wire format."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    context: Annotated[Any, Field(alias="@context")]
+    graph: Annotated[list[dict[str, Any]], Field(alias="@graph", min_length=1)]
+
+    @model_validator(mode="after")
+    def validate_root_dataset_fields(self) -> Self:
+        """Require a root data entity with API-mandated fields; leave other properties untouched."""
+        validate_root_dataset(self.graph)
+        return self
+
+    @cached_property
+    def _root(self) -> dict[str, Any]:
+        """Root data entity dict (validated during model construction)."""
+        root = _root_dataset_entity(self.graph)
+        if root is None:
+            msg = "RO-Crate must contain a root data entity with @id './'"
+            raise ValueError(msg)
+        return root
+
+    @cached_property
+    def identifier(self) -> str:
+        """Non-empty ``identifier`` from the root data entity (``@graph`` → ``@id`` ``./``)."""
+        return _extract_identifier(self._root)
+
+    @cached_property
+    def name(self) -> str | None:
+        """Optional RO-Crate ``name`` from the root data entity."""
+        return _extract_optional_text(self._root, "name")
+
+    @cached_property
+    def description(self) -> str | None:
+        """Optional RO-Crate ``description`` from the root data entity."""
+        return _extract_optional_text(self._root, "description")

--- a/middleware/shared/src/middleware/shared/api_models/v2/models.py
+++ b/middleware/shared/src/middleware/shared/api_models/v2/models.py
@@ -5,6 +5,7 @@ from typing import Annotated
 from pydantic import BaseModel, Field
 
 from ..common.models import ApiResponse, ArcOperationResult, TaskStatus
+from ..common.rocrate import RoCratePayload
 
 
 class HealthResponse(BaseModel):
@@ -18,7 +19,7 @@ class CreateOrUpdateArcRequest(BaseModel):
     """Request model for creating or updating a single ARC."""
 
     rdi: Annotated[str, Field(description="Research Data Infrastructure identifier")]
-    arc: Annotated[dict, Field(description="ARC definition in RO-Crate JSON format")]
+    arc: Annotated[RoCratePayload, Field(description="ARC definition in RO-Crate JSON format")]
 
 
 class CreateOrUpdateArcResponse(ApiResponse):

--- a/middleware/shared/src/middleware/shared/api_models/v3/models.py
+++ b/middleware/shared/src/middleware/shared/api_models/v3/models.py
@@ -6,13 +6,14 @@ from typing import Annotated
 from pydantic import BaseModel, Field
 
 from ..common.models import ApiResponse, ArcLifecycleStatus, ArcStatus, HarvestStatus
+from ..common.rocrate import RoCratePayload
 
 
 class CreateArcRequest(BaseModel):
     """Request model for creating or updating a single ARC."""
 
     rdi: Annotated[str, Field(description="Research Data Infrastructure identifier")]
-    arc: Annotated[dict, Field(description="ARC definition in RO-Crate JSON format")]
+    arc: Annotated[RoCratePayload, Field(description="ARC definition in RO-Crate JSON format")]
 
 
 class BaseStatusResponse(BaseModel):
@@ -49,7 +50,7 @@ class SubmitHarvestArcRequest(BaseModel):
     """
 
     arc: Annotated[
-        dict,
+        RoCratePayload,
         Field(
             description=(
                 "ARC definition in RO-Crate JSON format. "

--- a/middleware/shared/tests/unit/test_rocrate.py
+++ b/middleware/shared/tests/unit/test_rocrate.py
@@ -61,6 +61,30 @@ def test_rocrate_payload_description() -> None:
     assert RoCratePayload.model_validate(arc).description == "Cold stress experiment"
 
 
+@pytest.mark.parametrize(
+    ("field", "wire_value", "expected"),
+    [
+        ("identifier", {"@value": "dataset-jsonld"}, "dataset-jsonld"),
+        ("name", {"@value": "Study title"}, "Study title"),
+        ("description", {"@value": "Study summary"}, "Study summary"),
+    ],
+)
+def test_rocrate_payload_jsonld_value_objects(field: str, wire_value: object, expected: str) -> None:
+    """JSON-LD value objects for text fields are normalized to plain strings."""
+    root: dict[str, object] = {"@id": "./"}
+    if field == "identifier":
+        root["identifier"] = wire_value
+    else:
+        root["identifier"] = "dataset-1"
+        root[field] = wire_value
+    arc = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [root],
+    }
+    payload = RoCratePayload.model_validate(arc)
+    assert getattr(payload, field) == expected
+
+
 def test_rocrate_payload_preserves_extra_root_fields() -> None:
     """Root entity fields beyond the API contract remain in ``@graph`` unchanged."""
     arc = {

--- a/middleware/shared/tests/unit/test_rocrate.py
+++ b/middleware/shared/tests/unit/test_rocrate.py
@@ -1,0 +1,121 @@
+"""Unit tests for RO-Crate payload validation."""
+
+import pytest
+from pydantic import ValidationError
+
+from middleware.shared.api_models.common.rocrate import RoCratePayload
+
+_MINIMAL_ROCRATE = {
+    "@context": "https://w3id.org/ro/crate/1.1/context",
+    "@graph": [{"@id": "./", "identifier": "AthalianaColdStressSugar"}],
+}
+
+
+def test_rocrate_payload_accepts_wire_format_only() -> None:
+    """RoCratePayload mirrors top-level JSON-LD keys only."""
+    payload = RoCratePayload.model_validate(_MINIMAL_ROCRATE)
+    dumped = payload.model_dump(by_alias=True)
+    assert "@context" in dumped
+    assert "@graph" in dumped
+    assert "identifier" not in dumped
+
+
+def test_rocrate_payload_identifier() -> None:
+    """Validated identifier is read from the root data entity path."""
+    payload = RoCratePayload.model_validate(_MINIMAL_ROCRATE)
+    assert payload.identifier == "AthalianaColdStressSugar"
+
+
+def test_rocrate_payload_name() -> None:
+    """Optional RO-Crate ``name`` is extracted from the root data entity."""
+    arc = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {
+                "@id": "./",
+                "identifier": "AthalianaColdStressSugar",
+                "name": "Arabidopsis thaliana cold acclimation",
+            }
+        ],
+    }
+    assert RoCratePayload.model_validate(arc).name == "Arabidopsis thaliana cold acclimation"
+
+
+def test_rocrate_payload_missing_name_is_none() -> None:
+    """Missing RO-Crate ``name`` is represented as None."""
+    assert RoCratePayload.model_validate(_MINIMAL_ROCRATE).name is None
+
+
+def test_rocrate_payload_description() -> None:
+    """Optional RO-Crate ``description`` is extracted from the root data entity."""
+    arc = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {
+                "@id": "./",
+                "identifier": "dataset-1",
+                "description": "Cold stress experiment",
+            }
+        ],
+    }
+    assert RoCratePayload.model_validate(arc).description == "Cold stress experiment"
+
+
+def test_rocrate_payload_preserves_extra_root_fields() -> None:
+    """Root entity fields beyond the API contract remain in ``@graph`` unchanged."""
+    arc = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {
+                "@id": "./",
+                "@type": "Dataset",
+                "additionalType": "Investigation",
+                "identifier": "dataset-1",
+                "name": "Example study",
+                "license": {"@id": "#LICENSE"},
+                "datePublished": "2025-12-09T13:41:46.875",
+            }
+        ],
+    }
+    payload = RoCratePayload.model_validate(arc)
+    root = payload.model_dump(by_alias=True)["@graph"][0]
+    assert root["@type"] == "Dataset"
+    assert root["additionalType"] == "Investigation"
+    assert root["license"] == {"@id": "#LICENSE"}
+    assert root["datePublished"] == "2025-12-09T13:41:46.875"
+
+
+def test_rocrate_payload_rejects_extra_top_level_fields() -> None:
+    """RO-Crate metadata documents must not contain keys beyond @context and @graph."""
+    arc = {**_MINIMAL_ROCRATE, "unexpected": "field"}
+    with pytest.raises(ValidationError):
+        RoCratePayload.model_validate(arc)
+
+
+@pytest.mark.parametrize(
+    "arc",
+    [
+        {"@context": "https://w3id.org/ro/crate/1.1/context"},
+        {
+            "@graph": [
+                {"@id": "./", "identifier": "ARC-006"},
+            ]
+        },
+        {
+            "@context": "https://w3id.org/ro/crate/1.1/context",
+            "@graph": [{"@id": "ro-crate-metadata.json", "@type": "CreativeWork"}],
+        },
+        {
+            "@context": "https://w3id.org/ro/crate/1.1/context",
+            "@graph": [{"@id": "./"}],
+        },
+        {
+            "@context": "https://w3id.org/ro/crate/1.1/context",
+            "@graph": [{"@id": "./", "identifier": ""}],
+        },
+    ],
+)
+def test_rocrate_payload_rejects_invalid_structure(arc: dict[str, object]) -> None:
+    """Reject RO-Crate payloads that violate the API contract."""
+    with pytest.raises(ValidationError):
+        RoCratePayload.model_validate(arc)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ dev = [
   "ggshield>=1.51.0",
   "respx>=0.23.1",
   "testcontainers>=4.14.2",
+  # Starlette TestClient (FastAPI API tests) uses httpx2 when installed; avoids
+  # StarletteDeprecationWarning. Production api_client still uses httpx + respx.
   "httpx2>=2.4.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
   "ggshield>=1.51.0",
   "respx>=0.23.1",
   "testcontainers>=4.14.2",
+  "httpx2>=2.4.0",
 ]
 
 [tool.uv.sources]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ disallow_untyped_defs = true
 disallow_incomplete_defs = true
 explicit_package_bases = true
 namespace_packages = true
-mypy_path = "middleware/api/src:middleware/api_client/src:middleware/shared/src:middleware/api/tests:middleware/api_client/tests:middleware/shared/tests"
+mypy_path = "middleware/api/src:middleware/api_client/src:middleware/shared/src:middleware/api/tests/unit:middleware/api_client/tests:middleware/shared/tests"
 
 # Exclude directories from type checking
 exclude = [
@@ -138,6 +138,15 @@ exclude = [
   ".ruff_cache",
   ".*/tests/conftest\\.py$",
   ".*/tests/.+/conftest\\.py$",
+]
+
+[tool.pyright]
+# IDE import resolution (Pylance / BasedPyright); mirrors mypy_path and pylint source-roots.
+extraPaths = [
+  "middleware/api/src",
+  "middleware/api/tests/unit",
+  "middleware/api_client/tests",
+  "middleware/shared/tests",
 ]
 
 # Docstring-Regeln aktivieren, damit es wie pylint C0114/15/16 meckert
@@ -231,6 +240,9 @@ ignore = [".venv", "venv", ".git", "__pycache__", "build", "dist"]
 ignore-patterns = ["^\\..*", ".*\\.egg-info"]
 # Fail if the score is below 8.0
 fail-under = 8.0
+
+[tool.pylint.main]
+source-roots = "middleware/api/src,middleware/api/tests/unit,middleware/api_client/tests,middleware/shared/tests"
 
 [tool.pylint.messages_control]
 # Disable checks that are already covered by ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ disallow_untyped_defs = true
 disallow_incomplete_defs = true
 explicit_package_bases = true
 namespace_packages = true
-mypy_path = "middleware/api/src:middleware/api_client/src:middleware/shared/src"
+mypy_path = "middleware/api/src:middleware/api_client/src:middleware/shared/src:middleware/api/tests:middleware/api_client/tests:middleware/shared/tests"
 
 # Exclude directories from type checking
 exclude = [
@@ -136,6 +136,8 @@ exclude = [
   ".pytest_cache",
   ".mypy_cache",
   ".ruff_cache",
+  ".*/tests/conftest\\.py$",
+  ".*/tests/.+/conftest\\.py$",
 ]
 
 # Docstring-Regeln aktivieren, damit es wie pylint C0114/15/16 meckert

--- a/scripts/delete_gitlab_arc_projects.py
+++ b/scripts/delete_gitlab_arc_projects.py
@@ -2,10 +2,28 @@
 r"""Delete ARC-hash GitLab projects from a middleware group.
 
 Lists projects in a GitLab group and deletes those whose repository path is a
-64-character SHA256 hex string (the middleware ``arc_id``). Other projects in
-the group are skipped unless ``--all-projects`` is passed.
+64-character SHA256 hex string (the middleware ``arc_id``). Projects already
+marked for deletion use the path ``{hash}-deletion_scheduled-{id}`` and are
+matched for the purge phase.
 
-Dry-run is the default. Pass ``--execute`` to perform deletions.
+Deletion is two-step on GitLab:
+
+1. **Mark** — schedule active projects for deletion (``--mark``).
+2. **Purge** — permanently remove marked projects (``--purge``).
+
+Some projects can end up in an inconsistent state: the path still contains
+``-deletion_scheduled-{id}`` (often after a restore), but GitLab no longer
+lists them as pending deletion. ``--purge`` repairs that automatically by
+marking the project again before retrying permanent deletion.
+
+Dry-run is the default (no flags). Pass ``--mark`` and/or ``--purge`` to run phases:
+
+| Flags | Mark | Purge |
+|-------|------|-------|
+| *(none)* | no | no |
+| ``--mark`` | yes | no |
+| ``--purge`` | no | yes |
+| ``--mark --purge`` | yes | yes |
 
 Environment:
     GITLAB_TOKEN: Personal access token with ``api`` scope (used when ``--token``
@@ -20,16 +38,14 @@ Examples:
     # Fast dry-run: count only (no full target list in memory)
     uv run python scripts/delete_gitlab_arc_projects.py --count-only
 
-    # Development
-    uv run python scripts/delete_gitlab_arc_projects.py \\
-        --url https://datahub-dev.ipk-gatersleben.de \\
-        --group FAIRagro-advanced-middleware-dev
+    # Phase 1: mark active ARC projects for deletion
+    uv run python scripts/delete_gitlab_arc_projects.py --mark --workers 5
 
-    # Actually delete (stop middleware/Celery first)
-    uv run python scripts/delete_gitlab_arc_projects.py --execute --workers 5
+    # Phase 2: permanently remove inactive / pending-deletion projects
+    uv run python scripts/delete_gitlab_arc_projects.py --purge --workers 5
 
-    # Purge projects already marked for deletion (faster; skips re-marking)
-    uv run python scripts/delete_gitlab_arc_projects.py --execute --purge-only --workers 5
+    # Both phases in one run (mark all, re-scan, then purge all pending)
+    uv run python scripts/delete_gitlab_arc_projects.py --mark --purge --workers 5
 """
 
 from __future__ import annotations
@@ -40,11 +56,12 @@ import os
 import re
 import sys
 import time
-from collections.abc import Iterator
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from collections.abc import Callable, Iterator
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
+from enum import Enum
 from http import HTTPStatus
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import gitlab
 from gitlab.exceptions import GitlabDeleteError, GitlabError
@@ -57,30 +74,61 @@ DEFAULT_GITLAB_URL = "https://datahub.ipk-gatersleben.de"
 DEFAULT_GROUP = "fairagro-advanced-middleware"
 
 ARC_PATH_RE = re.compile(r"^[a-f0-9]{64}$")
+ARC_PENDING_DELETION_RE = re.compile(r"^[a-f0-9]{64}-deletion_scheduled-\d+$")
 LOG_FILE = "gitlab-delete.log"
 DRY_RUN_PREVIEW_LIMIT = 20
 LIST_PROGRESS_INTERVAL = 1000
+PURGE_PATH_RESOLVE_RETRIES = 3
+PURGE_PATH_RESOLVE_DELAY_S = 0.5
+
+
+class ArcProjectPhase(Enum):
+    """Whether a listed project is active or pending permanent deletion."""
+
+    ACTIVE = "active"
+    PENDING_DELETION = "pending_deletion"
 
 
 @dataclass(frozen=True)
-class DeleteJob:
-    """Parameters for deleting a single GitLab project."""
+class ProjectJob:
+    """Parameters for a mark or purge operation on one GitLab project."""
 
     gitlab_url: str
     token: str
     project_id: int
     listed_path: str
-    purge_only: bool
+
+
+@dataclass(frozen=True)
+class PhaseRunConfig:
+    """Parameters for running one mark or purge phase in parallel."""
+
+    workers: int
+    targets: list[tuple[int, str]]
+    gitlab_url: str
+    token: str
+    phase_name: str
+
+
+@dataclass(frozen=True)
+class PurgeResult:
+    """Outcome of a permanent-delete API attempt."""
+
+    success: bool
+    needs_mark_first: bool = False
 
 
 @dataclass(frozen=True)
 class ScanResult:
     """Outcome of scanning group projects."""
 
-    targets: list[tuple[int, str]]
+    mark_targets: list[tuple[int, str]]
+    purge_targets: list[tuple[int, str]]
     scanned: int
     skipped_non_arc: int
-    matches: int
+    active_matches: int
+    pending_matches: int
+    zombie_matches: int
 
 
 def _configure_logging() -> logging.Logger:
@@ -96,8 +144,28 @@ def _configure_logging() -> logging.Logger:
     return log
 
 
-def _project_matches(project: GroupProject, *, all_projects: bool) -> bool:
-    return all_projects or ARC_PATH_RE.fullmatch(project.path) is not None
+def _is_marked_for_deletion(project: GroupProject) -> bool:
+    """Return whether GitLab considers the project scheduled for deletion."""
+    attributes = project.attributes
+    if attributes.get("marked_for_deletion_on"):
+        return True
+    return bool(attributes.get("marked_for_deletion_at"))
+
+
+def _git_error_needs_mark_first(exc: GitlabError) -> bool:
+    return "must be marked for deletion first" in str(exc).lower()
+
+
+def _classify_arc_project(path: str, *, all_projects: bool) -> ArcProjectPhase | None:
+    if all_projects:
+        if ARC_PENDING_DELETION_RE.fullmatch(path):
+            return ArcProjectPhase.PENDING_DELETION
+        return ArcProjectPhase.ACTIVE
+    if ARC_PATH_RE.fullmatch(path):
+        return ArcProjectPhase.ACTIVE
+    if ARC_PENDING_DELETION_RE.fullmatch(path):
+        return ArcProjectPhase.PENDING_DELETION
+    return None
 
 
 def _iter_group_projects(
@@ -107,23 +175,38 @@ def _iter_group_projects(
     include_subgroups: bool,
 ) -> Iterator[GroupProject]:
     """Iterate group projects using a lighter, keyset-paginated listing."""
-    list_kwargs = {
-        "iterator": True,
+    list_kwargs: dict[str, Any] = {
         "get_all": False,
         "include_subgroups": include_subgroups,
         "simple": True,
         "per_page": 100,
+        "include_pending_delete": True,
     }
     try:
         yield from group.projects.list(
-            **list_kwargs,
+            iterator=True,
             pagination="keyset",
             order_by="id",
             sort="asc",
+            **list_kwargs,
         )
     except GitlabError as exc:
         log.warning("Keyset pagination unavailable (%s); falling back to offset pagination", exc)
-        yield from group.projects.list(**list_kwargs)
+        yield from group.projects.list(iterator=True, **list_kwargs)
+
+
+def _append_scan_target(
+    project: GroupProject,
+    targets: list[tuple[int, str]],
+    preview: list[tuple[int, str]],
+    *,
+    collect_targets: bool,
+) -> None:
+    entry = (project.id, project.path_with_namespace)
+    if collect_targets:
+        targets.append(entry)
+    elif len(preview) < DRY_RUN_PREVIEW_LIMIT:
+        preview.append(entry)
 
 
 def _scan_group_projects(
@@ -134,27 +217,43 @@ def _scan_group_projects(
     include_subgroups: bool,
     collect_targets: bool,
 ) -> ScanResult:
-    targets: list[tuple[int, str]] = [] if collect_targets else []
-    preview: list[tuple[int, str]] = []
+    mark_targets: list[tuple[int, str]] = []
+    purge_targets: list[tuple[int, str]] = []
+    mark_preview: list[tuple[int, str]] = []
+    purge_preview: list[tuple[int, str]] = []
     scanned = 0
     skipped_non_arc = 0
-    matches = 0
+    active_matches = 0
+    pending_matches = 0
+    zombie_matches = 0
     start = time.monotonic()
 
     log.info(
-        "Listing projects (simple=keyset, include_subgroups=%s)...",
+        "Listing projects (simple=keyset, include_subgroups=%s, include_pending_delete=True)...",
         include_subgroups,
     )
 
     for project in _iter_group_projects(group, log, include_subgroups=include_subgroups):
         scanned += 1
-        if _project_matches(project, all_projects=all_projects):
-            matches += 1
-            entry = (project.id, project.path_with_namespace)
-            if collect_targets:
-                targets.append(entry)
-            elif len(preview) < DRY_RUN_PREVIEW_LIMIT:
-                preview.append(entry)
+        phase = _classify_arc_project(project.path, all_projects=all_projects)
+        if phase is ArcProjectPhase.ACTIVE:
+            active_matches += 1
+            _append_scan_target(
+                project,
+                mark_targets,
+                mark_preview,
+                collect_targets=collect_targets,
+            )
+        elif phase is ArcProjectPhase.PENDING_DELETION:
+            pending_matches += 1
+            if not _is_marked_for_deletion(project):
+                zombie_matches += 1
+            _append_scan_target(
+                project,
+                purge_targets,
+                purge_preview,
+                collect_targets=collect_targets,
+            )
         else:
             skipped_non_arc += 1
 
@@ -162,25 +261,48 @@ def _scan_group_projects(
             elapsed = time.monotonic() - start
             rate = scanned / elapsed if elapsed else 0.0
             log.info(
-                "Scanned %d projects (%.0f/s, %d matches, %d skipped)...",
+                "Scanned %d projects (%.0f/s, %d active, %d pending, %d skipped)...",
                 scanned,
                 rate,
-                matches,
+                active_matches,
+                pending_matches,
                 skipped_non_arc,
             )
 
     if not collect_targets:
-        targets = preview
+        mark_targets = mark_preview
+        purge_targets = purge_preview
 
     return ScanResult(
-        targets=targets,
+        mark_targets=mark_targets,
+        purge_targets=purge_targets,
         scanned=scanned,
         skipped_non_arc=skipped_non_arc,
-        matches=matches,
+        active_matches=active_matches,
+        pending_matches=pending_matches,
+        zombie_matches=zombie_matches,
     )
 
 
-def _candidate_full_paths(attributes: dict[str, object]) -> list[str]:
+def _deletion_scheduled_path_candidates(
+    attributes: dict[str, object],
+    project_id: int,
+) -> list[str]:
+    """Build ``{hash}-deletion_scheduled-{id}`` paths when GitLab has not renamed yet."""
+    project_path = attributes.get("path")
+    if not isinstance(project_path, str) or ARC_PENDING_DELETION_RE.fullmatch(project_path):
+        return []
+
+    if ARC_PATH_RE.fullmatch(project_path):
+        namespace = attributes.get("namespace")
+        if isinstance(namespace, dict):
+            namespace_full_path = namespace.get("full_path")
+            if namespace_full_path:
+                return [f"{namespace_full_path}/{project_path}-deletion_scheduled-{project_id}"]
+    return []
+
+
+def _candidate_full_paths(attributes: dict[str, object], project_id: int) -> list[str]:
     """Build ordered, unique full_path candidates for permanently_remove.
 
     After a project is marked for deletion GitLab renames its path, e.g.
@@ -204,6 +326,8 @@ def _candidate_full_paths(attributes: dict[str, object]) -> list[str]:
     if explicit:
         candidates.append(str(explicit))
 
+    candidates.extend(_deletion_scheduled_path_candidates(attributes, project_id))
+
     unique: list[str] = []
     seen: set[str] = set()
     for candidate in candidates:
@@ -213,14 +337,35 @@ def _candidate_full_paths(attributes: dict[str, object]) -> list[str]:
     return unique
 
 
-def _resolve_project_full_path(gl: gitlab.Gitlab, project_id: int) -> list[str]:
+def _resolve_project_full_path(
+    gl: gitlab.Gitlab,
+    project_id: int,
+    log: logging.Logger,
+) -> list[str]:
     """Return GitLab full_path candidates for permanently_remove."""
-    project = gl.projects.get(project_id)
-    candidates = _candidate_full_paths(project.attributes)
-    if not candidates:
-        msg = f"Could not resolve full_path for project {project_id}"
-        raise ValueError(msg)
-    return candidates
+    last_candidates: list[str] = []
+    for attempt in range(1, PURGE_PATH_RESOLVE_RETRIES + 1):
+        project = gl.projects.get(project_id)
+        candidates = _candidate_full_paths(project.attributes, project_id)
+        if not candidates:
+            msg = f"Could not resolve full_path for project {project_id}"
+            raise ValueError(msg)
+
+        if any(ARC_PENDING_DELETION_RE.search(candidate) for candidate in candidates):
+            return candidates
+
+        last_candidates = candidates
+        if attempt < PURGE_PATH_RESOLVE_RETRIES:
+            log.debug(
+                "Project %s not renamed yet (attempt %d/%d); waiting %.1fs",
+                project_id,
+                attempt,
+                PURGE_PATH_RESOLVE_RETRIES,
+                PURGE_PATH_RESOLVE_DELAY_S,
+            )
+            time.sleep(PURGE_PATH_RESOLVE_DELAY_S)
+
+    return last_candidates
 
 
 def _permanently_remove_project(
@@ -228,7 +373,7 @@ def _permanently_remove_project(
     project_id: int,
     full_path_candidates: list[str],
     log: logging.Logger,
-) -> bool:
+) -> PurgeResult:
     last_error: GitlabError | None = None
     for full_path in full_path_candidates:
         try:
@@ -245,8 +390,10 @@ def _permanently_remove_project(
                     full_path,
                     project_id,
                 )
-            return True
+            return PurgeResult(success=True)
         except GitlabError as exc:
+            if _git_error_needs_mark_first(exc):
+                return PurgeResult(success=False, needs_mark_first=True)
             if exc.response_code == HTTPStatus.BAD_REQUEST and "full_path" in str(exc):
                 last_error = exc
                 continue
@@ -259,38 +406,103 @@ def _permanently_remove_project(
             project_id,
             last_error,
         )
-        return False
-    return False
+    return PurgeResult(success=False)
 
 
-def _delete_project(job: DeleteJob, log: logging.Logger) -> bool:
-    gl = gitlab.Gitlab(job.gitlab_url, private_token=job.token, per_page=100)
+def _schedule_project_for_deletion(
+    gl: gitlab.Gitlab,
+    project_id: int,
+    listed_path: str,
+    log: logging.Logger,
+) -> bool:
     try:
-        if not job.purge_only:
-            gl.http_delete(f"/projects/{job.project_id}")
-
-        # GitLab renames the project path when marking for deletion; resolve afterwards.
-        full_path_candidates = _resolve_project_full_path(gl, job.project_id)
-        primary_path = full_path_candidates[0]
-        if primary_path != job.listed_path:
-            log.debug(
-                "Resolved full_path candidates %s for project %s (listed as %s)",
-                full_path_candidates,
-                job.project_id,
-                job.listed_path,
-            )
-        return _permanently_remove_project(gl, job.project_id, full_path_candidates, log)
+        gl.http_delete(f"/projects/{project_id}")
+        return True
     except GitlabDeleteError as exc:
         if exc.response_code == HTTPStatus.NOT_FOUND:
             return True
-        log.error("DELETE failed %s (%s): %s", job.listed_path, job.project_id, exc)
+        log.error("MARK failed %s (%s): %s", listed_path, project_id, exc)
         return False
     except GitlabError as exc:
-        log.error("DELETE failed %s (%s): %s", job.listed_path, job.project_id, exc)
+        log.error("MARK failed %s (%s): %s", listed_path, project_id, exc)
+        return False
+
+
+def _mark_project(job: ProjectJob, log: logging.Logger) -> bool:
+    gl = gitlab.Gitlab(job.gitlab_url, private_token=job.token, per_page=100)
+    return _schedule_project_for_deletion(gl, job.project_id, job.listed_path, log)
+
+
+def _attempt_purge(
+    gl: gitlab.Gitlab,
+    project_id: int,
+    listed_path: str,
+    log: logging.Logger,
+) -> PurgeResult:
+    full_path_candidates = _resolve_project_full_path(gl, project_id, log)
+    if full_path_candidates[0] != listed_path:
+        log.debug(
+            "Resolved full_path candidates %s for project %s (listed as %s)",
+            full_path_candidates,
+            project_id,
+            listed_path,
+        )
+    return _permanently_remove_project(gl, project_id, full_path_candidates, log)
+
+
+def _repair_and_purge(
+    gl: gitlab.Gitlab,
+    job: ProjectJob,
+    log: logging.Logger,
+) -> bool:
+    log.warning(
+        "Repairing inconsistent deletion state for %s (%s): "
+        "deletion_scheduled path but not marked for deletion",
+        job.listed_path,
+        job.project_id,
+    )
+    if not _schedule_project_for_deletion(gl, job.project_id, job.listed_path, log):
+        return False
+    time.sleep(PURGE_PATH_RESOLVE_DELAY_S)
+    repair_result = _attempt_purge(gl, job.project_id, job.listed_path, log)
+    if not repair_result.success:
+        log.error(
+            "PURGE repair failed %s (%s) after re-marking",
+            job.listed_path,
+            job.project_id,
+        )
+    return repair_result.success
+
+
+def _purge_with_gitlab(gl: gitlab.Gitlab, job: ProjectJob, log: logging.Logger) -> bool:
+    result = _attempt_purge(gl, job.project_id, job.listed_path, log)
+    if result.success:
+        return True
+    if result.needs_mark_first:
+        return _repair_and_purge(gl, job, log)
+    return False
+
+
+def _purge_project(job: ProjectJob, log: logging.Logger) -> bool:
+    gl = gitlab.Gitlab(job.gitlab_url, private_token=job.token, per_page=100)
+    try:
+        return _purge_with_gitlab(gl, job, log)
+    except GitlabDeleteError as exc:
+        if exc.response_code == HTTPStatus.NOT_FOUND:
+            return True
+        log.error("PURGE failed %s (%s): %s", job.listed_path, job.project_id, exc)
+        return False
+    except GitlabError as exc:
+        log.error("PURGE failed %s (%s): %s", job.listed_path, job.project_id, exc)
         return False
     except ValueError as exc:
-        log.error("DELETE failed %s (%s): %s", job.listed_path, job.project_id, exc)
+        log.error("PURGE failed %s (%s): %s", job.listed_path, job.project_id, exc)
         return False
+
+
+def _resolve_execution_phases(args: argparse.Namespace) -> tuple[bool, bool]:
+    """Return (do_mark, do_purge) from CLI flags."""
+    return args.mark, args.purge
 
 
 def _parse_args(argv: list[str] | None) -> argparse.Namespace:
@@ -298,10 +510,12 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         description="Delete middleware ARC-hash projects from a GitLab group.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=(
-            "Stop middleware API and Celery workers before running with --execute.\n"
+            "Stop middleware API and Celery workers before running with --mark or --purge.\n"
+            "Phase 1 (mark):  --mark\n"
+            "Phase 2 (purge): --purge\n"
+            "Both phases:     --mark --purge\n"
             "Large groups (~30k projects) need several minutes to list; use --count-only\n"
-            "for a faster dry-run. For projects already marked for deletion, use\n"
-            "--purge-only to skip re-marking. See the script docstring for examples."
+            "for a faster dry-run. See the script docstring for examples."
         ),
     )
     parser.add_argument(
@@ -323,17 +537,17 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         "--workers",
         type=int,
         default=5,
-        help="Parallel delete workers when --execute is set (default: 5)",
+        help="Parallel workers when --mark or --purge is set (default: 5)",
     )
     parser.add_argument(
-        "--execute",
+        "--mark",
         action="store_true",
-        help="Delete projects (default: dry-run only)",
+        help="Mark active ARC projects for deletion (phase 1)",
     )
     parser.add_argument(
-        "--purge-only",
+        "--purge",
         action="store_true",
-        help="With --execute: only permanently remove projects already marked for deletion",
+        help="Permanently remove projects already marked for deletion (phase 2)",
     )
     parser.add_argument(
         "--count-only",
@@ -353,28 +567,37 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def _run_deletes(
-    args: argparse.Namespace,
-    targets: list[tuple[int, str]],
+def _run_parallel_jobs(
+    config: PhaseRunConfig,
+    worker_fn: Callable[[ProjectJob, logging.Logger], bool],
     log: logging.Logger,
 ) -> int:
+    if not config.targets:
+        log.info("Phase %s: no targets", config.phase_name)
+        return 0
+
+    log.info(
+        "Phase %s: processing %d projects with %d workers",
+        config.phase_name,
+        len(config.targets),
+        config.workers,
+    )
     ok = 0
     failed = 0
     start = time.monotonic()
-    with ThreadPoolExecutor(max_workers=args.workers) as pool:
-        futures = {
+    with ThreadPoolExecutor(max_workers=config.workers) as pool:
+        futures: dict[Future[bool], str] = {
             pool.submit(
-                _delete_project,
-                DeleteJob(
-                    gitlab_url=args.url,
-                    token=args.token,
+                worker_fn,
+                ProjectJob(
+                    gitlab_url=config.gitlab_url,
+                    token=config.token,
                     project_id=project_id,
                     listed_path=path,
-                    purge_only=args.purge_only,
                 ),
                 log,
             ): path
-            for project_id, path in targets
+            for project_id, path in config.targets
         }
         for index, future in enumerate(as_completed(futures), start=1):
             if future.result():
@@ -385,49 +608,136 @@ def _run_deletes(
                 elapsed = time.monotonic() - start
                 rate = index / elapsed if elapsed else 0.0
                 log.info(
-                    "Progress: %d/%d (%.1f/s, ok=%d, failed=%d)",
+                    "Phase %s progress: %d/%d (%.1f/s, ok=%d, failed=%d)",
+                    config.phase_name,
                     index,
-                    len(targets),
+                    len(config.targets),
                     rate,
                     ok,
                     failed,
                 )
 
-    log.info("Done: ok=%d failed=%d (see %s for errors)", ok, failed, LOG_FILE)
+    log.info("Phase %s done: ok=%d failed=%d", config.phase_name, ok, failed)
     return 1 if failed else 0
 
 
+@dataclass(frozen=True)
+class PhaseExecution:
+    """Which deletion phases to run and their shared scan context."""
+
+    args: argparse.Namespace
+    group: Group
+    scan: ScanResult
+    do_mark: bool
+    do_purge: bool
+
+
+def _run_phases(execution: PhaseExecution, log: logging.Logger) -> int:
+    exit_code = 0
+    args = execution.args
+
+    if execution.do_mark:
+        exit_code = max(
+            exit_code,
+            _run_parallel_jobs(
+                PhaseRunConfig(
+                    workers=args.workers,
+                    targets=execution.scan.mark_targets,
+                    gitlab_url=args.url,
+                    token=args.token,
+                    phase_name="mark",
+                ),
+                _mark_project,
+                log,
+            ),
+        )
+
+    purge_scan = execution.scan
+    if execution.do_mark and execution.do_purge:
+        log.info("Re-scanning group before purge phase...")
+        purge_scan = _scan_group_projects(
+            execution.group,
+            log,
+            all_projects=args.all_projects,
+            include_subgroups=args.include_subgroups,
+            collect_targets=True,
+        )
+        log.info(
+            "Re-scan complete: %d active, %d pending, %d inconsistent",
+            purge_scan.active_matches,
+            purge_scan.pending_matches,
+            purge_scan.zombie_matches,
+        )
+
+    if execution.do_purge:
+        exit_code = max(
+            exit_code,
+            _run_parallel_jobs(
+                PhaseRunConfig(
+                    workers=args.workers,
+                    targets=purge_scan.purge_targets,
+                    gitlab_url=args.url,
+                    token=args.token,
+                    phase_name="purge",
+                ),
+                _purge_project,
+                log,
+            ),
+        )
+
+    log.info("All phases complete (see %s for errors)", LOG_FILE)
+    return exit_code
+
+
 def _report_dry_run(scan: ScanResult, args: argparse.Namespace, log: logging.Logger) -> None:
-    match_count = scan.matches
-    log.info("Found %d projects to dry-run", match_count)
-    for _project_id, path in scan.targets:
-        log.info("would delete: %s", path)
-    remaining = match_count - len(scan.targets)
-    if remaining > 0:
-        log.info("... and %d more", remaining)
+    log.info("Active ARC projects (phase mark: --mark): %d", scan.active_matches)
+    for _project_id, path in scan.mark_targets:
+        log.info("would mark: %s", path)
+    remaining_mark = scan.active_matches - len(scan.mark_targets)
+    if remaining_mark > 0:
+        log.info("... and %d more active projects", remaining_mark)
+
+    log.info("Pending deletion (phase purge: --purge): %d", scan.pending_matches)
+    if scan.zombie_matches:
+        log.info(
+            "Inconsistent deletion_scheduled paths (repair during --purge): %d",
+            scan.zombie_matches,
+        )
+    for _project_id, path in scan.purge_targets:
+        log.info("would purge: %s", path)
+    remaining_purge = scan.pending_matches - len(scan.purge_targets)
+    if remaining_purge > 0:
+        log.info("... and %d more pending projects", remaining_purge)
+
     if args.count_only:
-        log.info("Use without --count-only before --execute to build the full target list")
+        log.info("Use without --count-only before --mark/--purge to build the full target list")
     else:
-        log.info("Re-run with --execute to delete. Log file: %s", LOG_FILE)
+        log.info("Re-run with --mark, --purge, or both. Log file: %s", LOG_FILE)
 
 
-def main(argv: list[str] | None = None) -> int:
-    """Run project listing and optional bulk deletion."""
-    args = _parse_args(argv)
-    log = _configure_logging()
-
+def _validate_args(args: argparse.Namespace, log: logging.Logger) -> int | None:
+    """Return an exit code when arguments are invalid, else None."""
     if not args.token:
         log.error("GitLab token required: pass --token or set GITLAB_TOKEN")
         return 1
     if args.workers < 1:
         log.error("--workers must be at least 1")
         return 1
-    if args.count_only and args.execute:
-        log.error("--count-only cannot be combined with --execute")
+    if args.count_only and (args.mark or args.purge):
+        log.error("--count-only cannot be combined with --mark or --purge")
         return 1
-    if args.purge_only and not args.execute:
-        log.error("--purge-only requires --execute")
-        return 1
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run project listing and optional bulk deletion."""
+    args = _parse_args(argv)
+    log = _configure_logging()
+    do_mark, do_purge = _resolve_execution_phases(args)
+
+    validation_error = _validate_args(args, log)
+    if validation_error is not None:
+        return validation_error
 
     gl = gitlab.Gitlab(args.url, private_token=args.token, per_page=100)
     gl.auth()
@@ -435,7 +745,7 @@ def main(argv: list[str] | None = None) -> int:
     group = gl.groups.get(args.group)
     log.info("Group: %s (id=%s)", group.full_path, group.id)
 
-    collect_targets = args.execute or not args.count_only
+    collect_targets = args.mark or args.purge or not args.count_only
     scan = _scan_group_projects(
         group,
         log,
@@ -445,17 +755,23 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     log.info(
-        "Scan complete: %d projects scanned, %d matches, %d skipped (non-ARC)",
+        "Scan complete: %d projects scanned, %d active ARC, %d pending deletion, "
+        "%d inconsistent, %d skipped",
         scan.scanned,
-        scan.matches,
+        scan.active_matches,
+        scan.pending_matches,
+        scan.zombie_matches,
         scan.skipped_non_arc,
     )
 
-    if not args.execute:
+    if not do_mark and not do_purge:
         _report_dry_run(scan, args, log)
         return 0
 
-    return _run_deletes(args, scan.targets, log)
+    return _run_phases(
+        PhaseExecution(args=args, group=group, scan=scan, do_mark=do_mark, do_purge=do_purge),
+        log,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/delete_gitlab_arc_projects.py
+++ b/scripts/delete_gitlab_arc_projects.py
@@ -166,31 +166,115 @@ def _scan_group_projects(
     )
 
 
+def _candidate_full_paths(attributes: dict[str, object]) -> list[str]:
+    """Build ordered, unique full_path candidates for permanently_remove."""
+    candidates: list[str] = []
+
+    namespace = attributes.get("namespace")
+    project_path = attributes.get("path")
+    if isinstance(namespace, dict):
+        namespace_full_path = namespace.get("full_path")
+        if namespace_full_path and project_path:
+            candidates.append(f"{namespace_full_path}/{project_path}")
+
+    explicit = attributes.get("full_path")
+    if explicit:
+        candidates.append(str(explicit))
+
+    path_with_namespace = attributes.get("path_with_namespace")
+    if path_with_namespace:
+        candidates.append(str(path_with_namespace))
+
+    unique: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        if candidate not in seen:
+            seen.add(candidate)
+            unique.append(candidate)
+    return unique
+
+
+def _resolve_project_full_path(gl: gitlab.Gitlab, project_id: int) -> list[str]:
+    """Return GitLab full_path candidates for permanently_remove."""
+    project = gl.projects.get(project_id)
+    candidates = _candidate_full_paths(project.attributes)
+    if not candidates:
+        msg = f"Could not resolve full_path for project {project_id}"
+        raise ValueError(msg)
+    return candidates
+
+
+def _permanently_remove_project(
+    gl: gitlab.Gitlab,
+    project_id: int,
+    full_path_candidates: list[str],
+    log: logging.Logger,
+) -> bool:
+    last_error: GitlabError | None = None
+    for full_path in full_path_candidates:
+        try:
+            gl.http_delete(
+                f"/projects/{project_id}",
+                query_data={
+                    "permanently_remove": "true",
+                    "full_path": full_path,
+                },
+            )
+            if full_path != full_path_candidates[0]:
+                log.info(
+                    "Permanent delete succeeded for %s (%s) using alternate full_path",
+                    full_path,
+                    project_id,
+                )
+            return True
+        except GitlabError as exc:
+            if exc.response_code == HTTPStatus.BAD_REQUEST and "full_path" in str(exc):
+                last_error = exc
+                continue
+            raise
+
+    if last_error is not None:
+        log.warning(
+            "Permanent delete skipped for %s (%s); project is scheduled for deletion: %s",
+            full_path_candidates[0],
+            project_id,
+            last_error,
+        )
+        return True
+    return False
+
+
 def _delete_project(
     gitlab_url: str,
     token: str,
     project_id: int,
-    full_path: str,
+    listed_path: str,
     log: logging.Logger,
 ) -> bool:
     gl = gitlab.Gitlab(gitlab_url, private_token=token, per_page=100)
     try:
+        full_path_candidates = _resolve_project_full_path(gl, project_id)
+        primary_path = full_path_candidates[0]
+        if primary_path != listed_path:
+            log.debug(
+                "Resolved full_path candidates %s for project %s (listed as %s)",
+                full_path_candidates,
+                project_id,
+                listed_path,
+            )
         gl.http_delete(f"/projects/{project_id}")
-        gl.http_delete(
-            f"/projects/{project_id}",
-            query_data={
-                "permanently_remove": "true",
-                "full_path": full_path,
-            },
-        )
+        _permanently_remove_project(gl, project_id, full_path_candidates, log)
         return True
     except GitlabDeleteError as exc:
         if exc.response_code == HTTPStatus.NOT_FOUND:
             return True
-        log.error("DELETE failed %s (%s): %s", full_path, project_id, exc)
+        log.error("DELETE failed %s (%s): %s", listed_path, project_id, exc)
         return False
     except GitlabError as exc:
-        log.error("DELETE failed %s (%s): %s", full_path, project_id, exc)
+        log.error("DELETE failed %s (%s): %s", listed_path, project_id, exc)
+        return False
+    except ValueError as exc:
+        log.error("DELETE failed %s (%s): %s", listed_path, project_id, exc)
         return False
 
 

--- a/scripts/delete_gitlab_arc_projects.py
+++ b/scripts/delete_gitlab_arc_projects.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+r"""Delete ARC-hash GitLab projects from a middleware group.
+
+Lists projects in a GitLab group and deletes those whose repository path is a
+64-character SHA256 hex string (the middleware ``arc_id``). Other projects in
+the group are skipped unless ``--all-projects`` is passed.
+
+Dry-run is the default. Pass ``--execute`` to perform deletions.
+
+Environment:
+    GITLAB_TOKEN: Personal access token with ``api`` scope (used when ``--token``
+        is omitted).
+
+Examples:
+    # Production (https://datahub.ipk-gatersleben.de/fairagro-advanced-middleware)
+    uv run python scripts/delete_gitlab_arc_projects.py \\
+        --url https://datahub.ipk-gatersleben.de \\
+        --group fairagro-advanced-middleware
+
+    # Fast dry-run: count only (no full target list in memory)
+    uv run python scripts/delete_gitlab_arc_projects.py --count-only
+
+    # Development
+    uv run python scripts/delete_gitlab_arc_projects.py \\
+        --url https://datahub-dev.ipk-gatersleben.de \\
+        --group FAIRagro-advanced-middleware-dev
+
+    # Actually delete (stop middleware/Celery first)
+    uv run python scripts/delete_gitlab_arc_projects.py --execute --workers 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
+import time
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from http import HTTPStatus
+from typing import TYPE_CHECKING
+
+import gitlab
+from gitlab.exceptions import GitlabDeleteError, GitlabError
+
+if TYPE_CHECKING:
+    from gitlab.v4.objects import Group, GroupProject
+
+# Production defaults; see module docstring for dev alternatives.
+DEFAULT_GITLAB_URL = "https://datahub.ipk-gatersleben.de"
+DEFAULT_GROUP = "fairagro-advanced-middleware"
+
+ARC_PATH_RE = re.compile(r"^[a-f0-9]{64}$")
+LOG_FILE = "gitlab-delete.log"
+DRY_RUN_PREVIEW_LIMIT = 20
+LIST_PROGRESS_INTERVAL = 1000
+
+
+@dataclass(frozen=True)
+class ScanResult:
+    """Outcome of scanning group projects."""
+
+    targets: list[tuple[int, str]]
+    scanned: int
+    skipped_non_arc: int
+    matches: int
+
+
+def _configure_logging() -> logging.Logger:
+    log = logging.getLogger("delete_gitlab_arc_projects")
+    log.setLevel(logging.INFO)
+    formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+    file_handler = logging.FileHandler(LOG_FILE, encoding="utf-8")
+    file_handler.setFormatter(formatter)
+    log.addHandler(stream_handler)
+    log.addHandler(file_handler)
+    return log
+
+
+def _project_matches(project: GroupProject, *, all_projects: bool) -> bool:
+    return all_projects or ARC_PATH_RE.fullmatch(project.path) is not None
+
+
+def _iter_group_projects(
+    group: Group,
+    log: logging.Logger,
+    *,
+    include_subgroups: bool,
+) -> Iterator[GroupProject]:
+    """Iterate group projects using a lighter, keyset-paginated listing."""
+    list_kwargs = {
+        "iterator": True,
+        "get_all": False,
+        "include_subgroups": include_subgroups,
+        "simple": True,
+        "per_page": 100,
+    }
+    try:
+        yield from group.projects.list(
+            **list_kwargs,
+            pagination="keyset",
+            order_by="id",
+            sort="asc",
+        )
+    except GitlabError as exc:
+        log.warning("Keyset pagination unavailable (%s); falling back to offset pagination", exc)
+        yield from group.projects.list(**list_kwargs)
+
+
+def _scan_group_projects(
+    group: Group,
+    log: logging.Logger,
+    *,
+    all_projects: bool,
+    include_subgroups: bool,
+    collect_targets: bool,
+) -> ScanResult:
+    targets: list[tuple[int, str]] = [] if collect_targets else []
+    preview: list[tuple[int, str]] = []
+    scanned = 0
+    skipped_non_arc = 0
+    matches = 0
+    start = time.monotonic()
+
+    log.info(
+        "Listing projects (simple=keyset, include_subgroups=%s)...",
+        include_subgroups,
+    )
+
+    for project in _iter_group_projects(group, log, include_subgroups=include_subgroups):
+        scanned += 1
+        if _project_matches(project, all_projects=all_projects):
+            matches += 1
+            entry = (project.id, project.path_with_namespace)
+            if collect_targets:
+                targets.append(entry)
+            elif len(preview) < DRY_RUN_PREVIEW_LIMIT:
+                preview.append(entry)
+        else:
+            skipped_non_arc += 1
+
+        if scanned % LIST_PROGRESS_INTERVAL == 0:
+            elapsed = time.monotonic() - start
+            rate = scanned / elapsed if elapsed else 0.0
+            log.info(
+                "Scanned %d projects (%.0f/s, %d matches, %d skipped)...",
+                scanned,
+                rate,
+                matches,
+                skipped_non_arc,
+            )
+
+    if not collect_targets:
+        targets = preview
+
+    return ScanResult(
+        targets=targets,
+        scanned=scanned,
+        skipped_non_arc=skipped_non_arc,
+        matches=matches,
+    )
+
+
+def _delete_project(
+    gitlab_url: str,
+    token: str,
+    project_id: int,
+    full_path: str,
+    log: logging.Logger,
+) -> bool:
+    gl = gitlab.Gitlab(gitlab_url, private_token=token, per_page=100)
+    try:
+        gl.http_delete(f"/projects/{project_id}")
+        gl.http_delete(
+            f"/projects/{project_id}",
+            query_data={
+                "permanently_remove": "true",
+                "full_path": full_path,
+            },
+        )
+        return True
+    except GitlabDeleteError as exc:
+        if exc.response_code == HTTPStatus.NOT_FOUND:
+            return True
+        log.error("DELETE failed %s (%s): %s", full_path, project_id, exc)
+        return False
+    except GitlabError as exc:
+        log.error("DELETE failed %s (%s): %s", full_path, project_id, exc)
+        return False
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Delete middleware ARC-hash projects from a GitLab group.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Stop middleware API and Celery workers before running with --execute.\n"
+            "Large groups (~30k projects) need several minutes to list; use --count-only\n"
+            "for a faster dry-run. See the script docstring for examples."
+        ),
+    )
+    parser.add_argument(
+        "--url",
+        default=DEFAULT_GITLAB_URL,
+        help=f"GitLab base URL (default: {DEFAULT_GITLAB_URL})",
+    )
+    parser.add_argument(
+        "--group",
+        default=DEFAULT_GROUP,
+        help=f"Group path or ID (default: {DEFAULT_GROUP})",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("GITLAB_TOKEN"),
+        help="GitLab personal access token (default: $GITLAB_TOKEN)",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=5,
+        help="Parallel delete workers when --execute is set (default: 5)",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Delete projects (default: dry-run only)",
+    )
+    parser.add_argument(
+        "--count-only",
+        action="store_true",
+        help="Dry-run: scan and print counts without building the full target list",
+    )
+    parser.add_argument(
+        "--include-subgroups",
+        action="store_true",
+        help="Include projects from subgroups (slower; default: group only)",
+    )
+    parser.add_argument(
+        "--all-projects",
+        action="store_true",
+        help="Delete every project in the group, not only ARC-hash paths (dangerous)",
+    )
+    return parser.parse_args(argv)
+
+
+def _run_deletes(
+    args: argparse.Namespace,
+    targets: list[tuple[int, str]],
+    log: logging.Logger,
+) -> int:
+    ok = 0
+    failed = 0
+    start = time.monotonic()
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        futures = {
+            pool.submit(
+                _delete_project,
+                args.url,
+                args.token,
+                project_id,
+                path,
+                log,
+            ): path
+            for project_id, path in targets
+        }
+        for index, future in enumerate(as_completed(futures), start=1):
+            if future.result():
+                ok += 1
+            else:
+                failed += 1
+            if index % 100 == 0:
+                elapsed = time.monotonic() - start
+                rate = index / elapsed if elapsed else 0.0
+                log.info(
+                    "Progress: %d/%d (%.1f/s, ok=%d, failed=%d)",
+                    index,
+                    len(targets),
+                    rate,
+                    ok,
+                    failed,
+                )
+
+    log.info("Done: ok=%d failed=%d (see %s for errors)", ok, failed, LOG_FILE)
+    return 1 if failed else 0
+
+
+def _report_dry_run(scan: ScanResult, args: argparse.Namespace, log: logging.Logger) -> None:
+    match_count = scan.matches
+    log.info("Found %d projects to dry-run", match_count)
+    for _project_id, path in scan.targets:
+        log.info("would delete: %s", path)
+    remaining = match_count - len(scan.targets)
+    if remaining > 0:
+        log.info("... and %d more", remaining)
+    if args.count_only:
+        log.info("Use without --count-only before --execute to build the full target list")
+    else:
+        log.info("Re-run with --execute to delete. Log file: %s", LOG_FILE)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run project listing and optional bulk deletion."""
+    args = _parse_args(argv)
+    log = _configure_logging()
+
+    if not args.token:
+        log.error("GitLab token required: pass --token or set GITLAB_TOKEN")
+        return 1
+    if args.workers < 1:
+        log.error("--workers must be at least 1")
+        return 1
+    if args.count_only and args.execute:
+        log.error("--count-only cannot be combined with --execute")
+        return 1
+
+    gl = gitlab.Gitlab(args.url, private_token=args.token, per_page=100)
+    gl.auth()
+
+    group = gl.groups.get(args.group)
+    log.info("Group: %s (id=%s)", group.full_path, group.id)
+
+    collect_targets = args.execute or not args.count_only
+    scan = _scan_group_projects(
+        group,
+        log,
+        all_projects=args.all_projects,
+        include_subgroups=args.include_subgroups,
+        collect_targets=collect_targets,
+    )
+
+    log.info(
+        "Scan complete: %d projects scanned, %d matches, %d skipped (non-ARC)",
+        scan.scanned,
+        scan.matches,
+        scan.skipped_non_arc,
+    )
+
+    if not args.execute:
+        _report_dry_run(scan, args, log)
+        return 0
+
+    return _run_deletes(args, scan.targets, log)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/delete_gitlab_arc_projects.py
+++ b/scripts/delete_gitlab_arc_projects.py
@@ -27,6 +27,9 @@ Examples:
 
     # Actually delete (stop middleware/Celery first)
     uv run python scripts/delete_gitlab_arc_projects.py --execute --workers 5
+
+    # Purge projects already marked for deletion (faster; skips re-marking)
+    uv run python scripts/delete_gitlab_arc_projects.py --execute --purge-only --workers 5
 """
 
 from __future__ import annotations
@@ -57,6 +60,17 @@ ARC_PATH_RE = re.compile(r"^[a-f0-9]{64}$")
 LOG_FILE = "gitlab-delete.log"
 DRY_RUN_PREVIEW_LIMIT = 20
 LIST_PROGRESS_INTERVAL = 1000
+
+
+@dataclass(frozen=True)
+class DeleteJob:
+    """Parameters for deleting a single GitLab project."""
+
+    gitlab_url: str
+    token: str
+    project_id: int
+    listed_path: str
+    purge_only: bool
 
 
 @dataclass(frozen=True)
@@ -167,8 +181,17 @@ def _scan_group_projects(
 
 
 def _candidate_full_paths(attributes: dict[str, object]) -> list[str]:
-    """Build ordered, unique full_path candidates for permanently_remove."""
+    """Build ordered, unique full_path candidates for permanently_remove.
+
+    After a project is marked for deletion GitLab renames its path, e.g.
+    ``{hash}-deletion_scheduled-{id}``. The permanently_remove call must use
+    that post-mark path, not the original listing path.
+    """
     candidates: list[str] = []
+
+    path_with_namespace = attributes.get("path_with_namespace")
+    if path_with_namespace:
+        candidates.append(str(path_with_namespace))
 
     namespace = attributes.get("namespace")
     project_path = attributes.get("path")
@@ -180,10 +203,6 @@ def _candidate_full_paths(attributes: dict[str, object]) -> list[str]:
     explicit = attributes.get("full_path")
     if explicit:
         candidates.append(str(explicit))
-
-    path_with_namespace = attributes.get("path_with_namespace")
-    if path_with_namespace:
-        candidates.append(str(path_with_namespace))
 
     unique: list[str] = []
     seen: set[str] = set()
@@ -234,47 +253,43 @@ def _permanently_remove_project(
             raise
 
     if last_error is not None:
-        log.warning(
-            "Permanent delete skipped for %s (%s); project is scheduled for deletion: %s",
+        log.error(
+            "Permanent delete failed for %s (%s): %s",
             full_path_candidates[0],
             project_id,
             last_error,
         )
-        return True
+        return False
     return False
 
 
-def _delete_project(
-    gitlab_url: str,
-    token: str,
-    project_id: int,
-    listed_path: str,
-    log: logging.Logger,
-) -> bool:
-    gl = gitlab.Gitlab(gitlab_url, private_token=token, per_page=100)
+def _delete_project(job: DeleteJob, log: logging.Logger) -> bool:
+    gl = gitlab.Gitlab(job.gitlab_url, private_token=job.token, per_page=100)
     try:
-        full_path_candidates = _resolve_project_full_path(gl, project_id)
+        if not job.purge_only:
+            gl.http_delete(f"/projects/{job.project_id}")
+
+        # GitLab renames the project path when marking for deletion; resolve afterwards.
+        full_path_candidates = _resolve_project_full_path(gl, job.project_id)
         primary_path = full_path_candidates[0]
-        if primary_path != listed_path:
+        if primary_path != job.listed_path:
             log.debug(
                 "Resolved full_path candidates %s for project %s (listed as %s)",
                 full_path_candidates,
-                project_id,
-                listed_path,
+                job.project_id,
+                job.listed_path,
             )
-        gl.http_delete(f"/projects/{project_id}")
-        _permanently_remove_project(gl, project_id, full_path_candidates, log)
-        return True
+        return _permanently_remove_project(gl, job.project_id, full_path_candidates, log)
     except GitlabDeleteError as exc:
         if exc.response_code == HTTPStatus.NOT_FOUND:
             return True
-        log.error("DELETE failed %s (%s): %s", listed_path, project_id, exc)
+        log.error("DELETE failed %s (%s): %s", job.listed_path, job.project_id, exc)
         return False
     except GitlabError as exc:
-        log.error("DELETE failed %s (%s): %s", listed_path, project_id, exc)
+        log.error("DELETE failed %s (%s): %s", job.listed_path, job.project_id, exc)
         return False
     except ValueError as exc:
-        log.error("DELETE failed %s (%s): %s", listed_path, project_id, exc)
+        log.error("DELETE failed %s (%s): %s", job.listed_path, job.project_id, exc)
         return False
 
 
@@ -285,7 +300,8 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         epilog=(
             "Stop middleware API and Celery workers before running with --execute.\n"
             "Large groups (~30k projects) need several minutes to list; use --count-only\n"
-            "for a faster dry-run. See the script docstring for examples."
+            "for a faster dry-run. For projects already marked for deletion, use\n"
+            "--purge-only to skip re-marking. See the script docstring for examples."
         ),
     )
     parser.add_argument(
@@ -313,6 +329,11 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         "--execute",
         action="store_true",
         help="Delete projects (default: dry-run only)",
+    )
+    parser.add_argument(
+        "--purge-only",
+        action="store_true",
+        help="With --execute: only permanently remove projects already marked for deletion",
     )
     parser.add_argument(
         "--count-only",
@@ -344,10 +365,13 @@ def _run_deletes(
         futures = {
             pool.submit(
                 _delete_project,
-                args.url,
-                args.token,
-                project_id,
-                path,
+                DeleteJob(
+                    gitlab_url=args.url,
+                    token=args.token,
+                    project_id=project_id,
+                    listed_path=path,
+                    purge_only=args.purge_only,
+                ),
                 log,
             ): path
             for project_id, path in targets
@@ -400,6 +424,9 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     if args.count_only and args.execute:
         log.error("--count-only cannot be combined with --execute")
+        return 1
+    if args.purge_only and not args.execute:
+        log.error("--purge-only requires --execute")
         return 1
 
     gl = gitlab.Gitlab(args.url, private_token=args.token, per_page=100)

--- a/scripts/install-cursor-ruff-extension.sh
+++ b/scripts/install-cursor-ruff-extension.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Install charliermarsh.ruff in Cursor remote/devcontainer via CLI.
+#
+# Cursor's marketplace UI can hang on "Installing" for Ruff because the extension
+# depends on ms-python.python and Cursor's dependency resolver can loop on remapped
+# Python/Pylance IDs (see astral-sh/ruff-vscode#943). Installing via the remote
+# CLI bypasses that gallery traversal.
+#
+# No-op when not in a Cursor remote session (e.g. VS Code devcontainer).
+
+set -euo pipefail
+
+extension_id="charliermarsh.ruff"
+
+cursor_cli=""
+while IFS= read -r candidate; do
+    cursor_cli="$candidate"
+    break
+done < <(find "${HOME}/.cursor-server/bin" -path '*/bin/remote-cli/cursor' -type f 2>/dev/null | sort -r)
+
+if [[ -z "$cursor_cli" ]]; then
+    echo "install-cursor-ruff-extension: no Cursor remote CLI; skipping (not a Cursor session)."
+    exit 0
+fi
+
+if "$cursor_cli" --list-extensions 2>/dev/null | grep -qxF "$extension_id"; then
+    echo "install-cursor-ruff-extension: ${extension_id} already installed."
+    exit 0
+fi
+
+echo "install-cursor-ruff-extension: installing ${extension_id} via Cursor CLI..."
+if "$cursor_cli" --install-extension "$extension_id" --force; then
+    echo "install-cursor-ruff-extension: ${extension_id} installed."
+else
+    echo "install-cursor-ruff-extension: WARNING: install failed; use format/lint via 'uv run ruff' or ./scripts/quality-fix.sh" >&2
+    exit 0
+fi

--- a/uv.lock
+++ b/uv.lock
@@ -48,7 +48,7 @@ wheels = [
 
 [[package]]
 name = "aiohttp"
-version = "3.14.0"
+version = "3.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
@@ -60,90 +60,90 @@ dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/ab/93ce242f899b68c51b0578c027aafa791ab3614cb9345fa5d37b5f5c8e3e/aiohttp-3.14.0.tar.gz", hash = "sha256:2882de819734c715fd1b9c11c97e09fa020d14438203d1d354d8ed1702791c9b", size = 7940674, upload-time = "2026-06-01T19:41:02.763Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/78/8ea7308cac6934de8c74a14f3d5f65d1c89287426688be79538d0e5c013d/aiohttp-3.14.1.tar.gz", hash = "sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035", size = 7955794, upload-time = "2026-06-07T21:09:35.529Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/97/2b6889bfb6b6847520d50d95eb8c4307a45e28aaca39faf4a9454b3d1b2f/aiohttp-3.14.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b29518c9c2ec7e373e68259206a137c7f4f5439c58baaec4b5ab3ab799850a4e", size = 750194, upload-time = "2026-06-01T19:37:48.164Z" },
-    { url = "https://files.pythonhosted.org/packages/21/e2/62634b7fff918ed98c3c6b2f0e70d520f7f28846cb412d451b04354c6459/aiohttp-3.14.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:dbec68ce61b64cb73cab4d33df9433427b1713c8bcccb181dce695c1b6f8e87c", size = 506966, upload-time = "2026-06-01T19:37:50.014Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/fb/5ce075150828c797a5106f1c2fb26034e709d4289b9d2bf8b07f1e59fac6/aiohttp-3.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3cdf534aa455593e589302990c5097aa5c92c06c4262a20da22934f9186a5fff", size = 507527, upload-time = "2026-06-01T19:37:51.96Z" },
-    { url = "https://files.pythonhosted.org/packages/01/d5/405a0ae4e6b081754a3609c1c97c63a950e000a2def16046f1e736933a0e/aiohttp-3.14.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb6c657104393b5fbff01a5f59b2023db74058a8077d94475d6c25d03882a108", size = 1762420, upload-time = "2026-06-01T19:37:53.839Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/1d/e05a7c896b15a6bc6fb8fc5319eb437861c2c49c34559ef928add6590315/aiohttp-3.14.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:46fbbec4e4fab7428d4396a3823f9320e4560aa3113b89eeebce712c27c9ed5a", size = 1733672, upload-time = "2026-06-01T19:37:55.791Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/22/a72f7c459e195fa41bf4f7abd1f925b91fe91f8097e51c654229ba144a33/aiohttp-3.14.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2c2c7e05dd5335b298085abf45ddf98673934c3ee1c083d0b9ea13d4186ad500", size = 1805064, upload-time = "2026-06-01T19:37:57.931Z" },
-    { url = "https://files.pythonhosted.org/packages/80/50/e85bdaba0be59ca4838005ebfef4048fcdd5f35a02b07057a9a123394440/aiohttp-3.14.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3c7139100fbaae76515b73051d8f0aa3a3ff02e415eec8a8eee8e2223d9ba955", size = 1902125, upload-time = "2026-06-01T19:38:00.225Z" },
-    { url = "https://files.pythonhosted.org/packages/19/d8/51de5c6b971c27bb1ef620293b8d1ca611ec78736b34b3f6ccf68e4c8785/aiohttp-3.14.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78d6f9286a629ce52728430afe18f8ed2b6c39a1fddb3802d7244b9983910ad2", size = 1783112, upload-time = "2026-06-01T19:38:02.641Z" },
-    { url = "https://files.pythonhosted.org/packages/73/ae/b4402bfde77e43dfb1b6ccff83c7b7ab63ed06b50c4754f0c5423fb374fe/aiohttp-3.14.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cc3c3e12cdaeb92d7dcf13db00e9f6b1956b910e47256e696df1cfa946d02159", size = 1586356, upload-time = "2026-06-01T19:38:04.637Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/05/750a3265ca4dc54a460bd0cb1121a8f2ce9171fce4a135fb47ea7fd594d2/aiohttp-3.14.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4d6a998191f5ebe3b8c28463ff72bc030250008b3193c402464efadd08b5ca02", size = 1723119, upload-time = "2026-06-01T19:38:06.713Z" },
-    { url = "https://files.pythonhosted.org/packages/37/01/8c0812c50b3b1b1c37b323bf170d6be8847a8f234060485b7d1e71953f60/aiohttp-3.14.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0fc2b75ae8d169d853be2862d960be8550da6c5c65711d5476407eb3fdb006bd", size = 1757216, upload-time = "2026-06-01T19:38:08.736Z" },
-    { url = "https://files.pythonhosted.org/packages/47/2a/50fb98028a26887cbe48dcc1df92a90825615bc73b5584301304090cded8/aiohttp-3.14.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:16eee56bcc72d04600bc56c1759982c2385ec0b41d3fd3521f836bf64a0957ef", size = 1770500, upload-time = "2026-06-01T19:38:11.111Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/32/0ffd598a2fa2b9a423daf242e700cfdabda35d6e602394ad9ae58972c1c7/aiohttp-3.14.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5a2e7ca615c3ddc15b82687e05a624e5f5cba3f1d6c20cb81172d70ea498451e", size = 1576224, upload-time = "2026-06-01T19:38:13.391Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/f9/b9fc381dd9b66afb33f2634c40e229d106467be0afcabe79648631ab6712/aiohttp-3.14.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:f0b7b8bbbec3ce9467ee0ebe334622fd90624f593edd3136c567811453fc4fae", size = 1794252, upload-time = "2026-06-01T19:38:15.498Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/fb/05d9214c975f23225a8cd5c439325e338c7c377b315480ef3871db51f54e/aiohttp-3.14.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ba10966d4f03dd96a14365be4b8e37c327c76f11c3ca867116966cdd9f98066", size = 1760193, upload-time = "2026-06-01T19:38:17.624Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/4b/02992fc4fb9e1b6673ee3f888a8e587a6447afda1f6f4aca776c148c2876/aiohttp-3.14.0-cp312-cp312-win32.whl", hash = "sha256:101df7779c80c0636014a6b2c6642acd3efb5b355d48347c9d7dfb720aee9430", size = 448650, upload-time = "2026-06-01T19:38:19.545Z" },
-    { url = "https://files.pythonhosted.org/packages/39/e9/246532214c3abda518477cbaaf16d420295ad8effa5233844cbb38f299ab/aiohttp-3.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:b0a5747586d4467efd1f932710b269131c9717a872dce082cd92a00c1c13123a", size = 476145, upload-time = "2026-06-01T19:38:21.505Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/c3/63f8c20090048915711598b0adf475b149216d736157961de06480a45b15/aiohttp-3.14.0-cp312-cp312-win_arm64.whl", hash = "sha256:5f1c5be60add78fabb4aacd13c5a348ae79d2fcbfc7fa78da8f1eb192273b370", size = 444250, upload-time = "2026-06-01T19:38:24.027Z" },
-    { url = "https://files.pythonhosted.org/packages/21/61/d11f7d9a3144bffe825247d6367cd93053666da50b94707c9129c78868d5/aiohttp-3.14.0-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:25400d710641a8040bf022a8a99f579e581ffa1c5bd42c33255d7d6f3957c127", size = 502399, upload-time = "2026-06-01T19:38:25.955Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/9b/a7e317625d36356844f8bb022cabd305b541f968856cc3c2e0b58e53ee6e/aiohttp-3.14.0-cp313-cp313-android_21_x86_64.whl", hash = "sha256:c5492b9929826e07cc3fcb9739ae87aab05dff6b5e67a9b73fd1700c6d008981", size = 510068, upload-time = "2026-06-01T19:38:27.828Z" },
-    { url = "https://files.pythonhosted.org/packages/11/41/cc2d2cfbfbdc3126ba258f3cd27d1ac8a33492ae3c35a4583ee21f0ba7f1/aiohttp-3.14.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3366751d68d237c621264233a32f3078bbc21b7904ab90a77e03d21390c742c6", size = 481670, upload-time = "2026-06-01T19:38:29.836Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/07/381f4023c3b08cb616e520f566d8c58957abad54e56441d41fe67cfb0195/aiohttp-3.14.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:57ea07d28695a7a40304d42251892a8df765e5588c10ee32afeddcd5df33c0a2", size = 487591, upload-time = "2026-06-01T19:38:31.704Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/4d/4506fdb7a022bdf70011a3bbb4ca00c5c570026ef6a3c5bd7bc70c39089c/aiohttp-3.14.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:076cb014191ae2e65d949e1ad01f1dcfe33e32789b5172510f3e79c79fc04d50", size = 496503, upload-time = "2026-06-01T19:38:33.6Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/7d/c814111e04894a45d9e2defc94443879a6f118d9633d5fedfe6e2e8af5f0/aiohttp-3.14.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2f3fc37054564dee64a855b5b092d87ec35dcddfaabf7dacb1c8a2b1f83dc0a9", size = 745870, upload-time = "2026-06-01T19:38:36.013Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/ee/80eee0efddfe187e7cd05027086b7ce1c0e492e82a4eda58f5c5543a44a0/aiohttp-3.14.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8fcaef74d2ab0f607d7ff85a0d15e21bb5a258c4a58df1908396eb50d7f4ed3c", size = 505588, upload-time = "2026-06-01T19:38:38.282Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/f8/0f28f04eef75d52fc9c715dde7ce9c0abb810fd20cfeb0fea7afd2ab1e98/aiohttp-3.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e4c01b0bfc6209590960e68eac083cd22d5d87c21f974dd6208cafa5d3542bc8", size = 504492, upload-time = "2026-06-01T19:38:40.611Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/db/44c755232085545065c94378dfce38641b1aee647f4939fcd32f5b32e719/aiohttp-3.14.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f12eb7896e81caf403a2b18c9406426f1207361e7239c057ab29c076d4257e83", size = 1752111, upload-time = "2026-06-01T19:38:42.682Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/6a/42e030a46743841414402a3b00cd3d78419055e86c66fb5822c14b5abfc6/aiohttp-3.14.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6c79a044cacf360ec46738d863d2f41c9300d2a06ef4a7402ea0df306a350e61", size = 1729674, upload-time = "2026-06-01T19:38:44.79Z" },
-    { url = "https://files.pythonhosted.org/packages/34/26/3199beb415202e3108e7b83ecebe10914d806d33fb9860c3e4aa60a19be3/aiohttp-3.14.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:85e0675f47be4eff0636bf88c02140ea89168ae0df3ff1f3f464e9de9610d277", size = 1798808, upload-time = "2026-06-01T19:38:47.01Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/94/b9b6fcf0ee17c21d0d19fb8c22bf83ad18f82e702a9c3bd901a868f5e446/aiohttp-3.14.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b33e751cab03fdc960095b1e326cb5a03f5ee577d6ded59f3d1c100f8668882", size = 1891921, upload-time = "2026-06-01T19:38:49.233Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/a3/3800dbd095cb2bb165a7ea5d94d790914677e27f45638c7d80e3f34c8945/aiohttp-3.14.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:26d9224c6dd7f5c749aba4f61315a894601448b28d94d12f4dea0903e26d2096", size = 1777241, upload-time = "2026-06-01T19:38:52.04Z" },
-    { url = "https://files.pythonhosted.org/packages/21/2a/45be91ad1b860508557448d4cc2e165a2ee68dd865657b73bf66cc5a00fb/aiohttp-3.14.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6281aecdf2732940f4fe06bd6adec5ae4d59b78b080b8e3a6b81467301010988", size = 1579554, upload-time = "2026-06-01T19:38:54.508Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/3d/dc94df99ed1511fdf28314f722643ed334112643cab00223577085e788c4/aiohttp-3.14.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:23e8314e7aed8576fbe33314d218bd81447a3adbc91dc36f1163bf583cd3084c", size = 1714864, upload-time = "2026-06-01T19:38:56.788Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/e4/1f1c8acbb3acd5c8f795473b92c9c3d44eb60a5692c6104256c8a1c83a0c/aiohttp-3.14.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:3b54fbff46127aeafdd764cecd0d99fa2f24a0e37ea5c18a7c3a4ac450df1db3", size = 1749803, upload-time = "2026-06-01T19:38:59.367Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/c8/c45ea6e7ed84cebba939b9c334498a045ba19d79c61b0110df5f21580de3/aiohttp-3.14.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b27d89af91a555f58e08e4902dbcbc48862fd40095720ca705990476bd93b7ac", size = 1765023, upload-time = "2026-06-01T19:39:01.651Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/a1/a932941784432962fe390e1066823aaef64b4e5ac9fa595df57b5fe472a9/aiohttp-3.14.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:25d2326a4967bf705a9f9913a13005e93b6020ad8a9f6bd6bd78850d5171332e", size = 1571671, upload-time = "2026-06-01T19:39:04.044Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/01/e1280feac522597a4d46eb67a0cdfa053cfae263033030b761ab146f29fb/aiohttp-3.14.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:a1d209375c503472b3c0a340cdf3c55fcd82e84b46dda7caeaced59faba373ec", size = 1789904, upload-time = "2026-06-01T19:39:06.294Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/10/ab28818262f4d26bdb47ed5f1fc7999b69e2fc6e0370b02d0f49011f45ea/aiohttp-3.14.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:666c7c5036df57b693026398b69b41874a1931ac5b3485fd910e57bfac253869", size = 1754516, upload-time = "2026-06-01T19:39:08.788Z" },
-    { url = "https://files.pythonhosted.org/packages/af/cc/c122eabd7a1b7e0c9bbdd6be60e4715905b858399145d9df872bb94f1427/aiohttp-3.14.0-cp313-cp313-win32.whl", hash = "sha256:23f094a1ef64823fd35854ddf5c7a80a078162f37f9d2f7c6142b51a6affa456", size = 448656, upload-time = "2026-06-01T19:39:11.171Z" },
-    { url = "https://files.pythonhosted.org/packages/41/a5/bab07d79848a00eedd8ed979ccb302aaea3ac6eb9fa16bd0ed87135869b4/aiohttp-3.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:e03abdaa17d553f17e1d1d06bb266b3970106c78051d06795723e748d8e49d11", size = 475803, upload-time = "2026-06-01T19:39:13.439Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/a0/f03ade8566c153666a3871afccbedf6d99911da006325e1fc6cf72a2de99/aiohttp-3.14.0-cp313-cp313-win_arm64.whl", hash = "sha256:acdb400538cf4769543548bb5d1eb23d39bed4f96554a6078cb728c7cb2c268b", size = 443889, upload-time = "2026-06-01T19:39:15.945Z" },
-    { url = "https://files.pythonhosted.org/packages/28/03/5f36ab196a88ba5e9648ae5643e6531e67a3a8c0e96f9c6510ff41540fec/aiohttp-3.14.0-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:363ef9e91014e7891679bfb2ac0a7c6ea93435dbbfd10ecf41b9f06fcf506c5f", size = 503330, upload-time = "2026-06-01T19:39:18.195Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/ce/8b49ec2f30f68e02f314f4832186cd45e583360a5a386058be36855d23b6/aiohttp-3.14.0-cp314-cp314-android_24_x86_64.whl", hash = "sha256:884a4edbdad77be9d0ef36142c8b504351b170df0bf62b51e784fadabf311c42", size = 509822, upload-time = "2026-06-01T19:39:20.396Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/fe/6edbf5d39bf29322b6816365b17ed8ede4dace164a3aea1abcd30110eb78/aiohttp-3.14.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:70ea956f6cc4a37620966b56c2e205d88ca3e6d85ec063277e414b1035cddad3", size = 483329, upload-time = "2026-06-01T19:39:22.607Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/5a/fae531bdbc6456fb6241f46b7b81e4d8a0dd3fc09118a0055dc7141ac1ec/aiohttp-3.14.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:ea3b9806c89f61da22fddf1f12dd524fb368e5e28f1261fbdafe5c3cd8ce893b", size = 489502, upload-time = "2026-06-01T19:39:24.881Z" },
-    { url = "https://files.pythonhosted.org/packages/36/f4/48a7b0414db7fed77a03d5dde34508c026afd83510ab6bca08c313855776/aiohttp-3.14.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:a071be341c2bd9b0188e62d173509f024e0a35b1c342c53c50f8daaeda8c3bd8", size = 497357, upload-time = "2026-06-01T19:39:27.197Z" },
-    { url = "https://files.pythonhosted.org/packages/75/75/e85a13a370acc007fca5feb1fd1b88ac2d8426e6dadd625479b7cadd55a3/aiohttp-3.14.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:198cfe61bf253b19da1fb3e0fa122249dc4f14c12709493fed8054aa0411cc76", size = 750898, upload-time = "2026-06-01T19:39:29.563Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/e4/3d637f800c724eff0e2bed64df72557444482366fd0a35b0cec0e6968f6c/aiohttp-3.14.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9dc203d6ce6b9106d54e2a93f41dfdfebfbca2d99962ba503bfd3e5921a6549e", size = 506986, upload-time = "2026-06-01T19:39:31.872Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/df/35161f3598bf7501d2b2a805b41ab4f45a2e34150c421bcb4ef8c0d281a7/aiohttp-3.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9e19d17ab02bf16832a2c8c0d55a486792c5b1645665652ee9531aebcc30cb72", size = 508033, upload-time = "2026-06-01T19:39:34.137Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/39/b36e5d3d31e850fb4691dd3e941684ac490a2559249f6fa634b6b0fdf020/aiohttp-3.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d925fba0c14d5b498a8028b0107beebdfd16c5d48d702ff54f879cb017aaaca3", size = 1746213, upload-time = "2026-06-01T19:39:36.654Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/28/24e1409e605a9aa5d84abe0e2acb365354b70ae56d40948101cabe3341ab/aiohttp-3.14.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d33e61021222ce7f9792bcac870d6f58d8adfceda33ab857b01264f4560f2c5f", size = 1705862, upload-time = "2026-06-01T19:39:38.968Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/d0/e5eb3ff1daeaf644c7e36a957517672494122628e067c38b263fa04eda77/aiohttp-3.14.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:44eca38755d0105bb32f47d085f5dd449846a449e1245fc105889e3279dcf8e3", size = 1798909, upload-time = "2026-06-01T19:39:41.334Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/ba/8943f906f0570342886ababb9a722a44e360f786a028c5e0b0e29e3f735b/aiohttp-3.14.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f13087e06f68fea4941c21a0c541c00553aa16e4f8fd7bbe2b198df761e964d6", size = 1868892, upload-time = "2026-06-01T19:39:43.807Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/05/27df32c844b2156e1675a8d8ec22d963e3c8ba469ed7ceb1863320c7b521/aiohttp-3.14.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ff82be7f1ef73634cb77890a770743239bc3d487b848669be1c599889336dc0a", size = 1751659, upload-time = "2026-06-01T19:39:46.398Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/62/da182e5910ab912b2e88aa919b61a16046a37a95714a5795b02eb57b2d18/aiohttp-3.14.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a150c0875ac8fd87f1c398650841308a30d65facf7416b12dbdb9cfdcbe5a48c", size = 1578775, upload-time = "2026-06-01T19:39:48.902Z" },
-    { url = "https://files.pythonhosted.org/packages/66/e3/53c67097e8a5ce98625e91e3fa7f43c9c6940de680345d03b3509a72a078/aiohttp-3.14.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:edc01ea4e1ec5a1649a28866262bf24195889ff7b27bdd947029a6086741de9b", size = 1710090, upload-time = "2026-06-01T19:39:51.392Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/55/0e2732ca598c7a4dfe8a775662376d0ca2977cb1030e48386d4da5d9a456/aiohttp-3.14.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:540632bf882ff8fc88f2e1697be0761578e89e0d79fb4a8a6d65dc5da7e729d4", size = 1715016, upload-time = "2026-06-01T19:39:53.807Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/96/f0b73730798c9ca525afc30b39f1f81bbe24e245d9654c54d3b39d63212d/aiohttp-3.14.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:860a86bc2c80237f5dff52edcf427e10a8d8352271fd84845429a3e60199e02c", size = 1763810, upload-time = "2026-06-01T19:39:56.31Z" },
-    { url = "https://files.pythonhosted.org/packages/71/cc/11acb6c4518f448323405a7312b6f255d0f974a34373ad1db7633c4aadc8/aiohttp-3.14.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5cbd50e6a50d6b99283a826b18cbdebf65b0797689a7535cb0e9dd37be0f63c3", size = 1573064, upload-time = "2026-06-01T19:39:58.718Z" },
-    { url = "https://files.pythonhosted.org/packages/de/2d/28c31dde0a7dc98c0ee7d0da2ddcec3f7688c4fc131e5989e278d0c03c0a/aiohttp-3.14.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:20144819e99db593e22bbd2f3f2691a5e149f879142d6b8670254708853ff4fb", size = 1775765, upload-time = "2026-06-01T19:40:01.195Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/69/155c4ef3aec96417d47024800472b33b16c5d8a665371dcd044c2afdf25d/aiohttp-3.14.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:26b6d79aa54cb4ed50cc7d41ed14e99e0f1fc8e7c2d42f2e05b37aea897b2b52", size = 1733716, upload-time = "2026-06-01T19:40:03.631Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/44/6126116fd8a316b712bb615660b855c78466bb67ba1bb1742427eafcf7ac/aiohttp-3.14.0-cp314-cp314-win32.whl", hash = "sha256:106ed074a856f3e21d186b8579e2c8afb6da598e267cdaab01059e13db2fc44d", size = 453684, upload-time = "2026-06-01T19:40:06.277Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/d7/eff4c58a88c5cac5e38b55f44fb8a6d3929c3cbd77356e383e094d3220bd/aiohttp-3.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:4f770846edae8f00ecc57af825bce811f787f87a7dcf0e90d191790efe5b31f7", size = 481758, upload-time = "2026-06-01T19:40:08.653Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/ed/17b5bd9fbcb46e688f02e572f517754a9a75831e7b54702f027761dc4fa5/aiohttp-3.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:acf1581c4f21ed4b80a2dded504d87b055a071a84d5737ea966435f768275ac6", size = 450557, upload-time = "2026-06-01T19:40:11.03Z" },
-    { url = "https://files.pythonhosted.org/packages/12/34/6180103ce9aabc8ebff3f7bb55a1228ffe60f61042823031d9692cb7b101/aiohttp-3.14.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6aa1a40f9cbb3da9f80714c5966b8946c21e6a2530d809b9498b33161e3c8733", size = 787878, upload-time = "2026-06-01T19:40:13.401Z" },
-    { url = "https://files.pythonhosted.org/packages/92/e9/08954a40e8b7baa3d8beadd2b074b186e9b1e9c8ddabc288678a6265de50/aiohttp-3.14.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b62af5a8cc96a194eaa01a9ed7b34a3ffa58d3d8daaa1a0d7a749353ad12d228", size = 524400, upload-time = "2026-06-01T19:40:15.972Z" },
-    { url = "https://files.pythonhosted.org/packages/08/6a/b5965a634ac4d5ba99a463314cf4ab214ca073fcdc38a15e0294273701fc/aiohttp-3.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6eb63b1417efaf7d1002a6ad034a40d44376afcc16508a57f8e74b49ad26a095", size = 527904, upload-time = "2026-06-01T19:40:18.28Z" },
-    { url = "https://files.pythonhosted.org/packages/06/b4/932bcdd850c354d9bcca30f360e475d7852e30413fbbd44b182782ed5432/aiohttp-3.14.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c20b9ad156a79eb97be5cf9e069eec01d2f0dc8472ffbd75299a8b2d4c2cbbde", size = 1912162, upload-time = "2026-06-01T19:40:20.825Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/85/ce79bab0310d2e3fd2d7bc7e44412abeff7c8338f8a21dd0f2f1714989e5/aiohttp-3.14.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:40ae7b0642c25632c7eabc4a04754012691864d2a1b93becf7cddb76027b838a", size = 1778813, upload-time = "2026-06-01T19:40:23.726Z" },
-    { url = "https://files.pythonhosted.org/packages/05/54/ba62ac2d1bc87e010aad23751e383b8794e45d931df67677313a2da78823/aiohttp-3.14.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:95f5217e76a046b9f228a101717ef8d42b1eb3d9d196d15202db5bf41df88936", size = 1899969, upload-time = "2026-06-01T19:40:26.406Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/82/7cc7907725d83a19f31551334061e1ab8e108b1d7ac52632a2a844a4acb5/aiohttp-3.14.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1a4a9f17e85b80878c176695c1998c790e83731d8271881e5d356488652a1f9e", size = 1991771, upload-time = "2026-06-01T19:40:29.061Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/1c/a57de71a4508c93a830b77c28af3d08cd97f606dedfc6b94275347744508/aiohttp-3.14.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:145262119b07d7f95abc1839add35ba2bfc84551d4b4660ca11542c0b215455b", size = 1868606, upload-time = "2026-06-01T19:40:31.843Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/ae/3839726cd49150a53ed340cc24ce5ba09d4c2117020ef9d45542bec5eb2f/aiohttp-3.14.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:49a33ded29b0b2fa7a367a02cf0fb89af602bb87542a16177ec8ce1c9c51d12a", size = 1665437, upload-time = "2026-06-01T19:40:35.01Z" },
-    { url = "https://files.pythonhosted.org/packages/35/1e/c237923232c7da7f0392ea25d89fc5e60c0e93f685f4ebca8e7bcdd5271c/aiohttp-3.14.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cc736a9c9fc2bc4dd71fd404815741b6573df27c3f985948ec4076989ac57de", size = 1834090, upload-time = "2026-06-01T19:40:37.733Z" },
-    { url = "https://files.pythonhosted.org/packages/98/02/a5a7a2524f92d3911761b405a7c067c751891942144adc13e2ad79611e39/aiohttp-3.14.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:b4141a3e5342ee3053a9cab54d25b64ed28289c1041e4c54b3d99839314d90ce", size = 1816907, upload-time = "2026-06-01T19:40:40.46Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/76/a8b9f0d09234d516af9f2d7dd715557f33b5da3b0b56ead41d1170e86e3c/aiohttp-3.14.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:e30871b2d58996cb81aac52d2b1d15ac05257131ef0f90f18c2115a380fbfe7c", size = 1840382, upload-time = "2026-06-01T19:40:43.48Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/8e/140e715a0a4bbc211979ea30ec8396ad2ed5bf90ab87d8058fc4668b1923/aiohttp-3.14.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:667b881d083ccae3900ea5a241e17e5007ca78844c53ed389bb63d48f729d9c7", size = 1659497, upload-time = "2026-06-01T19:40:46.265Z" },
-    { url = "https://files.pythonhosted.org/packages/10/c7/7ba5de8af9650b9767b063c675427b8685f43fa7ce563673a7bc3af60f08/aiohttp-3.14.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:b584dfe615d151e9b8f0a8ecb3aee6147f2927ec5b95ba25fe621f5377510928", size = 1870829, upload-time = "2026-06-01T19:40:49.583Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/bc/2aaab2f85cadb26ea59c091fa2b8e370d625154b5c14b478f1b489d07551/aiohttp-3.14.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6199707cc40e0e9cd39c36fbc97bec416c704e1d0ddce03412bb3b3e6a90ccd0", size = 1832281, upload-time = "2026-06-01T19:40:52.303Z" },
-    { url = "https://files.pythonhosted.org/packages/39/98/31b9ad9fbc01f0075ee7221002df5fd2d10b647f451ca5f30edc802d9dd6/aiohttp-3.14.0-cp314-cp314t-win32.whl", hash = "sha256:a8d93334d4961c9d566b1f046c81dee475b7c21eb730728d38237bfa70d1c8e6", size = 490597, upload-time = "2026-06-01T19:40:54.937Z" },
-    { url = "https://files.pythonhosted.org/packages/59/1f/299b21441c8de42ff70fddc7cfe65e92f810abcf740739a09b56f7835364/aiohttp-3.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2d2ffe9b614f50f069068b3b52e73414e4107fc10b7efc939a76acff9251fdd2", size = 525789, upload-time = "2026-06-01T19:40:57.306Z" },
-    { url = "https://files.pythonhosted.org/packages/70/11/7f83fcba9ee05d4c54d61b3f8104da0d43a59adac44dd28effc0c9a10422/aiohttp-3.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:7a3fc4358e65826c515350f199c210de747cf669998211b1ee6c2e46de364b24", size = 467399, upload-time = "2026-06-01T19:40:59.993Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/21/151624b51cd92553d95424daf4bf19f19ce9be9002d19253e7e7ce67197b/aiohttp-3.14.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d35143e27778b4bb0fb189562d7f275bff79c62ab8e98459717c0ea617ff2480", size = 757402, upload-time = "2026-06-07T21:06:40.311Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/82/280619e0bd7bf2454987e19282616e84762255dd9c8468f62382e8c191f1/aiohttp-3.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:bcfb80a2cc36fba2534e5e5b5264dc7ae6fcd9bf15256da3e53d2f499e6fa29d", size = 512310, upload-time = "2026-06-07T21:06:42.207Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b2/2aac325583aaa1353045f96dffa586d8a34e8322e14a7ba49cffeb103ab4/aiohttp-3.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:27fd7c91e51729b4f7e1577865fa6d34c9adccbc39aabe9000285b48af9f0ec2", size = 512448, upload-time = "2026-06-07T21:06:43.813Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/72/a60607cb849faa8af8a356c9329ea2eb6f395d49e82cc82ccba1fd8deb8f/aiohttp-3.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:64c567bf9eaf664280116a8688f63016e6b32db2505908e2bdaca1b6438142f2", size = 1766854, upload-time = "2026-06-07T21:06:45.391Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d3/d9fe1c9ec7557ab4d0d82bebaa728c6418f0b93295ec2f4ab015f7710cc7/aiohttp-3.14.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:f5e6ff2bdbb8f4cd3fbe41f99e25bbcd58e3bf9f13d3dd31a11e7917251cc77a", size = 1740884, upload-time = "2026-06-07T21:06:47.413Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/dc/f2cecfaf9337ba3e63f181500814ff502aa3d00d9c7ec93a9d23d10a27b2/aiohttp-3.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2f73e01dc37122325caf079982621262f96d74823c179038a82fddfc50359264", size = 1810034, upload-time = "2026-06-07T21:06:50.165Z" },
+    { url = "https://files.pythonhosted.org/packages/66/d7/2ff65c5e65c0d7476daf7e15c032e0805e36811185b9623e3238ad6c763e/aiohttp-3.14.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bb2c0c80d431c0d03f2c7dbf125150fedd4f0de17366a7ca33f7ccb822391842", size = 1904054, upload-time = "2026-06-07T21:06:52.035Z" },
+    { url = "https://files.pythonhosted.org/packages/20/9c/d445818389df371f56d141d881153ba23183c4735a03f7356ffb43f7757d/aiohttp-3.14.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3e6fc1a85fa7194a1a7d19f44e8609180f4a8eb5fa4c7ed8b4355f080fad235c", size = 1790278, upload-time = "2026-06-07T21:06:54.049Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/aa/bf04cb4d865fc6101c2229a294ad744973b72e513fdc5a6b791e6983d72a/aiohttp-3.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:686b6c0d3911ec387b444ddf5dc62fb7f7c0a7d5186a7861626496a5ab4aff95", size = 1591795, upload-time = "2026-06-07T21:06:55.911Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b4/4dac0038960427ba832f6609dfb4ea5437d7fd80c72001b9e48f834f428b/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c6fa4dc7ad6f8109c70bb1499e589f76b0b792baf39f9b017eb92c8a81d0a199", size = 1728397, upload-time = "2026-06-07T21:06:57.777Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/7cd4e8ad7aa3b75f17d56bb5498dd604a93d4e6eece822ba0568c413fff0/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:87a5eea1b2a5e21e1ebdbb33ad4165359189327e63fc4e4894693e7f821ac817", size = 1766504, upload-time = "2026-06-07T21:07:00.009Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/df/fc01d9fcad0f73fed3f3d361f1f94f975947b50dff82919f6dc2bf4316cc/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1c1421eb01d4fd608d88cc8290211d177a58532b55ad94076fb349c5bf467f0a", size = 1777806, upload-time = "2026-06-07T21:07:02.064Z" },
+    { url = "https://files.pythonhosted.org/packages/41/09/47e2d090bddcc8fb4ccb4c314aadc32d7c5d9bb55f50f6ad1c92fc15d501/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:34b257ec41345c1e8f2df68fa908a7952f5de932723871eb633ecbbff396c9a4", size = 1580707, upload-time = "2026-06-07T21:07:03.942Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/36/f1a4ce904ae0b6930cfe9afc96d0896f7ec1a620c400405d63783bb95a9c/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:de538791a80e5d862addbc183f70f0158ac9b9bb872bb147f1fd2a683691e087", size = 1798121, upload-time = "2026-06-07T21:07:05.987Z" },
+    { url = "https://files.pythonhosted.org/packages/70/0a/e0075ce9ca0279ee1d4f0c0b85f54fea02ebc83c3007651a72bece658fec/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6f71173be42d3241d428f760122febb748de0623f44308a6f120d0dd9ec572e3", size = 1767580, upload-time = "2026-06-07T21:07:07.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/a0c0a8f327a9c52095cdd8e312391b00d3ed64ab6c72bb5c33d8ec251cf7/aiohttp-3.14.1-cp312-cp312-win32.whl", hash = "sha256:ec8dc383ee57ea3e883477dcca3f11b65d58199f1080acaf4cd6ad9a99698be4", size = 452771, upload-time = "2026-06-07T21:07:09.669Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d9/ea367c75f16ac9c6cdc8febb25e8318fa21a2b1bc8d6514d4b2d890bface/aiohttp-3.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:2aa92c87868cd13674989f9ee83e5f9f7ea4237589b728048e1f0c8f6caa3271", size = 479873, upload-time = "2026-06-07T21:07:11.538Z" },
+    { url = "https://files.pythonhosted.org/packages/03/64/8d96784a7851156db8a4c6c3f6f91042fdf39fb15a4cc38c8b3c14833c45/aiohttp-3.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:2c840c90759922cb5e6dda94596e079a30fb5a5ba548e7e0dc00574703940847", size = 448073, upload-time = "2026-06-07T21:07:13.637Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/97/bd137012dd97e1649162b099135a80e1fd59aaa807b2430fc448d1029aff/aiohttp-3.14.1-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:b3a03285a7f9c7b016324574a6d92a1c895da6b978cb8f1deee3ac72bc6da178", size = 506882, upload-time = "2026-06-07T21:07:15.501Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/79/e5cc690e9d922a66887ceeaca53a8ffd5a7b0be3816142b7abc433742d89/aiohttp-3.14.1-cp313-cp313-android_21_x86_64.whl", hash = "sha256:2a73f487ab8ef5abbb24b7aa9b73e98eaba9e9e031804ff2416f02eca315ccaf", size = 515270, upload-time = "2026-06-07T21:07:17.53Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/22/a73ccbf9dbd6e26dda0b24d5fd5db7da92ee3383a79f47677ffb834c5c5b/aiohttp-3.14.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:915fbb7b41b115192259f8c9ae58f3ddc444d2b5579917270211858e606a4afd", size = 485841, upload-time = "2026-06-07T21:07:19.555Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b9/57ed8eaf596321c2ad747bd480fb1700dbd7177c60dfc9e4c187f629662e/aiohttp-3.14.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:7fb4bdf95b0561a79f259f9d28fbc109728c5ee7f27aff6391f0ca703a329abe", size = 492088, upload-time = "2026-06-07T21:07:21.581Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c0/5ebe5270a7c140d7c6f79dcb018640225f14d406c149e4eec04a7d82fe71/aiohttp-3.14.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:1b9748363260121d2927704f5d4fc498150669ca3ae93625986ee89c8f80dcd4", size = 501564, upload-time = "2026-06-07T21:07:23.388Z" },
+    { url = "https://files.pythonhosted.org/packages/75/7f/8cdaa24fc7983865e0915153b96a9ac5bcdd3548d64c5a27d17cecccad2d/aiohttp-3.14.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:86a6dab78b0e43e2897a3bbe15745aa60dc5423ca437b7b0b164c069bf91b876", size = 751998, upload-time = "2026-06-07T21:07:25.046Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f4/c4227aacfacc5cb0cc2d119b65301d177912a6842cd64e120c47af76064f/aiohttp-3.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4dfd6e47d3c44c2279907607f73a4240b88c69eb8b90da7e2441a8045dfd21da", size = 510918, upload-time = "2026-06-07T21:07:27.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/01/a2d5f96cd4e74424864d30bc0a7e44d0a12dacdcfa91b5b2d1bd3dca6bf3/aiohttp-3.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:317acd9f8602858dc7d59679812c376c7f0b97bcbbf16e0d6237f54141d8a8a6", size = 508657, upload-time = "2026-06-07T21:07:29.252Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ed/3c0fb5c500fdd8e7ebc10d1889c04384fffa1a9163eac1356088ca9da1b1/aiohttp-3.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd869c427324e5cb15195793de951295710db28be7d818247f3097b4ab5d4b96", size = 1757907, upload-time = "2026-06-07T21:07:31.03Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ab/d4c924d9bd5be3050c226612413ce68cb54c70d2c31b661bfc8d9a5b6a70/aiohttp-3.14.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:93b032b5ec3255473c143627d21a69ac74ae12f7f33974cb587c564d11b1066f", size = 1737565, upload-time = "2026-06-07T21:07:33.031Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/37326821ff779084020cdc33224d20b19f42f4183a500ff92022a739eda7/aiohttp-3.14.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f234b4deb12f3ad59127e037bc57c40c21e45b45282df7d3a55a0f409f595296", size = 1799018, upload-time = "2026-06-07T21:07:35.003Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/4f/6e947ba73e4ce09070761c05ed3a8ceb7c21f5e46798671d8b2aac0e4626/aiohttp-3.14.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9af6779bfb46abf124068327abcdf9ce95c9ef8287a3e8da76ccf2d0f16c28fa", size = 1894416, upload-time = "2026-06-07T21:07:36.956Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/6e/dbf1d0625dc711fb2851f4f3c3055c39ed58bae92082d8c627dbe6013736/aiohttp-3.14.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:faccab372e66bc76d5731525e7f1143c922271725b9d38c9f97edcc66266b451", size = 1783881, upload-time = "2026-06-07T21:07:39.063Z" },
+    { url = "https://files.pythonhosted.org/packages/44/c2/5e25098a67268ed369483ae7d1a58bd0a13d03aab860d2a0e4a6eb25b046/aiohttp-3.14.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f380468b09d2a81633ee863b0ec5648d364bd17bb8ecfb8c2f387f7ac1faf42c", size = 1587572, upload-time = "2026-06-07T21:07:41.058Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/bd/cf9cee17e140f942a3de73e658a543aa8fbf35a5fc67a9d2538d52d77f0b/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:97e704dcd26271f5bda3fa07c3ce0fb76d6d3f8659f4baa1a24442cc9ba177ca", size = 1722137, upload-time = "2026-06-07T21:07:43.014Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6d/5684f8c59045c96f81a18cefbc1fbbd79d25b88f1c622f2a5c5c08fcb632/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:269b76ac5394092b95bc4a098f4fc6c191c083c3bd12775d1e30e663132f6a09", size = 1755953, upload-time = "2026-06-07T21:07:45.933Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/40/35caf3170f8359760740a7d9aa0fff2e344bef98e1d1186f5a0f6dec17e6/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c0b3e614340c889d575451696374c9d17affd54cd607ca0babed8f8c37b9397", size = 1766479, upload-time = "2026-06-07T21:07:48.047Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a1/b0c61e7a137f0d81de49a82023a6df73c3c16d6fefb0f8e4a93d21639002/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:5663ee9257cfa1add7253a7da3035a02f31b6600ec48261585e1800a81533080", size = 1580077, upload-time = "2026-06-07T21:07:50.069Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/41/194ea4623693009fcefebef7aef63c141754f153e9cd0d39d3b9e36c175c/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:603a2c834142172ffddc054067f5ec0ca65d57a0aa98a71bc81952573208e345", size = 1791688, upload-time = "2026-06-07T21:07:52.106Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/45/4de841f005cfe1fd63e2a2fe011262c515e2a62aa6994b15947e7d717ac9/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cb21957bb8aca671c1765e32f58164cf0c50e6bf41c0bbbd16da20732ecaf588", size = 1761094, upload-time = "2026-06-07T21:07:54.113Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/ae/dbce10533d3896d544d5053939ed75b7dc31a1b0973d959b1b5ae21028d6/aiohttp-3.14.1-cp313-cp313-win32.whl", hash = "sha256:e509a55f681e6158c20f70f102f9cf61fb20fbc382272bc6d94b7343f2582780", size = 452662, upload-time = "2026-06-07T21:07:56.06Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d9/0bf1a19362c32f06229da5e7ddfcec91f93474d6307f7a2d3135e9c674dc/aiohttp-3.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:1ac8531b638959718e18c2207fbfe297819875da46a740b29dfa29beba64355a", size = 479748, upload-time = "2026-06-07T21:07:58.319Z" },
+    { url = "https://files.pythonhosted.org/packages/22/0a/62e7232dc9484fbec112ceb32efb6a624cc7994ec6e2b019286f17c4e8f2/aiohttp-3.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:250d14af67f6b6a1a4a811049b1afa69d61d617fca6bf33149b3ab1a6dbcf7b8", size = 447723, upload-time = "2026-06-07T21:08:00.154Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a1/5fafa04e1ca91ddb47608699d60649c1c6db3cf41c99e78fc4056f9513db/aiohttp-3.14.1-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:7c106c26852ca1c2047c6b80384f17100b4e439af276f21ef3d4e2f450ae7e15", size = 508531, upload-time = "2026-06-07T21:08:02.093Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/2e/bfa02f699d87ffc86d5959270b28f1cb410add3ccaced8ed2e0b8a5238fc/aiohttp-3.14.1-cp314-cp314-android_24_x86_64.whl", hash = "sha256:20205f7f5ade7aaec9f4b500549bbc071b046453aed72f9c06dcab87896a83e8", size = 514718, upload-time = "2026-06-07T21:08:04.476Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a5/9594ad6289eebbc97d167c44213d557807f90e59115caad24de21ad2c3b1/aiohttp-3.14.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:62a759436b29e677181a9e76bab8b8f689a29cb9c535f45f7c48c9c830d3f8c3", size = 487918, upload-time = "2026-06-07T21:08:06.377Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/61/16a32c36c3c49edec122a3dc811f2057df2f94d3b14aa107c8017d981618/aiohttp-3.14.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:2964cbf553df4d7a57348da44d961d871895fc1ee4e8c322b2a95612c7b17fba", size = 494014, upload-time = "2026-06-07T21:08:08.263Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/89/3ebcf96ed99c05bec9c434aaac6963fd3cbab4a786ae739908a144d9ce44/aiohttp-3.14.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:237651caadc3a59badd39319c54642b5299e9cc98a3a194310e55d5bb9f5e397", size = 502398, upload-time = "2026-06-07T21:08:10.244Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/3d/b74870a0c2d40c355928cd5b96c7a11fa821b8a40fc41365e64479b151fb/aiohttp-3.14.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:896e12dfdbbab9d8f7e16d2b28c6769a60126fa92095d1ebf9473d02593a2448", size = 758018, upload-time = "2026-06-07T21:08:12.447Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/66/f42f5c984d99e49c6cff5f26f590750f2e2f7ef1fcfb99966ab5be1b632e/aiohttp-3.14.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d03f281ed22579314ba00821ce20115a7c0ac430660b4cc05704a3f818b3e004", size = 512462, upload-time = "2026-06-07T21:08:14.624Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a7/248e1aebe0c7810b0271e021a0f2a5eb6e78a051885b3c9df49f42a5802d/aiohttp-3.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:07eabb979d236335fed927e137a928c9adfb7df3b9ec7aa31726f133a62be983", size = 512824, upload-time = "2026-06-07T21:08:16.572Z" },
+    { url = "https://files.pythonhosted.org/packages/26/97/2aa0e5ba0727dc3bd5aaebb7ccbc510f7dfb7fb961ec87497cd496635ab1/aiohttp-3.14.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4fe1f1087cbadb280b5e1bb054a4f00d1423c74d6626c5e48400d871d34ecefe", size = 1749898, upload-time = "2026-06-07T21:08:18.635Z" },
+    { url = "https://files.pythonhosted.org/packages/00/8d/e97f6c96c891d457c8479d92a514ba194d0412f981d72c70341ee18488ed/aiohttp-3.14.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:367a9314fdc79dab0fac96e216cb41dd73c85bdca85306ce8999118ba7e0f333", size = 1710114, upload-time = "2026-06-07T21:08:20.892Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/e6/aa8d7e863048c8fceb5cd6ce74017311cec3ead07847387e12265fb4444e/aiohttp-3.14.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a24f677ebe83749039e7bdf862ff0bbb16818ae4193d4ef96505e269375bcce0", size = 1802541, upload-time = "2026-06-07T21:08:23.044Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a8/72193137de57fda4ebfae4563182d082c8856e3b6e9871d0b46f028fb369/aiohttp-3.14.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c83afe0ba876be7e943d2e0ba645809ad441575d2840c895c21ee5de93b9377a", size = 1875776, upload-time = "2026-06-07T21:08:25.288Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/18/938441025db6769a3464596b2410af3afde0b21eb2f204c6f766f68af4bd/aiohttp-3.14.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:634e385930fb6d2d479cf3aa66515955863b77a5e3c2b5894ca259a25b308602", size = 1760329, upload-time = "2026-06-07T21:08:27.363Z" },
+    { url = "https://files.pythonhosted.org/packages/60/29/bf2496b4065e76e09fe48015aaffe5ce161d8f089b06ac6982070f653076/aiohttp-3.14.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:eeea07c4397bbc57719c4eed8f9c284874d4f175f9b6d57f7a1546b976d455ca", size = 1587293, upload-time = "2026-06-07T21:08:29.805Z" },
+    { url = "https://files.pythonhosted.org/packages/49/a2/2136674d52123b1354bd05dd5753c318db47dc0c927cc70b27bab3755456/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:335c0cc3e3545ce98dcb9cfcb836f40c3411f43fa03dab757597d80c89af8a35", size = 1714756, upload-time = "2026-06-07T21:08:32.094Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/b9/e5fd2e6f915503081c0f9b1e8540947037929c70c191da2e4d54b31a21a1/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:ae6be797afdef264e8a84864a85b196ca06045586481b3df8a967322fd2fa844", size = 1721052, upload-time = "2026-06-07T21:08:34.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/5a/2833e324a2263e104e31e2e91bc5bbee81bc499afd32203faee048a883f0/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:8560b4d712474335d08907db7973f71912d3a9a8f1dee992ec06b5d2fe359496", size = 1766888, upload-time = "2026-06-07T21:08:36.95Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fa/dea6511870913162f3b2e8c42a7614eb203a4540b8c2da43e0bfb0548f3c/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b7edd08e0a5deb1e8564a2fcd8f4561014a3f05252334671bbf55ddd47db0e5", size = 1581679, upload-time = "2026-06-07T21:08:39.292Z" },
+    { url = "https://files.pythonhosted.org/packages/14/bd/3cf0d55e71784b33534e9710a67d382d900598b4787fbce6cc7317f8c42a/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:b6ff7fcee63287ae57b5df3e4f5957ce032122802509246dec1a5bcc55904c95", size = 1782021, upload-time = "2026-06-07T21:08:41.407Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/af/14bb5843eccbe234f4dfb78ab73e549d99727247e62ae5d62cbd22eaf5b0/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6ffbb2f4ec1ceaff7e07d43922954da26b223d188bf30658e561b98e23089444", size = 1742574, upload-time = "2026-06-07T21:08:43.795Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/1e/fbeb7af9210a67ac0f9c9bec0f8f4568497924e33137a3d5b48e1cf85f3f/aiohttp-3.14.1-cp314-cp314-win32.whl", hash = "sha256:a9875b46d910cff3ea2f5962f9d266b465459fe634e22556ab9bd6fc1192eea0", size = 457773, upload-time = "2026-06-07T21:08:46.168Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/2b/13e8d741a9ec5db7d900c060554cf8352ab85e44e2a4469ebb9d377bda17/aiohttp-3.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:af8b4b81a960eeaf1234971ac3cd0ba5901f3cd42eae42a46b4d089a8b492719", size = 485001, upload-time = "2026-06-07T21:08:48.401Z" },
+    { url = "https://files.pythonhosted.org/packages/df/30/491acfa2c4d6c3ff59c49a14fc1b50be3241e25bbb0c84c09e2da4d11395/aiohttp-3.14.1-cp314-cp314-win_arm64.whl", hash = "sha256:cf4491381b1b57425c315a56a439251b1bdac07b2275f19a8c44bc57744532ec", size = 453809, upload-time = "2026-06-07T21:08:50.7Z" },
+    { url = "https://files.pythonhosted.org/packages/34/e3/19dbe1a1f4cc6230eb9e314de7fe68053b0992f9302b27d12141a0b5db53/aiohttp-3.14.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:819c054312f1af92947e6a55883d1b66feefab11531a7fc45e0fb9b63880b5c2", size = 793320, upload-time = "2026-06-07T21:08:52.775Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/20/1b7182219ba1b108430d6e4dc53d25ae02dcfcf5a045b33af4e8c5167527/aiohttp-3.14.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10ee9c1753a8f706345b22496c79fbddb5be0599e0823f3738b1534058e25340", size = 529077, upload-time = "2026-06-07T21:08:55Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c8/14ce60ec31a2e5f5274bb17d383a6f7a3aabca31ac04eee05585bbadab16/aiohttp-3.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1601cc37baf5750ccacae618ec2daf020769581695550e3b654a911f859c563d", size = 532476, upload-time = "2026-06-07T21:08:57.176Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/02/9ac85e081e53da2e061b02fa7758fe0a12d17b8ce2d1f5e6c7cb76730328/aiohttp-3.14.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d6e0ac9da31c9c04c84e1c0182ad8d6df35965a85cae29cd71d089621b3ae94", size = 1922347, upload-time = "2026-06-07T21:08:59.563Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/3e/d3ba07a0ab38b5389e10bec4362d21e10a4f667cba2d79ba30837b3a5059/aiohttp-3.14.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9e8f2d660c350b3d0e259c7a7e3d9b7fc8b41210cbcc3d4a7076ff0a5e5c2fdc", size = 1786465, upload-time = "2026-06-07T21:09:01.909Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/cb/e2ee978a00cfb2df829704a69528b18154eba5939f45bc1efa8f33aee4c5/aiohttp-3.14.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4691802dda97be727f79d86818acaad7eb8e9252626a1d6b519fedbb92d5e251", size = 1909423, upload-time = "2026-06-07T21:09:04.357Z" },
+    { url = "https://files.pythonhosted.org/packages/73/5d/1430334858b1022b58ae50399a918f0bd6fe8fa7fa183598d657ff61e040/aiohttp-3.14.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c389c482a7e9b9dc3ee2701ac46c4125297a3818875b9c305ddb603c04828fd1", size = 2001906, upload-time = "2026-06-07T21:09:06.722Z" },
+    { url = "https://files.pythonhosted.org/packages/66/4e/560c7472d3d198a23aa5c8b19a5115bf6a9b77b7d3e4bb363da320430ad2/aiohttp-3.14.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fc0cacab7ba4e56f0f81c82a98c09bed2f39c940107b03a34b168bdf7597edd3", size = 1877095, upload-time = "2026-06-07T21:09:09.011Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f1/4745806578d447db4a784a8591e2dae3afdfc2bcb96f8f81271b13df6543/aiohttp-3.14.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:979ed4717f59b8bb12e3963378fa285d93d367e15bcd66c721311826d3c44a6c", size = 1676222, upload-time = "2026-06-07T21:09:11.461Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c9/48255813cca749a229ef0ab476004ec623728ad79a9c0840616f6c076325/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:38e1e7daaea81df51c952e18483f323d878499a1e2bfe564790e0f9701d6f203", size = 1842922, upload-time = "2026-06-07T21:09:14.118Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c0/bbd054e2bee909f529523a5af3891052606af5143c09f5f183ec3b234676/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:4132e72c608fe9fecb8f409113567605915b83e9bdd3ea56538d2f9cd35002f1", size = 1825035, upload-time = "2026-06-07T21:09:16.447Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ae/90395d4376deceb74e09ec26b6adf7d2015a6f8802d6d84446af860fef04/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:eefd9cc9b6d4a2db5f00a26bc3e4f9acf71926a6ec557cd56c9c6f27c290b665", size = 1849512, upload-time = "2026-06-07T21:09:18.742Z" },
+    { url = "https://files.pythonhosted.org/packages/93/bd/fb25f3049957553d4ce0ba6ae480aa2f592a6985497fca590837d16c1be0/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:b165790117eea512d7f3fb22f1f6dad3d55a7189571993eb015591c1401276d1", size = 1668571, upload-time = "2026-06-07T21:09:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/22/7f73303d64dd567ff3addca90b556690ed1233a47b8f55d242fb90af3681/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:ed09c7eb1c391271c2ed0314a51903e72a3acb653d5ccfc264cdf3ef11f8269d", size = 1881159, upload-time = "2026-06-07T21:09:23.813Z" },
+    { url = "https://files.pythonhosted.org/packages/44/be/0474c5a8b5640e1e4aa1923430a91f4151be82e511373fe764189b89aef5/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:99abd37084b82f5830c635fddd0b4993b9742a66eb746dacf433c8590e8f9e3c", size = 1841409, upload-time = "2026-06-07T21:09:26.207Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/3c/bb4a7cba26956cb3da4553cc2056cf67be5b5ff6e6d8fa4fbdff73bfb7ae/aiohttp-3.14.1-cp314-cp314t-win32.whl", hash = "sha256:47ddf841cdecc810749921d25606dee45857d12d2ad5ddb7b5bd7eab12e4b365", size = 494166, upload-time = "2026-06-07T21:09:28.505Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/84/ec80c2c1f66a952555a9f86df6b33af65108a6febfa0471b69013a12f807/aiohttp-3.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:5e78b522b7a6e27e0b25d19b247b75039ac4c94f99823e3c9e53ae1603a9f7e9", size = 530255, upload-time = "2026-06-07T21:09:30.843Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/71/6e22be134a4061ada85a92951b842f2657f17d926b727f3f94c56ae963d6/aiohttp-3.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:90d53f1609c29ccc2193945ef732428382a28f78d0456ae4d3daf0d48b74f0f6", size = 469640, upload-time = "2026-06-07T21:09:33.028Z" },
 ]
 
 [[package]]
@@ -191,15 +191,15 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.13.0"
+version = "4.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/b5/001890774a9552aff22502b8da382593109ce0c95314abaebbb116567545/anyio-4.14.0.tar.gz", hash = "sha256:b47c1f9ccf73e67021df785332508f99379c68fa7d0684e8e3492cb1d4b23f89", size = 253586, upload-time = "2026-06-15T22:00:49.021Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/16/9826f089383c593cdfc4a6e5aca94d9e91ae1692c57af82c3b2aa5e810f7/anyio-4.14.0-py3-none-any.whl", hash = "sha256:dd9b7a2a9799ed6552fde617b2c5df02b7fdd7d88392fc48101e51bae46164d9", size = 123506, upload-time = "2026-06-15T22:00:47.595Z" },
 ]
 
 [[package]]
@@ -398,11 +398,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.5.20"
+version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
 ]
 
 [[package]]
@@ -539,6 +539,15 @@ wheels = [
 ]
 
 [[package]]
+name = "configupdater"
+version = "3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/603bd8a65e040b23d25b5843836297b0f4e430f509d8ed2ef8f072fb4127/ConfigUpdater-3.2.tar.gz", hash = "sha256:9fdac53831c1b062929bf398b649b87ca30e7f1a735f3fbf482072804106306b", size = 140603, upload-time = "2023-11-27T17:16:45.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/f0/b59cb7613d9d0f866b6ff247c5953ad78363c27ff5d684a2a98899ab8220/ConfigUpdater-3.2-py2.py3-none-any.whl", hash = "sha256:0f65a041627d7693840b4dd743581db4c441c97195298a29d075f91b79539df2", size = 34688, upload-time = "2023-11-27T17:16:43.53Z" },
+]
+
+[[package]]
 name = "coverage"
 version = "7.14.1"
 source = { registry = "https://pypi.org/simple" }
@@ -624,55 +633,52 @@ wheels = [
 
 [[package]]
 name = "cryptography"
-version = "48.0.0"
+version = "49.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
-    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
-    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
-    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
-    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
-    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
-    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
-    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
-    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
-    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
-    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
-    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
-    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
-    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
-    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
-    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
-    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
-    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
-    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
 ]
 
 [[package]]
@@ -707,11 +713,11 @@ wheels = [
 
 [[package]]
 name = "distlib"
-version = "0.4.0"
+version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+    { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
 ]
 
 [[package]]
@@ -825,7 +831,7 @@ dev = [{ name = "types-pyyaml", specifier = ">=6.0.12.20250915" }]
 
 [[package]]
 name = "fastapi"
-version = "0.136.3"
+version = "0.137.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -834,9 +840,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/29/cc5819dc24d3daa80cdaa1aec023bf8652a70dd7fd1c96b0b225c99a7690/fastapi-0.137.2.tar.gz", hash = "sha256:b9d893bebc97dcfbdcb1917e88a292d062844ea19445a5fa4f7eb28c4baea9e3", size = 410332, upload-time = "2026-06-18T06:58:24.434Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/ed/0c6b644e99fb5697d8bdcd36cdb47c52e77a63fc7a1514b1f03a6ecab955/fastapi-0.137.2-py3-none-any.whl", hash = "sha256:791d36261e916a98b25ac85ee591bc3db159394070f6d3d096d94fb378f60ce2", size = 122252, upload-time = "2026-06-18T06:58:26.074Z" },
 ]
 
 [package.optional-dependencies]
@@ -854,16 +860,16 @@ standard = [
 
 [[package]]
 name = "fastapi-cli"
-version = "0.0.24"
+version = "0.0.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "rich-toolkit" },
     { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/58/74797ae9e4610cfa0c6b34c8309096d3b20bb29be3b8b5fbf1004d10fa5f/fastapi_cli-0.0.24.tar.gz", hash = "sha256:1afc9c9e21d7ebc8a3ca5e31790cd8d837742be7e4f8b9236e99cb3451f0de00", size = 19043, upload-time = "2026-02-24T10:45:10.476Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/d0/ee5678346811967b8d096d5d5604e71b50d6bf5a2abfbdb331157e2bbaa9/fastapi_cli-0.0.27.tar.gz", hash = "sha256:1dffb1e40c0c88f2e0171a8a252a2b615c1e63ff8c05626649e4badd6a84336a", size = 23630, upload-time = "2026-06-18T14:48:43.421Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/4b/68f9fe268e535d79c76910519530026a4f994ce07189ac0dded45c6af825/fastapi_cli-0.0.24-py3-none-any.whl", hash = "sha256:4a1f78ed798f106b4fee85ca93b85d8fe33c0a3570f775964d37edb80b8f0edc", size = 12304, upload-time = "2026-02-24T10:45:09.552Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ab/0a709f9488fe62647db80f8a277fb0ee62e85adc6746abf477ed373c9eb7/fastapi_cli-0.0.27-py3-none-any.whl", hash = "sha256:2e389a40f318e29fec8cb1e289f267f17c048876fb82dbfa869a10b16740495d", size = 13070, upload-time = "2026-06-18T14:48:44.311Z" },
 ]
 
 [package.optional-dependencies]
@@ -874,7 +880,7 @@ standard = [
 
 [[package]]
 name = "fastapi-cloud-cli"
-version = "0.18.0"
+version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "detect-installer" },
@@ -887,9 +893,9 @@ dependencies = [
     { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7f/1d/57221a834b0f62dfa510c2b3db6e9b682cfbc280cef41919a8811ce1ff89/fastapi_cloud_cli-0.18.0.tar.gz", hash = "sha256:95f7a79200e3a90a005e068a4d8ede49d4b04accb095ccd4fd47da998fc28c74", size = 53320, upload-time = "2026-05-22T09:53:54.462Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/bf/97d19633c6ec6fb0ef59df474b9705ea992f7b4f879208d0007ac6d25ab6/fastapi_cloud_cli-0.20.0.tar.gz", hash = "sha256:9681c46adcd299024d0775658bd5d88992fd35c4ad42b1f045c6df913390ba37", size = 85904, upload-time = "2026-06-11T17:41:02.814Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/1e/1d54aabf71c003e89e73df92c3dfded311228e68db7cea5db90b3e0ef2b5/fastapi_cloud_cli-0.18.0-py3-none-any.whl", hash = "sha256:1f136fc651b0b6e2f4a9679e23c56e1c3be3405e74469c14ba6e2d5b87fdc113", size = 37087, upload-time = "2026-05-22T09:53:53.001Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/6e/bbb2e1b8f3170b6426b707d49981a838fc1d5cbb428dd9a271f1c3951c23/fastapi_cloud_cli-0.20.0-py3-none-any.whl", hash = "sha256:dcbf071fc659ae2d3fb30e221a661c3fa240b7d5091203cf941face31f6d7860", size = 68793, upload-time = "2026-06-11T17:41:01.804Z" },
 ]
 
 [[package]]
@@ -966,11 +972,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.29.0"
+version = "3.29.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/dc/be6cbe99670cd6e4ad387123647cb08e0c32975e223f82551e914c5568a6/filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a", size = 63028, upload-time = "2026-06-13T16:12:00.744Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+    { url = "https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767", size = 42757, upload-time = "2026-06-13T16:11:59.582Z" },
 ]
 
 [[package]]
@@ -1064,12 +1070,14 @@ wheels = [
 
 [[package]]
 name = "ggshield"
-version = "1.51.0"
+version = "1.52.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "charset-normalizer" },
     { name = "click" },
+    { name = "configupdater" },
     { name = "cryptography" },
+    { name = "filelock" },
     { name = "keyring" },
     { name = "marshmallow" },
     { name = "marshmallow-dataclass" },
@@ -1089,9 +1097,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/d5/54067ee60dee03485ceab3f5f3f998fed550ffb087e63a25635797cb0e77/ggshield-1.51.0.tar.gz", hash = "sha256:e7f21d6a2693ab7c546f1be84d218e5cd69357ed5ac2e0bfb92fb93cfa367edb", size = 770492, upload-time = "2026-05-26T13:10:58.243Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/f9/3f2b594156cda7ed2afba978daec90fc0fad5023a1896aacf120f259f9a1/ggshield-1.52.2.tar.gz", hash = "sha256:bcb3f485e0ac12adbca44b4e7135bb522e29b2a774842eaf942ffca972f2219a", size = 839118, upload-time = "2026-06-17T13:38:10.541Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/58/d4712914f27681cc435ba15ccde921c6810371dad8784b716eb2e65f341f/ggshield-1.51.0-py3-none-any.whl", hash = "sha256:3422ee6bc10cd13d1bcec40b46dbcdf15eb7a7e992df57575bb19f8f583de41b", size = 279772, upload-time = "2026-05-26T13:10:56.888Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/57/87d9192d07f34f586e229b033d50c3d91a29ec2423a83777b9116bddb06c/ggshield-1.52.2-py3-none-any.whl", hash = "sha256:c5a60a97148f1bd5cca53a5c0f031cf6adba24a0e7eac07257840645cb567ea7", size = 308163, upload-time = "2026-06-17T13:38:08.899Z" },
 ]
 
 [[package]]
@@ -1132,43 +1140,43 @@ wheels = [
 
 [[package]]
 name = "grpcio"
-version = "1.80.0"
+version = "1.81.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/b5/1ff353970a87eda4c98251e34d2dfd214abd4982dc89119c9252a2a482d2/grpcio-1.81.1.tar.gz", hash = "sha256:6fa10a767143a5e82e8eaab53918af0cd8909a57a27f8cb2288b80a613ac671b", size = 13026582, upload-time = "2026-06-11T12:46:51.673Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/e8/a2b749265eb3415abc94f2e619bbd9e9707bebdda787e61c593004ec927a/grpcio-1.80.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:c624cc9f1008361014378c9d776de7182b11fe8b2e5a81bc69f23a295f2a1ad0", size = 6015616, upload-time = "2026-03-30T08:47:13.428Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/97/b1282161a15d699d1e90c360df18d19165a045ce1c343c7f313f5e8a0b77/grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:f49eddcac43c3bf350c0385366a58f36bed8cc2c0ec35ef7b74b49e56552c0c2", size = 12014204, upload-time = "2026-03-30T08:47:15.873Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/5e/d319c6e997b50c155ac5a8cb12f5173d5b42677510e886d250d50264949d/grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d334591df610ab94714048e0d5b4f3dd5ad1bee74dfec11eee344220077a79de", size = 6563866, upload-time = "2026-03-30T08:47:18.588Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/f6/fdd975a2cb4d78eb67769a7b3b3830970bfa2e919f1decf724ae4445f42c/grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0cb517eb1d0d0aaf1d87af7cc5b801d686557c1d88b2619f5e31fab3c2315921", size = 7273060, upload-time = "2026-03-30T08:47:21.113Z" },
-    { url = "https://files.pythonhosted.org/packages/db/f0/a3deb5feba60d9538a962913e37bd2e69a195f1c3376a3dd44fe0427e996/grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4e78c4ac0d97dc2e569b2f4bcbbb447491167cb358d1a389fc4af71ab6f70411", size = 6782121, upload-time = "2026-03-30T08:47:23.827Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/84/36c6dcfddc093e108141f757c407902a05085e0c328007cb090d56646cdf/grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ed770b4c06984f3b47eb0517b1c69ad0b84ef3f40128f51448433be904634cd", size = 7383811, upload-time = "2026-03-30T08:47:26.517Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/ef/f3a77e3dc5b471a0ec86c564c98d6adfa3510d38f8ee99010410858d591e/grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:256507e2f524092f1473071a05e65a5b10d84b82e3ff24c5b571513cfaa61e2f", size = 8393860, upload-time = "2026-03-30T08:47:29.439Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/8d/9d4d27ed7f33d109c50d6b5ce578a9914aa68edab75d65869a17e630a8d1/grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a6284a5d907c37db53350645567c522be314bac859a64a7a5ca63b77bb7958f", size = 7830132, upload-time = "2026-03-30T08:47:33.254Z" },
-    { url = "https://files.pythonhosted.org/packages/14/e4/9990b41c6d7a44e1e9dee8ac11d7a9802ba1378b40d77468a7761d1ad288/grpcio-1.80.0-cp312-cp312-win32.whl", hash = "sha256:c71309cfce2f22be26aa4a847357c502db6c621f1a49825ae98aa0907595b193", size = 4140904, upload-time = "2026-03-30T08:47:35.319Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/2c/296f6138caca1f4b92a31ace4ae1b87dab692fc16a7a3417af3bb3c805bf/grpcio-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:9fe648599c0e37594c4809d81a9e77bd138cc82eb8baa71b6a86af65426723ff", size = 4880944, upload-time = "2026-03-30T08:47:37.831Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/3a/7c3c25789e3f069e581dc342e03613c5b1cb012c4e8c7d9d5cf960a75856/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad", size = 6017243, upload-time = "2026-03-30T08:47:40.075Z" },
-    { url = "https://files.pythonhosted.org/packages/04/19/21a9806eb8240e174fd1ab0cd5b9aa948bb0e05c2f2f55f9d5d7405e6d08/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0", size = 12010840, upload-time = "2026-03-30T08:47:43.11Z" },
-    { url = "https://files.pythonhosted.org/packages/18/3a/23347d35f76f639e807fb7a36fad3068aed100996849a33809591f26eca6/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f", size = 6567644, upload-time = "2026-03-30T08:47:46.806Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/40/96e07ecb604a6a67ae6ab151e3e35b132875d98bc68ec65f3e5ab3e781d7/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6", size = 7277830, upload-time = "2026-03-30T08:47:49.643Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/e2/da1506ecea1f34a5e365964644b35edef53803052b763ca214ba3870c856/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140", size = 6783216, upload-time = "2026-03-30T08:47:52.817Z" },
-    { url = "https://files.pythonhosted.org/packages/44/83/3b20ff58d0c3b7f6caaa3af9a4174d4023701df40a3f39f7f1c8e7c48f9d/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d", size = 7385866, upload-time = "2026-03-30T08:47:55.687Z" },
-    { url = "https://files.pythonhosted.org/packages/47/45/55c507599c5520416de5eefecc927d6a0d7af55e91cfffb2e410607e5744/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7", size = 8391602, upload-time = "2026-03-30T08:47:58.303Z" },
-    { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752, upload-time = "2026-03-30T08:48:01.311Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310, upload-time = "2026-03-30T08:48:04.594Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833, upload-time = "2026-03-30T08:48:07.363Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
-    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
-    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
-    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
-    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
-    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
-    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
+    { url = "https://files.pythonhosted.org/packages/85/07/9a979c81738863a738dc23d65177056e71fbb2db817740ed870b33434e7a/grpcio-1.81.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:8b39472beafc0bdcafc4c8c73ad082ebfdb449d566897a61e7acb4fa88089115", size = 6053264, upload-time = "2026-06-11T12:45:21.017Z" },
+    { url = "https://files.pythonhosted.org/packages/75/95/539706ca0d3bd40dbad583dc56fd883da941f37556b629132da5762781b9/grpcio-1.81.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:12b7524c88d4026d3dcb7b0ebe16b6714f3b4af402ddd0f0639ab064a00c87c3", size = 12052560, upload-time = "2026-06-11T12:45:23.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/44/f257b7e0bd69c93b06c6cb8ac8d1b901ccb42bedabd83c1a4c77a71f8810/grpcio-1.81.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1e123f9b37edb8375fd74130d1f69c944bbf0a7b06761ae7211154b8759e94d2", size = 6595983, upload-time = "2026-06-11T12:45:26.963Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f3/19782aa04c960968bef8c5539329d8e3bbc3364e2e46d19eb5e5cc5e43b7/grpcio-1.81.1-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:2c2e2ae6867c2966b8daccc836d54a13218e0007e9a490aeb81dd05be64d22d7", size = 7303455, upload-time = "2026-06-11T12:45:29.707Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/8c/dea020b6d91508cd84463917a63149ec196ee7db505d032ae43fcb3303b9/grpcio-1.81.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:766bc7c9a9c340342f4c864ccbda8e78111e4751f13b895812b9c148fb79e9d0", size = 6809167, upload-time = "2026-06-11T12:45:32.52Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/3030dd940408083bd32cd95d634777a71605ade4887154d93e8a89244946/grpcio-1.81.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b259a04a737cb3496be0901328eb8b7552ed8df4865d8c8f1cf1bffcfc0776a3", size = 7412536, upload-time = "2026-06-11T12:45:35.403Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/dd/1172a9e42b168edcafefad6115346ef619a3fc02158bb170e66ced24bcdd/grpcio-1.81.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:85b10a45b8993d195c4f3ff57025b8d1e11834909ee475c403bfa60cb4caefaf", size = 8408276, upload-time = "2026-06-11T12:45:37.78Z" },
+    { url = "https://files.pythonhosted.org/packages/25/7a/71437c7f3596e5246155c515852795a85a1a8d228190212432b13b97a95d/grpcio-1.81.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8ea1936c26b99999b27479853039a7f34713f56c49375ad52b38535ec93a796c", size = 7849660, upload-time = "2026-06-11T12:45:40.627Z" },
+    { url = "https://files.pythonhosted.org/packages/65/40/7debc0da45d2efebafb82da75644be347497fe4ee250514b8cd3b86ae8bf/grpcio-1.81.1-cp312-cp312-win32.whl", hash = "sha256:a185a04039df6cae8648bc8ab6d6fde7bf94f7188ecf7828e76ac52eef1e41d6", size = 4185819, upload-time = "2026-06-11T12:45:43.027Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b9/8fe3ba5ed462067774ebc1f9c7f26aa7ebcc280ddd476be107153de1339e/grpcio-1.81.1-cp312-cp312-win_amd64.whl", hash = "sha256:3ad74f8bb1a18963914c5452d289422830b39459e8776ebbcd207be1fbfb1d94", size = 4930461, upload-time = "2026-06-11T12:45:45.775Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/42/dcc2e4b600538ef18327c0839d56b7d3c3812337c5d710df5877dbb39b1e/grpcio-1.81.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:b10e1ff4756ed27d5a29d7fc79cfce7ef1ff56ad20025b89bac7cf79e09abbbe", size = 6054466, upload-time = "2026-06-11T12:45:48.43Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/4a/a36e03210183a8a7d4c80c3936acee679f4bd77d5861f369db47b2cc5f05/grpcio-1.81.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:819edbdcb42ab8598b494bcf0222684bbb7a3c772bd1b1f0be7e029a6063c28e", size = 12048795, upload-time = "2026-06-11T12:45:54.011Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d5/d68e30b29098f63beab6fe501100fe82674ff142b32c672532da86a99b3a/grpcio-1.81.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c5bf2dc311127d91230cc79b92188c082634a06cf66c5234db49a43b910183b0", size = 6599094, upload-time = "2026-06-11T12:45:57.799Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b3/e837954d279754f638a11cca5dcf6b24a005efb398984cefaf7735945a54/grpcio-1.81.1-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:e8ca6a1fcdb2943c9cbc1804a1baf3acb6071d72a471591678ded84218006e14", size = 7307182, upload-time = "2026-06-11T12:46:00.568Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1e/b47957057e729adc6cdf519a47f8be2562b7140e280f1418443eb4022192/grpcio-1.81.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e64dd101d380a115cc5a0c7856788adb535f1a4e21fc543775602f8be95180ae", size = 6810962, upload-time = "2026-06-11T12:46:03.312Z" },
+    { url = "https://files.pythonhosted.org/packages/40/26/569868e364e05b19ec8f969da53d230bcd89c962cd198f7c29943155c4d3/grpcio-1.81.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:98a07f9bf591e3a8919797bee1c53f026ba4acd587e5a4404c8e57c9ec36b2a5", size = 7415698, upload-time = "2026-06-11T12:46:06.005Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0c/5440a0582cb5653fc42a6e262eeb22700943313f8076f9dc927491b20a59/grpcio-1.81.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:c261d74b1a945cf895a9d6eccd1685a8e837531beaab782da4d630a8d12deffb", size = 8407779, upload-time = "2026-06-11T12:46:08.84Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/aa/66fe9f39871d766987d869a03ee0842a026f499c7b1e62decb9e78a8088e/grpcio-1.81.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:58ad1131c300d3c9b933802b3cc4dc69d380822935ba50b28703156ea826fbf7", size = 7844521, upload-time = "2026-06-11T12:46:12.171Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/9e/69bb7194861bcd28fb3193261d4f9c3831b4446993f002cf59068943e7ab/grpcio-1.81.1-cp313-cp313-win32.whl", hash = "sha256:78e29211f26da2fdd0e9c6d2b79f489476140cf7029b6a64808ade7ca4156a42", size = 4182786, upload-time = "2026-06-11T12:46:15.192Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/20/3da8bb0d637feccdc3e1e419bb511ce93651ce7d54164f95de22cc0b8b34/grpcio-1.81.1-cp313-cp313-win_amd64.whl", hash = "sha256:edb59506291b647a30884b1d51a599d605f40b20af4a7dc3d33786a47a31de60", size = 4928648, upload-time = "2026-06-11T12:46:17.823Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/58/19414622b1bf6981bc9c05a365bd548e71876c89000083b3af489251e9c0/grpcio-1.81.1-cp314-cp314-linux_armv7l.whl", hash = "sha256:506f48f2f9c29b143fca3dad7b0d518c188b6c9648c75a2ae6e2d9f2c13a060b", size = 6055336, upload-time = "2026-06-11T12:46:20.557Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f1/2ec88adb92b0eba970dd0e0e7dd086341daa3c75eba4f735f9e44bf684b0/grpcio-1.81.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d865db4a6318e1c1bea83292e0ed231090538fc4ca45425b0f0480eb338bbc6e", size = 12056279, upload-time = "2026-06-11T12:46:24.255Z" },
+    { url = "https://files.pythonhosted.org/packages/41/36/e8c5f8c6ec71de73733695ebc809e98b178b534ec6d8eaa31a7ebab4ad4c/grpcio-1.81.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e2aa72e3ce1770317ef534f63d397b55e130725f5149bd36077c3b539019db27", size = 6608225, upload-time = "2026-06-11T12:46:27.601Z" },
+    { url = "https://files.pythonhosted.org/packages/30/22/96fc577a845ab093326d9ab1adb874bd4936c8cf98ac8ed2f3db13a0a2fb/grpcio-1.81.1-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0490c30c261eded63f3f354979f9dc4502a9fb944cccb60cd9dc85f5a7349854", size = 7306576, upload-time = "2026-06-11T12:46:30.514Z" },
+    { url = "https://files.pythonhosted.org/packages/76/7b/61dab5d5969f28d97fb1009cead1df0a5cd987d3315e1b37f18a4449f8bc/grpcio-1.81.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:410482da976329fe5f4067270401b12cf2bd552ff8020f054ecfaddb5475f9d6", size = 6812165, upload-time = "2026-06-11T12:46:33.699Z" },
+    { url = "https://files.pythonhosted.org/packages/82/78/6e501929d4f5f96462fd82fd9f0f06e5f9612207582b862868d68757b27d/grpcio-1.81.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3657301562ac3cb8018d30d0d3ebfa39932239f7b5703422057ef14b69949f5", size = 7422962, upload-time = "2026-06-11T12:46:36.511Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7e/f2157589e66daa78ebb3165942d05a08bdea93b9d11c2bc1e172aef89685/grpcio-1.81.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:24c8e57504c8f45b237e40b99262d181071e5099a07053695b75d97bb53053a0", size = 8408176, upload-time = "2026-06-11T12:46:39.803Z" },
+    { url = "https://files.pythonhosted.org/packages/da/df/c6717fef716e00d235ffb96123baf6dce76d6004f6233fa767c502861460/grpcio-1.81.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b427c19380991a4eaab2f6144b64b99b412043314c6bf4ab544f97bb31ee4190", size = 7846681, upload-time = "2026-06-11T12:46:43.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/84/3502e9f210a6a5c4438c8aca3f88edd2e04f6a27f3d41b26cf0a0024b096/grpcio-1.81.1-cp314-cp314-win32.whl", hash = "sha256:61233fe8951e5c85dff81c2458b6528624760166946b5b47ea150a589168411f", size = 4264615, upload-time = "2026-06-11T12:46:45.741Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b0/4af731ff7492c68a96e4c71bfd0f4590acde92b31c6fe4894e6465c10ff6/grpcio-1.81.1-cp314-cp314-win_amd64.whl", hash = "sha256:3768a5ff1b2125e6f552e561b6b2dca0e64982d8949689b4df145cf8b98d7821", size = 5070275, upload-time = "2026-06-11T12:46:48.486Z" },
 ]
 
 [[package]]
@@ -1191,6 +1199,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpcore2"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/9b/2b1d1833a58236d1f6ee755e027a3917da0db59cc9708554cefc440ee8b6/httpcore2-2.4.0.tar.gz", hash = "sha256:3093a8ab8980d9f910b9cb4351df9186a0ad2350a6284a9107ac9a362a584422", size = 64618, upload-time = "2026-06-11T06:35:53.425Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/72/4fdf2306143a92a471fad9f3655aa542d43aa9188a7c9534e82c9aecf837/httpcore2-2.4.0-py3-none-any.whl", hash = "sha256:5218779da5d6e3c2013ac706121abfb3815d450e0613495c0de50264dce58242", size = 80151, upload-time = "2026-06-11T06:35:50.89Z" },
 ]
 
 [[package]]
@@ -1245,6 +1266,22 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx2"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/60/b43ced4ccf26e95b396dbf67051d3e5042b645917d4da0469dd82a3bdd4f/httpx2-2.4.0.tar.gz", hash = "sha256:32e0734b61eb0824b3f56a9e98d6d92d381a3ef12c0045aa917ee63df6c411ef", size = 81691, upload-time = "2026-06-11T06:35:54.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/45/82bc57c3d9c3314f663b67cc057f1c017a6450685dde513f4f8db5cf431f/httpx2-2.4.0-py3-none-any.whl", hash = "sha256:425acd99297829599decf6701386dd84db3542597d36d3e2e4def930ecd57fd9", size = 74941, upload-time = "2026-06-11T06:35:52.235Z" },
+]
+
+[[package]]
 name = "id"
 version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1267,11 +1304,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.16"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -1467,6 +1504,7 @@ dev = [
     { name = "fastapi", extra = ["standard"] },
     { name = "ggshield" },
     { name = "httpx" },
+    { name = "httpx2" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pylint" },
@@ -1493,6 +1531,7 @@ dev = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.136.0" },
     { name = "ggshield", specifier = ">=1.51.0" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "httpx2", specifier = ">=2.4.0" },
     { name = "mypy", specifier = ">=1.20.1" },
     { name = "pre-commit", specifier = ">=4.0.0" },
     { name = "pylint", specifier = ">=4.0.4" },
@@ -1583,27 +1622,25 @@ wheels = [
 
 [[package]]
 name = "marshmallow"
-version = "3.26.2"
+version = "4.3.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/55/79/de6c16cc902f4fc372236926b0ce2ab7845268dcc30fb2fbb7f71b418631/marshmallow-3.26.2.tar.gz", hash = "sha256:bbe2adb5a03e6e3571b573f42527c6fe926e17467833660bebd11593ab8dfd57", size = 222095, upload-time = "2025-12-22T06:53:53.309Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/7e/1dbd4096eb7c148cd2841841916f78820bb85a4d80a0c25c02d30815a7fb/marshmallow-4.3.0.tar.gz", hash = "sha256:fb43c53b3fe240b8f6af37223d6ef1636f927ad9bea8ab323afad95dff090880", size = 224485, upload-time = "2026-04-03T21:46:32.72Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/2f/5108cb3ee4ba6501748c4908b908e55f42a5b66245b4cfe0c99326e1ef6e/marshmallow-3.26.2-py3-none-any.whl", hash = "sha256:013fa8a3c4c276c24d26d84ce934dc964e2aa794345a0f8c7e5a7191482c8a73", size = 50964, upload-time = "2025-12-22T06:53:51.801Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/e0/ff24e25218bb59eb6290a530cea40651b14068b6e3659b20f9c175179632/marshmallow-4.3.0-py3-none-any.whl", hash = "sha256:46c4fe6984707e3cbd485dfebbf0a59874f58d695aad05c1668d15e8c6e13b46", size = 49148, upload-time = "2026-04-03T21:46:31.241Z" },
 ]
 
 [[package]]
 name = "marshmallow-dataclass"
-version = "8.5.14"
+version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "marshmallow" },
+    { name = "typeguard" },
     { name = "typing-inspect" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/20/f2/1af94d8e8432ddd80e30983b3c7fdeb4cf7c9b0790d6d4855c4343dbecde/marshmallow_dataclass-8.5.14.tar.gz", hash = "sha256:233c414dd24a6d512bcdb6fb840076bf7a29b7daaaea40634f155a5933377d2e", size = 19355, upload-time = "2023-04-27T16:58:49.713Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/23/a863a5d569f03454d733f884a72415ac3f1e1b1b3215de3a9f4f621a83a6/marshmallow_dataclass-8.7.1.tar.gz", hash = "sha256:4fb80e1bf7b31ce1b192aa87ffadee2cedb3f6f37bb0042f8500b07e6fad59c4", size = 32059, upload-time = "2024-09-12T16:18:51.952Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/56/997c3a603386f3736ab778e258f7ce7935219676744e4e9216e9f6932a95/marshmallow_dataclass-8.5.14-py3-none-any.whl", hash = "sha256:73859c8963774b5aad6b23ff3dd8456c8463e7c96bf5076051e1656fd4e101d0", size = 17699, upload-time = "2023-04-27T16:58:47.185Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/f5/6764f3f3203d14a0e6df0fce4838f8195ccc61ec7d48d7ed89acfb8adeed/marshmallow_dataclass-8.7.1-py3-none-any.whl", hash = "sha256:405cbaaad9cea56b3de2f85eff32a9880e3bf849f652e7f6de7395e4b1ddc072", size = 19111, upload-time = "2024-09-12T16:18:50.286Z" },
 ]
 
 [[package]]
@@ -2059,11 +2096,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.9.6"
+version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
 ]
 
 [[package]]
@@ -2354,7 +2391,7 @@ wheels = [
 
 [[package]]
 name = "pygitguardian"
-version = "1.30.0"
+version = "1.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "marshmallow" },
@@ -2363,9 +2400,9 @@ dependencies = [
     { name = "setuptools" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/d9/15e6d313c47c1e8753d7c0a274717b8841f34e9e187ba8a9f5b9598096f4/pygitguardian-1.30.0.tar.gz", hash = "sha256:fd6a43a2650d181c06d3e0a5c38b7a9ed9e4868bdd1997ce4e6c5863c94de9fe", size = 56271, upload-time = "2026-04-28T12:02:32.555Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/58/17a8fb8459871f0a7a758a64f492a282a1251b629789a6f72d80a6831fc4/pygitguardian-1.32.0.tar.gz", hash = "sha256:2bc9880c139dee3692bff369a10d42e99f58e4122358ce0d632b51e250e90252", size = 57374, upload-time = "2026-06-16T13:27:06.488Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/3e/aefd6fcc2fcb88dfe5fd1a026a3ca5d5ba87eb7baba3feea70ce4db117c4/pygitguardian-1.30.0-py3-none-any.whl", hash = "sha256:9ff6acb3e6a47ddc96fb4fc7f70dbe058ccb828c5cef67097ab5cef897c88219", size = 23518, upload-time = "2026-04-28T12:02:31.151Z" },
+    { url = "https://files.pythonhosted.org/packages/56/4a/b26702ad735fa24b0b93bfbb64cbe6a4a761304a767e8b3ce4b890dd8f6d/pygitguardian-1.32.0-py3-none-any.whl", hash = "sha256:7f0549565a4a7ef13be2ced9b2fd787cfe402bdd169c3e40e8057a63e0c06bf6", size = 23910, upload-time = "2026-06-16T13:27:05.556Z" },
 ]
 
 [[package]]
@@ -2388,7 +2425,7 @@ wheels = [
 
 [[package]]
 name = "pylint"
-version = "4.0.5"
+version = "4.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astroid" },
@@ -2399,27 +2436,27 @@ dependencies = [
     { name = "platformdirs" },
     { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/b6/74d9a8a68b8067efce8d07707fe6a236324ee1e7808d2eb3646ec8517c7d/pylint-4.0.5.tar.gz", hash = "sha256:8cd6a618df75deb013bd7eb98327a95f02a6fb839205a6bbf5456ef96afb317c", size = 1572474, upload-time = "2026-02-20T09:07:33.621Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/1d/3bb57f303701549550d74bf7ced2b07412be97125c167a0c9d216aa9f762/pylint-4.0.6.tar.gz", hash = "sha256:52f19191bee08bf103f9705ad1a0ece4aa5a0a4ef2bdcbd969375a1e6f6579d5", size = 1585588, upload-time = "2026-06-14T14:43:26.772Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl", hash = "sha256:00f51c9b14a3b3ae08cff6b2cdd43f28165c78b165b628692e428fb1f8dc2cf2", size = 536694, upload-time = "2026-02-20T09:07:31.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/da/acb2e7d4dbd2dfb792d38c0d850481f29ad7049b356d23f56c687d35203b/pylint-4.0.6-py3-none-any.whl", hash = "sha256:d11a0e1fdb7b1cd46ec5d6fc78fee8b95f28695b2d6140e5809925f61e32ea54", size = 538389, upload-time = "2026-06-14T14:43:24.873Z" },
 ]
 
 [[package]]
 name = "pyopenssl"
-version = "26.2.0"
+version = "26.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/51/27a5ad5f939d08f690a326ef9582cda7140555180db71695f6fb747d6a36/pyopenssl-26.2.0.tar.gz", hash = "sha256:8c6fcecd1183a7fc897548dfe388b0cdb7f37e018200d8409cf33959dbe35387", size = 182195, upload-time = "2026-05-04T23:06:09.72Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/b7/da07bae88f5a9506b4def6f2f4903cf4c3b8831e560dba8fa18ca08f758f/pyopenssl-26.3.0.tar.gz", hash = "sha256:589de7fae1c9ea670d18422ed00fc04da787bbde8e1454aea872aa57b49ad341", size = 182024, upload-time = "2026-06-12T20:28:07.458Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/b8/a0e2790ae249d6f38c9f66de7a211621a7ab2650217bcd04e1262f578a56/pyopenssl-26.2.0-py3-none-any.whl", hash = "sha256:4f9d971bc5298b8bc1fab282803da04bf000c755d4ad9d99b52de2569ca19a70", size = 55823, upload-time = "2026-05-04T23:06:08.395Z" },
+    { url = "https://files.pythonhosted.org/packages/54/18/1dd71c9b43192ab83f1d531ad6002dc81108ac36c475f79fb7a295abe2f4/pyopenssl-26.3.0-py3-none-any.whl", hash = "sha256:46367f8f66b92271e6d218da9c87607e1ef5a0bc5c8dea5bb3db82f395c385a3", size = 56008, upload-time = "2026-06-12T20:28:05.999Z" },
 ]
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -2428,9 +2465,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
 ]
 
 [[package]]
@@ -2462,14 +2499,15 @@ wheels = [
 
 [[package]]
 name = "pytest-env"
-version = "1.2.0"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
+    { name = "python-dotenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/13/12/9c87d0ca45d5992473208bcef2828169fa7d39b8d7fc6e3401f5c08b8bf7/pytest_env-1.2.0.tar.gz", hash = "sha256:475e2ebe8626cee01f491f304a74b12137742397d6c784ea4bc258f069232b80", size = 8973, upload-time = "2025-10-09T19:15:47.42Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/69/4db1c30625af0621df8dbe73797b38b6d1b04e15d021dd5d26a6d297f78c/pytest_env-1.6.0.tar.gz", hash = "sha256:ac02d6fba16af54d61e311dd70a3c61024a4e966881ea844affc3c8f0bf207d3", size = 16163, upload-time = "2026-03-12T22:39:43.78Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/98/822b924a4a3eb58aacba84444c7439fce32680592f394de26af9c76e2569/pytest_env-1.2.0-py3-none-any.whl", hash = "sha256:d7e5b7198f9b83c795377c09feefa45d56083834e60d04767efd64819fc9da00", size = 6251, upload-time = "2025-10-09T19:15:46.077Z" },
+    { url = "https://files.pythonhosted.org/packages/27/16/ad52f56b96d851a2bcfdc1e754c3531341885bd7177a128c13ff2ca72ab4/pytest_env-1.6.0-py3-none-any.whl", hash = "sha256:1e7f8a62215e5885835daaed694de8657c908505b964ec8097a7ce77b403d9a3", size = 10400, upload-time = "2026-03-12T22:39:41.887Z" },
 ]
 
 [[package]]
@@ -2498,15 +2536,15 @@ wheels = [
 
 [[package]]
 name = "python-discovery"
-version = "1.3.1"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/60/e88788207d81e46362cfbef0d4aaf4c0f49efc3c12d4c3fa3f542c34ebec/python_discovery-1.3.1.tar.gz", hash = "sha256:62f6db28064c9613e7ca76cb3f00c38c839a07c31c00dfe7ed0986493d2150a6", size = 68011, upload-time = "2026-05-12T20:53:36.336Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/1a/cbbaf13b730abb0a16b964d984e19f2fe520c21a4dc664051359a3f5a9e7/python_discovery-1.4.2.tar.gz", hash = "sha256:8f3746c4b4968d22afbb97d36e1a0e5b66e6c0f297290f2e95f05b9b8bf18690", size = 70277, upload-time = "2026-06-11T16:10:42.383Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/6f/a05a317a66fee0aad270011461f1a63a453ed12471249f172f7d2e2bc7b4/python_discovery-1.3.1-py3-none-any.whl", hash = "sha256:ed188687ebb3b82c01a17cd5ac62fc94d9f6487a7f1a0f9dfe89753fec91039c", size = 33185, upload-time = "2026-05-12T20:53:34.969Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/82/a70006589557f267f15bd384c0642ad49f0d97b690c3a05b166b9dcbad3b/python_discovery-1.4.2-py3-none-any.whl", hash = "sha256:475803f53b7b2ed6e490e27373f9d8340f7d2eebf9acdaf645d7d714c97bb500", size = 33886, upload-time = "2026-06-11T16:10:41.192Z" },
 ]
 
 [[package]]
@@ -2520,40 +2558,43 @@ wheels = [
 
 [[package]]
 name = "python-gitlab"
-version = "8.3.0"
+version = "8.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
     { name = "requests-toolbelt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/00/9a9eb79cf3608f9ab172bc6311b40a7ed128cae7be42dbf2d3830d713a48/python_gitlab-8.3.0.tar.gz", hash = "sha256:2ca67cf64b8d9290fe64463cfef6e77dbde066285dd848db2eb7816d6a7e9ec9", size = 410332, upload-time = "2026-04-28T02:32:30.16Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/96/c20b37e7fd86481e1bf2b1922e84b98dc5477fd9aafd30e5c5086f94d922/python_gitlab-8.4.0.tar.gz", hash = "sha256:f36f20ec3f09138f3b12089394941f4dbe5a407021bed71b70a04bbdd37b8a74", size = 410803, upload-time = "2026-05-28T02:43:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/b1/3e3144c3ada2ae1a60a378396629064ef14e425e356c8e7c1db3a50ef351/python_gitlab-8.3.0-py3-none-any.whl", hash = "sha256:7aace3585d57ee97ebcb74bc776f30af3e861e285290082a91646348aca3f22a", size = 148177, upload-time = "2026-04-28T02:32:28.133Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/af/1c3540dbdccb85fca0b0bbc58cdaf514d0a830d7e0302b2059a6c627b172/python_gitlab-8.4.0-py3-none-any.whl", hash = "sha256:102c747d9c107820e215cc5913627388001592a9a3ba1b43fc341a40f6943e72", size = 148242, upload-time = "2026-05-28T02:43:31.505Z" },
 ]
 
 [[package]]
 name = "python-multipart"
-version = "0.0.31"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/64/7e/9b35ad8f3d9ca680f7c87a88f19612fdd8da9796c4d3b46e560ac79dcc4a/python_multipart-0.0.31.tar.gz", hash = "sha256:fc631183bb13e56db3158a4909908dfb2e23565286744e798241e63750e5d680", size = 46689, upload-time = "2026-06-04T08:27:49.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/1e/7f7f299527a5a8ad90acd5f2f78dfa6c8495c6301a3205106ea68a84de96/python_multipart-0.0.31-py3-none-any.whl", hash = "sha256:8408153d68a9773291fc1da39a8b85a50044bddbabd2dd72e9229776b7b15e28", size = 29996, upload-time = "2026-06-04T08:27:47.804Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]
 name = "pywin32"
-version = "311"
+version = "312"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
-    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
-    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
 ]
 
 [[package]]
@@ -2697,16 +2738,16 @@ wheels = [
 
 [[package]]
 name = "rich-toolkit"
-version = "0.19.10"
+version = "0.20.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/02/32217f3657ae91a0ea7cf1d74ade78f44352f830d00c468f753ddb3d4980/rich_toolkit-0.19.10.tar.gz", hash = "sha256:dc2e8c515ef9fbb4894e62bd41a2d2960dd7c2f505b5084894604d5ccfee3f09", size = 198167, upload-time = "2026-05-21T10:11:42.397Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/63/3e427c62f1992945c997d4ec31e2fcb37d26aadbe5aa44ae5b29f7f64d26/rich_toolkit-0.20.1.tar.gz", hash = "sha256:c7336ae281f435c785acecaedc4b71d4b663dc73d9c8079fea96372527e822a4", size = 203473, upload-time = "2026-06-05T08:56:57.679Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/84/a005adcb4d1e6846ba3d62768090c3b943e3f6d8dc5c47af64f33584c4a7/rich_toolkit-0.19.10-py3-none-any.whl", hash = "sha256:93a41f67a09aefe90379f1729495c2fee9ccbcc8cfda48e2ca2ae54a995e32b1", size = 33907, upload-time = "2026-05-21T10:11:43.578Z" },
+    { url = "https://files.pythonhosted.org/packages/00/88/309f07d08155da2ba1d5ceb42d270fb42fbe34a807684543e3ffc10fe713/rich_toolkit-0.20.1-py3-none-any.whl", hash = "sha256:2a6d5f8e15759b9eba5a9ee63da10b275359ead20e5a0fc92bd5b4dbae8ce4bf", size = 35525, upload-time = "2026-06-05T08:56:58.586Z" },
 ]
 
 [[package]]
@@ -2779,27 +2820,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.14"
+version = "0.15.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dc/8a/8bce2894573e9dae6ff4d77fe34ad727d79b9e6238ad288c5638990d90f6/ruff-0.15.14.tar.gz", hash = "sha256:48e866b165be4a9bdbf310f7d3c9a07edef2fe8cd63ffeb4e00bb590506ebf9f", size = 4700910, upload-time = "2026-05-21T14:34:55.177Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/a9/3abdf488f1bf3d24c699415e454ed554a6350d5d89ce183be1ee0a3361ac/ruff-0.15.17.tar.gz", hash = "sha256:2ec446937fd16c8c4de2674a209cc5af64d9c6f17d21fbf1151054fa0bcf5219", size = 4743346, upload-time = "2026-06-11T17:54:47.663Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/c8/74a92c6ff9fcfb4f1f947126d3ebee8389276e161ecc85de5bda7cda51bd/ruff-0.15.14-py3-none-linux_armv6l.whl", hash = "sha256:8dd2db9416e487c8d4b01fa7056bb02c4d05969d4f8d17a08c229c2f4ff3c108", size = 10739177, upload-time = "2026-05-21T14:34:37.332Z" },
-    { url = "https://files.pythonhosted.org/packages/45/91/254a35c20acc38a7223c9d2d594af12e794432464f2cdeb52af1dc4a892d/ruff-0.15.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:be4ff55af755bd71a00ab3dc6bd7ffc467bd76e0df6881e286c2e3d23e8fb43b", size = 11144969, upload-time = "2026-05-21T14:34:43.978Z" },
-    { url = "https://files.pythonhosted.org/packages/56/9e/d13e40f83b8d0a94430e6778ce1d94a43b38cf2efe63278bdd2b4c65abbf/ruff-0.15.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:48d5909d7d06276ce7dde6d32bfa4b0d4cb2651145cd8ee4b440722cbc77832f", size = 10478207, upload-time = "2026-05-21T14:34:48.378Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/f1/b15a7839fa4f332f8acec78e20564f26bb2d866e3d21710b877fd0263000/ruff-0.15.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca8cbfa94c4f90984a67561978602746d4cd27103568f745fa90eee3f0d4107d", size = 10818459, upload-time = "2026-05-21T14:34:22.318Z" },
-    { url = "https://files.pythonhosted.org/packages/45/33/53d651177f84f94b400a0e27f8824eeada3dddc9d5ee8aeb048f4352a520/ruff-0.15.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9a6bbc0333f1ab053423bcbf6226477d266ca7cec7738c4c8e3f55647803f3c4", size = 10541800, upload-time = "2026-05-21T14:34:20.209Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/a6/868f87e0bf9786ed24b5d0d0ad8676b8a94fd1912f42cddf9cfc7857818a/ruff-0.15.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a24a4f7605d7003a6674d4387651effd939dead3fddd0f36561eb77a9a2e542", size = 11342149, upload-time = "2026-05-21T14:34:46.365Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/8b/38cd5c19faffdcc05a408d2b78edccc69492ab9720eadb49ea15ef80d768/ruff-0.15.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:049b5326e53ed80978f2fc041a280603f69dd6b0c95464342a2bb4572d9d9e2f", size = 12212563, upload-time = "2026-05-21T14:34:28.579Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/4d/a3c5b874a556d5731e3e657aaf04311bb76f0a5c3ec220ed43051be6b64b/ruff-0.15.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4ed42e6696c8dfa5f06728e6441993901f548eb92d73bc472cb5a38d1395fbf", size = 11493299, upload-time = "2026-05-21T14:34:41.836Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/c0/56472c251d09858a53e51efbd485b09e1995d8731668b76d52e5dd6ee0f1/ruff-0.15.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:715c543cf450c4888251f91c52f1942a800541d9bddd7ac060aa4e6b77ae7cba", size = 11455931, upload-time = "2026-05-21T14:34:57.276Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/4a/e2e7b4d8dbf233d4eace59c75bc3435fa6d8bd3bae82d351d4e4300c0fd1/ruff-0.15.14-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:72ebab6013ec887d439d8b7593737a0a4ffb06d45d209d4e4bf2e92813082d3f", size = 11400794, upload-time = "2026-05-21T14:34:39.773Z" },
-    { url = "https://files.pythonhosted.org/packages/97/c7/83c0539fe34c3e09136204d1e75d6052492364e0b3cb05e9465423f567d7/ruff-0.15.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:49072d36abdbe97a8dd7f480afe9c675699c0c495d4c84076e2c1203c4550581", size = 10804759, upload-time = "2026-05-21T14:34:31.045Z" },
-    { url = "https://files.pythonhosted.org/packages/86/a6/18f2bfc095a2ab4a78745644e428205532ce6653a5d0fa8501572891534d/ruff-0.15.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:958522aee105068640c2c2ceae08f413ae44d922f52a1374ac13d6a96032fc93", size = 10539517, upload-time = "2026-05-21T14:34:53.064Z" },
-    { url = "https://files.pythonhosted.org/packages/54/3a/5a8b3b69c654d4e4bf1d246ac5b49cbcdac6eaab6905925f8915f31e3b80/ruff-0.15.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f3707da619a143a2e8830e2abab8224478d69ace2d28cb6c20543ae97c36bf61", size = 11065169, upload-time = "2026-05-21T14:34:24.484Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/c5/8864e4e7925b836ea354b31d57641ec03830564e281a8b6f061f8c3e0ec1/ruff-0.15.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:bb01d645694e3ec0102105d07ef2d53703970407d59c04e59d3ba0b7a1d53553", size = 11560214, upload-time = "2026-05-21T14:34:50.975Z" },
-    { url = "https://files.pythonhosted.org/packages/36/38/012bf76752e1f89ed50b77b99532d90f3a3e287bc7918e1fc0948ac866ac/ruff-0.15.14-py3-none-win32.whl", hash = "sha256:6d0c1ad2a0ab718d39b6d8fd2217981ce4d625cd96a720095f798fb47d8b13e6", size = 10805548, upload-time = "2026-05-21T14:34:33.453Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/b7/4ea2c170f10ad760fff2a5250beb18897719dc8b52b53a24cddbb9dd3f19/ruff-0.15.14-py3-none-win_amd64.whl", hash = "sha256:802342981e056db3851a7836e5b070f8f15f67d4a685ae2a6160939d364b2902", size = 11939523, upload-time = "2026-05-21T14:34:18.077Z" },
-    { url = "https://files.pythonhosted.org/packages/62/d5/bc97ff895ec35cf3925d4bd60f3b39d822f377a446906ec9bcc87405e59b/ruff-0.15.14-py3-none-win_arm64.whl", hash = "sha256:ff47b90a9ef6a40c9e2f3b479c1fb78531adf055b94c1eba0a7ba04b31951826", size = 11208607, upload-time = "2026-05-21T14:34:26.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4d/e11259f5da07cb6afb2d074c31bf09da9671993f7329d4f15d2fdc458301/ruff-0.15.17-py3-none-linux_armv6l.whl", hash = "sha256:d9feddb927fc68bd295f5eebc587a7e42cfaf9b65f60ca4a2386febff575da8f", size = 10856677, upload-time = "2026-06-11T17:54:49.533Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3e/772d679e1a0dc058e58875bd2c0cb713a0530877b4a76fee3c7966df0d49/ruff-0.15.17-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:25805a226d741c47d274a35ad5c10a7dde175fcddfa511d7cf3da0a21eb3eab7", size = 11223443, upload-time = "2026-06-11T17:55:00.573Z" },
+    { url = "https://files.pythonhosted.org/packages/68/58/bd41f7688b2fd5623012605130ed70e60aa7f2244baa3d5066bdd61530c8/ruff-0.15.17-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f6ad73b14c2d18a3bf8ad7cb6974294d7f613a7898604826058e6ac64918ef4d", size = 10566458, upload-time = "2026-06-11T17:55:07.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5b/733371013fcf1ec339e477ece6ab42bfe10bdd9bba8ee88a9516aa56bfc0/ruff-0.15.17-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ba0c1e4f95bcb3869d0d30cbd5917071ef2e28665abfec970cdab0492c713ed", size = 10914483, upload-time = "2026-06-11T17:55:05.501Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/cc/6f24251cc0252f7239391ccb85833f320efad14ebe5b443943f37ced6332/ruff-0.15.17-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:81647960f10bff57d2e51cadd0c3950fe598400c852863a038720ef5b8cca91e", size = 10647497, upload-time = "2026-06-11T17:54:57.733Z" },
+    { url = "https://files.pythonhosted.org/packages/68/dd/0d10c17ce1a1624d6fc3156309c3f834fdb5dfaad026ec90c85684f3990e/ruff-0.15.17-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e01a84ddbc8c16c23055ba3924476850f1bbc1917cebbb9376665a63e74260d", size = 11416967, upload-time = "2026-06-11T17:54:51.461Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/91/556bfb156f6144f355e831c23db00b2fc4120f86b3ce81cc5f7fd2df51f3/ruff-0.15.17-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:84fe9f653152f8f294f9f7e03bf3a453d8b4a27f7a59c78c8666167f2b17b96c", size = 12335770, upload-time = "2026-06-11T17:54:45.793Z" },
+    { url = "https://files.pythonhosted.org/packages/88/82/8b5999aa13355e926f06d9f42a32dcca862f623bf0363785ff89d607dffd/ruff-0.15.17-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c0fe88a7676e7a05b73174d4d4a59cb2ac21ff8263583f87a81a6018475a978", size = 11575441, upload-time = "2026-06-11T17:54:32.661Z" },
+    { url = "https://files.pythonhosted.org/packages/11/93/f10377bb04109ca0e8cbc483ff1982c54b6d418210041776f93e8cdc7fa9/ruff-0.15.17-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecfc3c7878fff94633ab0348524e093f9ce3243080416dd7d14f8ba400174719", size = 11557614, upload-time = "2026-06-11T17:54:34.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a6/eeeae7f7d5493df41649ab3db92f086b2d0a30199e4efdf8e3dd7a033f24/ruff-0.15.17-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:b8461180b22420b1bdc289909410930761629fddf2a5aaf60fae1ab26cedc4c4", size = 11544450, upload-time = "2026-06-11T17:54:39.042Z" },
+    { url = "https://files.pythonhosted.org/packages/32/88/5991ce565129a24dd4a00db1254b3b5db2e53018cbe4018ea5a89738e727/ruff-0.15.17-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6eccbe50a038b503e7140b441aa9c7fc8c1f36edf23ebef9f4165c2f28f568b7", size = 10892524, upload-time = "2026-06-11T17:55:09.432Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/1d/0fdd248313425f55223968af04b0a42125466a8d88d21c1d99c6af0a51e8/ruff-0.15.17-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:382fc0521025f5a8ad447d8bdd523545d0d7646adb718eb1c2dac5065ec27c0f", size = 10659573, upload-time = "2026-06-11T17:54:36.824Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/0e/072e8260deb9461062ce9311ced27a8e541229a6ffd483013dd37661e43e/ruff-0.15.17-py3-none-musllinux_1_2_i686.whl", hash = "sha256:456d41fcd1b2777ad63f09a6e7121d43f7b688bbc76a800c10f7f8fb1f912c3f", size = 11127818, upload-time = "2026-06-11T17:55:03.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/b4/55060a34163121498014696b5f656db5b8c6963768f227dbf0d76b311073/ruff-0.15.17-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b1a04bcc94ae6194e9db05d16ad31f298a7194bfbcb08258bbe589cee1d587b8", size = 11655901, upload-time = "2026-06-11T17:54:53.562Z" },
+    { url = "https://files.pythonhosted.org/packages/49/71/9b29d6b87cef468d697f43c6a91e3fae4a80185779d7d5a4ef27d173439f/ruff-0.15.17-py3-none-win32.whl", hash = "sha256:596065960ab1ff593f744220c9fe6580eda00a95003cffa9f4048bb5b1bf0392", size = 10925574, upload-time = "2026-06-11T17:54:55.723Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b2/8fc77f3723228836fa5d12497eb71c808f83782e10d058d2b15cfa14640b/ruff-0.15.17-py3-none-win_amd64.whl", hash = "sha256:6769e5fa1710b179b92e0bfa5a51735b35baea9013dadb06d5f44cbcf9547084", size = 12058788, upload-time = "2026-06-11T17:54:41.042Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c7/c53e8dbff9c9dc4b7928773421ae294a5d28fcb8dcda1a089579d3a7e510/ruff-0.15.17-py3-none-win_arm64.whl", hash = "sha256:f3be1fbb34bcdfd146240d8fb92a709d4c2c8191348580a3c044ec60fa0b4456", size = 11355275, upload-time = "2026-06-11T17:54:43.635Z" },
 ]
 
 [[package]]
@@ -2826,15 +2867,15 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.60.0"
+version = "2.63.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/54/a2/2e6c090db384cc515069f4f85542bd5baf6786852073020ea73d4a76d3ea/sentry_sdk-2.60.0.tar.gz", hash = "sha256:0bd25e54e78ca02d0be512529fa644bbbf9e8470d7b26371294012d4ca93c978", size = 452946, upload-time = "2026-05-13T13:34:52.516Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/c8/b3c970a5b186722d276cd40a05b3254e03bccc0208560aff20f612e018e8/sentry_sdk-2.63.0.tar.gz", hash = "sha256:2a1502bf864769275dbc8c2c9fc7a0f7f5e18358180b615d262d13a31ffba216", size = 912449, upload-time = "2026-06-16T12:45:57.553Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/41/f2b800b7f12a05dd48c2a6280d4dd812d1425fc66ed3fe3fd99420c41d1a/sentry_sdk-2.60.0-py3-none-any.whl", hash = "sha256:28a536c03291c8bcb363cf35c611b32738ec118ff64d8d6383b096448ac4c803", size = 475616, upload-time = "2026-05-13T13:34:50.259Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/57/cb205f7d93373120f666b9c5736dc0815524d96a9b278e7a728f018dc22a/sentry_sdk-2.63.0-py3-none-any.whl", hash = "sha256:3a9b5ddd403f79eb73bd670f75f04485819db53d28f76ced7bc09041cb0dfd6a", size = 495950, upload-time = "2026-06-16T12:45:55.819Z" },
 ]
 
 [[package]]
@@ -2925,15 +2966,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.1.0"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/66/4d20cdf39a8d6a51e663b7038e3b828ff211d3891a43a713fe7e4643f3a8/starlette-1.1.0.tar.gz", hash = "sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f", size = 2660060, upload-time = "2026-05-23T16:55:41.376Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl", hash = "sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382", size = 72899, upload-time = "2026-05-23T16:55:39.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]
@@ -3048,8 +3089,20 @@ wheels = [
 ]
 
 [[package]]
+name = "typeguard"
+version = "4.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/1c/dfba5c4633cafc4c701f237d2ba63b416805047fd6d96aab4cfc40969f98/typeguard-4.5.2.tar.gz", hash = "sha256:5a16dcac23502039299c97c8941651bc33d7ea8cc4b2f7d6bbb1b528f6eea423", size = 80240, upload-time = "2026-05-14T12:59:40.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/29/74eeb4d3f3ae61ca096b018ad486b3b3c74b17bec09ab4edab721cbefec3/typeguard-4.5.2-py3-none-any.whl", hash = "sha256:fcf9de18bd945cdb4c7b996e12b4c51ce83f92f191314a6d7cf1739586ec98cf", size = 36748, upload-time = "2026-05-14T12:59:39.473Z" },
+]
+
+[[package]]
 name = "typer"
-version = "0.26.2"
+version = "0.26.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -3057,9 +3110,9 @@ dependencies = [
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/67/a5/756f2e6bc81a7dd79aa3c625dd01b74cabc4516628cace2caaec09ca6ff2/typer-0.26.2.tar.gz", hash = "sha256:9b4f19e08fcc9427a822d1ef467b1fe76737a2f65c7926bdeba2337d73569b68", size = 198991, upload-time = "2026-05-27T10:41:39.166Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/ed/ef06584ccdd5c410df0837951ecd7e15d9a6144ea1bd4c73cecab1a89891/typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a", size = 201709, upload-time = "2026-06-03T07:18:06.843Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/a5/6ffd702beda8798b2b82ff70805ed4a66d963557e43a5d1823ab456251a4/typer-0.26.2-py3-none-any.whl", hash = "sha256:39beff72ffbb31978a5b545f677d57edb97c6f980f433b38556deb0af25f094d", size = 123123, upload-time = "2026-05-27T10:41:40.504Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl", hash = "sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58", size = 122456, upload-time = "2026-06-03T07:18:05.732Z" },
 ]
 
 [[package]]
@@ -3116,14 +3169,14 @@ wheels = [
 
 [[package]]
 name = "tzlocal"
-version = "5.3.1"
+version = "5.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/55/15e2340963d2bfedcc6042da3911438fd336f8ae96b65bdbe3a29766da0c/tzlocal-5.4.3.tar.gz", hash = "sha256:3a8c9bc18cf47e1dcde252ea0e6a72a6cde320a400b6ac6db1f1f8cccd553c00", size = 30873, upload-time = "2026-06-17T04:17:41.764Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
+    { url = "https://files.pythonhosted.org/packages/42/28/fc144409c71569e928585f8f3c629d80d1ca3ef40175e9222f01588f98c9/tzlocal-5.4.3-py3-none-any.whl", hash = "sha256:24ce97bb58e2a973f7640ec2553ab4e6f6d5a0d0d1aa9dc43bca21d89e1feb82", size = 18039, upload-time = "2026-06-17T04:17:40.027Z" },
 ]
 
 [[package]]
@@ -3137,15 +3190,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.48.0"
+version = "0.49.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/bf/f6544ba992ddb9a6077343a576f9844f7f8f06ab819aefd00206e9255f18/uvicorn-0.48.0.tar.gz", hash = "sha256:a5504207195d08c2511bf9125ede5ac4a4b71725d519e758d01dcf0bc2d31c37", size = 91074, upload-time = "2026-05-24T12:08:41.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/be/72532be3da7acc5fdfbccdb95215cd04f995a0886532a5b423f929cda4cc/uvicorn-0.48.0-py3-none-any.whl", hash = "sha256:48097851328b87ec36117d3d575234519eb58c2b22d79666e9bbc6c49a761dad", size = 71410, upload-time = "2026-05-24T12:08:40.258Z" },
+    { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
 ]
 
 [package.optional-dependencies]
@@ -3202,7 +3255,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.3.3"
+version = "21.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -3210,9 +3263,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/ba/1f6e8c957e4932be060dcdc482d339c12e0216351478add3645cdaa53c05/virtualenv-21.3.3.tar.gz", hash = "sha256:f5bda277e553b1c2b3c1a8debfc30496e1288cc93ce6b7b71b3280047e317328", size = 7613784, upload-time = "2026-05-13T18:01:30.19Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/a5/81f987504738e6defeed61ec1c47e2aefab3c35d8eeb87e1b3f38cf28254/virtualenv-21.5.1.tar.gz", hash = "sha256:dca3bf98275a59c652b69d68e73433e597d977c2da9198882479d1a7188009c8", size = 4578798, upload-time = "2026-06-16T16:23:58.603Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/34/a9dbe051de88a63eb7408ea66630bac38e72f7f6077d4be58737106860d9/virtualenv-21.3.3-py3-none-any.whl", hash = "sha256:7d5987d8369e098e41406efb780a3d4ca79280097293899e351a6407ee153ab3", size = 7594554, upload-time = "2026-05-13T18:01:27.815Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl", hash = "sha256:55aa670b67bbfb991b03fda39bd3276d92c419d702376e98c5df1c9989a26783", size = 4558820, upload-time = "2026-06-16T16:23:56.963Z" },
 ]
 
 [[package]]
@@ -3303,11 +3356,11 @@ wheels = [
 
 [[package]]
 name = "wcwidth"
-version = "0.7.0"
+version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/b4/51fe890511f0f242d07cb1ebe6a5b6db417262b9d2568b460347c57d95cc/wcwidth-0.8.1.tar.gz", hash = "sha256:faf5b4a5366a72dc49cad48cdf21f52bdf63bdda995178e483ba247ff79089b9", size = 1466072, upload-time = "2026-06-08T05:57:23.146Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl", hash = "sha256:f453740b1e4a4f3291faa37944c555d71056c4da08d59809b307ef4feba695c8", size = 323092, upload-time = "2026-06-08T05:57:21.413Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
* added gitlab titles, description and tags for a nicer DataHUB experience.
* This required introducing the class `GitProjectMetadata`.
* Also improved the API interface models by introducing the model `GitProjectMetadata` to check if the RO-Crate JSON-LD conforms to the minimal requirements (having a `@graph` and a `@context` element and a root Entity defining an `idenitifier`). This is a BREAKING CHANGE! (although it is not considered that this will have an actual breaking effect on productive operation).
* Fixed inconsistencies in the specs
* updated dependencies

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens the public ARC wire contract and changes the ingest/Git sync path (including GitLab project updates on every sync); well-covered by tests but may reject previously accepted payloads or alter existing GitLab project fields.
> 
> **Overview**
> Improves the DataHub/GitLab experience by setting **human-readable project titles** (`{identifier} ({rdi})`), **descriptions** from RO-Crate `name`/`description`, and **RDI topics** on create and on later syncs, while keeping the Git **path** as stable `arc_id`. `GitRepo` passes `rdi` into `ArcStore` and builds `GitProjectMetadata` via `git_project_metadata_from_arc`.
> 
> ARC ingest now centers on shared **`RoCratePayload`** validation (`@context`, `@graph`, root `./`, non-empty `identifier`) through **`parse_rocrate`** instead of ad-hoc `extract_identifier`. v2/v3 request models and the **API client** validate before upload; **`store_arc`** requires a pre-extracted identifier, and **`calculate_arc_id`** strips whitespace on identifier/RDI. API ingest stays lightweight (no arctrl); the worker still parses with arctrl for Git sync.
> 
> Specs are aligned with harvest stats at finalize (not per-ARC increments) and related HTTP contracts. Devcontainers switch to **signageos SOPS**, add a **Cursor Ruff CLI install** workaround, ignore `*.decrypted.*`, and refresh tool/test paths (`httpx2`, mypy/pyright/pylint roots).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34554a1475ee815d396874c5ad4f0eef5bd40c84. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->