### PR TITLE
Add content hash utilities for RO-Crate change detection

### DIFF
--- a/.github/workflows/reusable-code-quality.yml
+++ b/.github/workflows/reusable-code-quality.yml
@@ -59,7 +59,7 @@ jobs:
           uv run ruff format --check --diff middleware/
           uv run ruff check middleware/
           uv run pylint middleware/
-          uv run mypy middleware/
+          uv run mypy --config-file pyproject.toml middleware/
 
       - name: Security check with bandit
         if: ${{ !inputs.skip }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,13 +46,13 @@ repos:
         files: ^middleware/
         pass_filenames: false
 
-      # mypy - Type checking
+      # mypy - Type checking (full middleware/ tree; same as CI and IDE extension)
       - id: mypy
         name: mypy type check
-        entry: uv run mypy
+        entry: uv run mypy middleware/
         language: system
-        types: [python]
         files: ^middleware/
+        pass_filenames: false
         args: [--config-file, pyproject.toml]
 
       # bandit - Security linting

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -39,6 +39,11 @@
   "sops.binPath": "sops",
 
   "mypy.configFile": "pyproject.toml",
+  "mypy-type-checker.args": [
+    "--config-file",
+    "${workspaceFolder}/pyproject.toml"
+  ],
+  "mypy-type-checker.reportingScope": "workspace",
 
   // Ruff Extension Settings - use same execution mode as pre-commit and CI
   "ruff.path": ["uv", "run", "ruff"],

--- a/middleware/api/src/middleware/api/document_store/content_hash.py
+++ b/middleware/api/src/middleware/api/document_store/content_hash.py
@@ -1,0 +1,41 @@
+"""Content-hash helpers for RO-Crate change detection."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+# JSON shapes produced by ``json.loads`` / consumed by ``json.dumps``.
+type JsonPrimitive = str | int | float | bool | None
+type JsonValue = JsonPrimitive | list[JsonValue] | dict[str, JsonValue]
+
+# Top-level RO-Crate document stored in CouchDB (``@context``, ``@graph``, …).
+type RoCrateContent = dict[str, JsonValue]
+
+# arctrl ToROCrateJsonString() refreshes these on every serialization even when
+# semantic ARC content is unchanged (see arctrl round-trip behaviour).
+_VOLATILE_ROCRATE_FIELDS = frozenset({"datePublished", "sdDatePublished", "dateModified"})
+
+
+def strip_volatile_rocrate_fields(value: RoCrateContent) -> RoCrateContent:
+    """Return a copy of RO-Crate JSON with serialization timestamps removed."""
+
+    def _strip(node: JsonValue) -> JsonValue:
+        if isinstance(node, dict):
+            return {key: _strip(item) for key, item in node.items() if key not in _VOLATILE_ROCRATE_FIELDS}
+        if isinstance(node, list):
+            return [_strip(item) for item in node]
+        return node
+
+    stripped = _strip(value)
+    if not isinstance(stripped, dict):
+        msg = "RO-Crate content must be a JSON object"
+        raise TypeError(msg)
+    return stripped
+
+
+def calculate_arc_content_hash(arc_content: RoCrateContent) -> str:
+    """SHA-256 of normalized RO-Crate JSON (volatile timestamp fields excluded)."""
+    normalized = strip_volatile_rocrate_fields(arc_content)
+    json_str = json.dumps(normalized, sort_keys=True)
+    return hashlib.sha256(json_str.encode("utf-8")).hexdigest()

--- a/middleware/api/src/middleware/api/document_store/couchdb.py
+++ b/middleware/api/src/middleware/api/document_store/couchdb.py
@@ -1,13 +1,12 @@
 """CouchDB implementation of DocumentStore."""
 
-import hashlib
-import json
 import logging
 import uuid
 from datetime import UTC, datetime
 from typing import Any
 
 from middleware.api.document_store.config import CouchDBConfig
+from middleware.api.document_store.content_hash import calculate_arc_content_hash
 from middleware.api.document_store.couchdb_client import CouchDBClient
 from middleware.api.utils import calculate_arc_id
 from middleware.shared.api_models.common.models import ArcEventType, ArcLifecycleStatus, HarvestStatus
@@ -40,17 +39,6 @@ class CouchDB(DocumentStore):
         self._db_name = config.db_name
         self._client = CouchDBClient.from_config(config)
 
-    @staticmethod
-    def _calculate_content_hash(arc_content: dict[str, Any]) -> str:
-        """Calculate SHA256 hash of ARC content.
-
-        Note: We use sort_keys=True to ensure consistent hashing even if
-        the JSON dictionary order or whitespace changes.
-        """
-        # orjson is faster if available, but standard json is fine for relatively small dicts
-        json_str = json.dumps(arc_content, sort_keys=True)
-        return hashlib.sha256(json_str.encode("utf-8")).hexdigest()
-
     async def store_arc(
         self,
         rdi: str,
@@ -65,7 +53,7 @@ class CouchDB(DocumentStore):
         arc_id = calculate_arc_id(identifier, rdi)
         doc_id = f"arc_{arc_id}"
 
-        content_hash = self._calculate_content_hash(arc_content)
+        content_hash = calculate_arc_content_hash(arc_content)
         now = datetime.now(UTC)
 
         # Check existing document
@@ -97,17 +85,20 @@ class CouchDB(DocumentStore):
             # Reject duplicate submissions within the same harvest run.
             if harvest_id and existing_doc.metadata.last_harvest_id == harvest_id:
                 raise DuplicateArcError(f"ARC '{identifier}' was already submitted in harvest '{harvest_id}'.")
-            # Check for changes
-            has_changes = existing_doc.metadata.arc_hash != content_hash
+            # Compare normalized content, not the stored hash field, so documents
+            # written before volatile-field stripping still compare correctly.
+            has_changes = calculate_arc_content_hash(existing_doc.arc_content) != content_hash
 
             # Start with existing metadata
             metadata = existing_doc.metadata
             metadata.last_seen = now
             metadata.last_harvest_id = harvest_id
 
+            old_hash = metadata.arc_hash
+            metadata.arc_hash = content_hash
+
             if has_changes:
-                logger.info("ARC %s changed (old: %s, new: %s)", arc_id, metadata.arc_hash[:8], content_hash[:8])
-                metadata.arc_hash = content_hash
+                logger.info("ARC %s changed (old: %s, new: %s)", arc_id, old_hash[:8], content_hash[:8])
                 metadata.last_changed = now
                 metadata.last_changed_harvest_id = harvest_id
                 metadata.status = ArcLifecycleStatus.ACTIVE  # Reset to active if it was missing/deleted

--- a/middleware/api/tests/unit/test_content_hash.py
+++ b/middleware/api/tests/unit/test_content_hash.py
@@ -1,0 +1,99 @@
+"""Unit tests for RO-Crate content-hash normalization."""
+
+import hashlib
+import json
+
+from middleware.api.document_store.content_hash import (
+    RoCrateContent,
+    calculate_arc_content_hash,
+    strip_volatile_rocrate_fields,
+)
+
+
+def test_strip_volatile_rocrate_fields_removes_timestamps_recursively() -> None:
+    """Volatile fields anywhere in the RO-Crate tree are excluded from hashing."""
+    arc: RoCrateContent = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {
+                "@id": "./",
+                "identifier": "arc-1",
+                "datePublished": "2026-01-01T00:00:00.000",
+                "sdDatePublished": "2026-01-01T00:00:00.001",
+            },
+            {
+                "@id": "#study",
+                "dateModified": "2026-01-02T00:00:00.000",
+                "name": "Study",
+            },
+        ],
+    }
+
+    stripped = strip_volatile_rocrate_fields(arc)
+
+    graph = stripped["@graph"]
+    assert isinstance(graph, list)
+    root = graph[0]
+    study = graph[1]
+    assert isinstance(root, dict)
+    assert isinstance(study, dict)
+
+    assert "datePublished" not in root
+    assert "sdDatePublished" not in root
+    assert "dateModified" not in study
+    assert study["name"] == "Study"
+
+
+def test_calculate_arc_content_hash_ignores_timestamp_only_differences() -> None:
+    """arctrl-style timestamp refresh must not count as a content change."""
+    base: RoCrateContent = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {
+                "@id": "./",
+                "identifier": "arc-1",
+                "datePublished": "2026-01-01T10:00:00.111",
+                "sdDatePublished": "2026-01-01T10:00:00.112",
+            },
+            {"@id": "#study", "dateModified": "2026-01-01T10:00:00.200", "name": "Study"},
+        ],
+    }
+    refreshed: RoCrateContent = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {
+                "@id": "./",
+                "identifier": "arc-1",
+                "datePublished": "2026-07-01T11:19:33.494",
+                "sdDatePublished": "2026-07-01T11:19:33.557",
+            },
+            {"@id": "#study", "dateModified": "2026-07-01T11:19:33.522", "name": "Study"},
+        ],
+    }
+
+    assert calculate_arc_content_hash(base) == calculate_arc_content_hash(refreshed)
+
+
+def test_calculate_arc_content_hash_detects_real_content_changes() -> None:
+    """Semantic differences must still produce a different hash."""
+    unchanged: RoCrateContent = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [{"@id": "./", "identifier": "arc-1", "name": "Original"}],
+    }
+    changed: RoCrateContent = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [{"@id": "./", "identifier": "arc-1", "name": "Updated"}],
+    }
+
+    assert calculate_arc_content_hash(unchanged) != calculate_arc_content_hash(changed)
+
+
+def test_calculate_arc_content_hash_differs_from_legacy_full_json_hash() -> None:
+    """Documents stored before normalization used the full JSON hash."""
+    arc: RoCrateContent = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [{"@id": "./", "identifier": "arc-1", "datePublished": "2026-01-01T00:00:00.000"}],
+    }
+    legacy_hash = hashlib.sha256(json.dumps(arc, sort_keys=True).encode("utf-8")).hexdigest()
+
+    assert calculate_arc_content_hash(arc) != legacy_hash

--- a/middleware/api/tests/unit/test_couchdb_store.py
+++ b/middleware/api/tests/unit/test_couchdb_store.py
@@ -11,6 +11,7 @@ from pydantic import SecretStr
 from middleware.api.document_store import DuplicateArcError
 from middleware.api.document_store.arc_document import ArcDocument, ArcEvent, ArcMetadata
 from middleware.api.document_store.config import CouchDBConfig
+from middleware.api.document_store.content_hash import RoCrateContent, calculate_arc_content_hash
 from middleware.api.document_store.couchdb import CouchDB
 from middleware.shared.api_models.common.models import ArcEventType, ArcLifecycleStatus
 
@@ -50,7 +51,7 @@ async def test_store_arc_new(store: CouchDB, mock_client_instance: MagicMock) ->
     """Test storing a new ARC."""
     # Setup
     rdi = "test_rdi"
-    arc_content = {
+    arc_content: RoCrateContent = {
         "@context": "https://w3id.org/ro/crate/1.1/context",
         "@graph": [{"@id": "./", "identifier": "arc_123"}],
     }
@@ -81,7 +82,7 @@ async def test_store_arc_new(store: CouchDB, mock_client_instance: MagicMock) ->
 @pytest.mark.asyncio
 async def test_get_arc_content(store: CouchDB, mock_client_instance: MagicMock) -> None:
     """Test get_arc_content returns content."""
-    arc_content = {"key": "value"}
+    arc_content: RoCrateContent = {"key": "value"}
     mock_client_instance.get_document.return_value = {"arc_content": arc_content}
 
     result = await store.get_arc_content("test_id")
@@ -146,7 +147,7 @@ async def test_store_arc_update_changed(store: CouchDB, mock_client_instance: Ma
     """Test updating an existing ARC with changes."""
     # Setup
     rdi = "test_rdi"
-    arc_content = {
+    arc_content: RoCrateContent = {
         "@context": "https://w3id.org/ro/crate/1.1/context",
         "@graph": [{"@id": "./", "identifier": "arc_123"}, {"@id": "dataset", "name": "Changed Name"}],
     }
@@ -191,14 +192,13 @@ async def test_store_arc_no_change(store: CouchDB, mock_client_instance: MagicMo
     """Test storing an unchanged ARC."""
     # Setup
     rdi = "test_rdi"
-    arc_content = {
+    arc_content: RoCrateContent = {
         "@context": "https://w3id.org/ro/crate/1.1/context",
         "@graph": [{"@id": "./", "identifier": "arc_123"}],
     }
 
-    # Calculate hash to match
-    json_str = json.dumps(arc_content, sort_keys=True)
-    content_hash = hashlib.sha256(json_str.encode("utf-8")).hexdigest()
+    # Calculate hash to match (normalized, volatile fields excluded)
+    content_hash = calculate_arc_content_hash(arc_content)
 
     # Existing document matches
     existing_doc = {
@@ -230,10 +230,9 @@ async def test_store_arc_no_change(store: CouchDB, mock_client_instance: MagicMo
     mock_client_instance.save_document.assert_called_once()
 
 
-def _make_existing_arc_doc(rdi: str, arc_content: dict, last_harvest_id: str | None = None) -> dict:
+def _make_existing_arc_doc(rdi: str, arc_content: RoCrateContent, last_harvest_id: str | None = None) -> dict:
     """Build a minimal existing ARC document dict for mocking."""
-    json_str = json.dumps(arc_content, sort_keys=True)
-    content_hash = hashlib.sha256(json_str.encode("utf-8")).hexdigest()
+    content_hash = calculate_arc_content_hash(arc_content)
     return {
         "_id": "arc_...",
         "_rev": "1-rev",
@@ -251,11 +250,67 @@ def _make_existing_arc_doc(rdi: str, arc_content: dict, last_harvest_id: str | N
 
 
 @pytest.mark.asyncio
+async def test_store_arc_timestamp_only_not_a_change(store: CouchDB, mock_client_instance: MagicMock) -> None:
+    """Re-serialized RO-Crate with fresh arctrl timestamps must not trigger a change."""
+    rdi = "test_rdi"
+    stored_content: RoCrateContent = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {
+                "@id": "./",
+                "identifier": "arc_123",
+                "datePublished": "2026-01-01T10:00:00.111",
+                "sdDatePublished": "2026-01-01T10:00:00.112",
+            },
+            {"@id": "#study", "dateModified": "2026-01-01T10:00:00.200", "name": "Study"},
+        ],
+    }
+    resubmitted_content: RoCrateContent = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {
+                "@id": "./",
+                "identifier": "arc_123",
+                "datePublished": "2026-07-01T11:19:33.494",
+                "sdDatePublished": "2026-07-01T11:19:33.557",
+            },
+            {"@id": "#study", "dateModified": "2026-07-01T11:19:33.522", "name": "Study"},
+        ],
+    }
+    legacy_hash = hashlib.sha256(json.dumps(stored_content, sort_keys=True).encode("utf-8")).hexdigest()
+    existing_doc = {
+        "_id": "arc_...",
+        "_rev": "1-rev",
+        "rdi": rdi,
+        "arc_content": stored_content,
+        "metadata": {
+            "arc_hash": legacy_hash,
+            "status": "ACTIVE",
+            "first_seen": "2023-01-01T00:00:00Z",
+            "last_seen": "2023-01-01T00:00:00Z",
+            "events": [],
+        },
+    }
+
+    mock_client_instance.get_document.return_value = existing_doc
+    mock_client_instance.save_document.return_value = {"ok": True}
+
+    result = await store.store_arc(rdi, resubmitted_content, "arc_123")
+
+    assert result.is_new is False
+    assert result.has_changes is False
+    mock_client_instance.save_document.assert_called_once()
+    _, doc_data = mock_client_instance.save_document.call_args[0]
+    assert doc_data["metadata"]["arc_hash"] == calculate_arc_content_hash(resubmitted_content)
+    assert doc_data["metadata"]["events"] == []
+
+
+@pytest.mark.asyncio
 async def test_store_arc_duplicate_in_same_harvest_raises(store: CouchDB, mock_client_instance: MagicMock) -> None:
     """store_arc raises DuplicateArcError when the same ARC is re-submitted in the same harvest."""
     rdi = "test_rdi"
     harvest_id = "harvest-abc"
-    arc_content = {
+    arc_content: RoCrateContent = {
         "@context": "https://w3id.org/ro/crate/1.1/context",
         "@graph": [{"@id": "./", "identifier": "arc_dup"}],
     }
@@ -284,7 +339,7 @@ async def test_store_arc_concurrent_duplicate_detected_via_validator(
     """
     rdi = "test_rdi"
     harvest_id = "harvest-concurrent"
-    arc_content = {
+    arc_content: RoCrateContent = {
         "@context": "https://w3id.org/ro/crate/1.1/context",
         "@graph": [{"@id": "./", "identifier": "arc_concurrent"}],
     }
@@ -314,7 +369,7 @@ async def test_store_arc_concurrent_duplicate_detected_via_validator(
 async def test_store_arc_same_arc_different_harvest_is_allowed(store: CouchDB, mock_client_instance: MagicMock) -> None:
     """store_arc allows re-submitting an ARC that was seen in a *different* harvest."""
     rdi = "test_rdi"
-    arc_content = {
+    arc_content: RoCrateContent = {
         "@context": "https://w3id.org/ro/crate/1.1/context",
         "@graph": [{"@id": "./", "identifier": "arc_dup"}],
     }
@@ -333,7 +388,7 @@ async def test_store_arc_same_arc_different_harvest_is_allowed(store: CouchDB, m
 async def test_store_arc_no_harvest_context_allows_resubmit(store: CouchDB, mock_client_instance: MagicMock) -> None:
     """store_arc never raises DuplicateArcError for stand-alone ARC submissions (no harvest_id)."""
     rdi = "test_rdi"
-    arc_content = {
+    arc_content: RoCrateContent = {
         "@context": "https://w3id.org/ro/crate/1.1/context",
         "@graph": [{"@id": "./", "identifier": "arc_dup"}],
     }

--- a/middleware/tools/repro_arctrl_rocrate_dates.py
+++ b/middleware/tools/repro_arctrl_rocrate_dates.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Minimal reproducer: ISA dates lost on RO-Crate -> ARC -> RO-Crate round-trip.
+
+Run:
+    uv run --with "arctrl>=3.0.5" python repro_arctrl_rocrate_dates.py
+
+Profile: https://github.com/nfdi4plants/isa-ro-crate-profile/blob/main/profile/isa_ro_crate.md
+  Submission Date      -> dateCreated
+  Public Release Date  -> datePublished
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+
+from arctrl import ARC  # type: ignore[import-untyped]
+
+# ro_crates/minimal.json (embedded so this file is self-contained)
+MINIMAL_ROCRATE = {
+    "@context": "https://w3id.org/ro/crate/1.2/context",
+    "@graph": [
+        {
+            "@id": "./",
+            "@type": "Dataset",
+            "additionalType": "Investigation",
+            "identifier": "Test",
+        },
+        {
+            "@id": "ro-crate-metadata.json",
+            "@type": "CreativeWork",
+            "conformsTo": {"@id": "https://w3id.org/ro/crate/1.2"},
+            "about": {"@id": "./"},
+        },
+    ],
+}
+
+SUBMISSION_DATE = "2024-01-15"
+PUBLIC_RELEASE_DATE = "2025-06-01"
+
+input_json = json.dumps(MINIMAL_ROCRATE)
+arc = ARC.from_rocrate_json_string(input_json)
+arc.Title = "Test"
+arc.SubmissionDate = SUBMISSION_DATE
+arc.PublicReleaseDate = PUBLIC_RELEASE_DATE
+
+output_json = arc.ToROCrateJsonString()
+root = next(node for node in json.loads(output_json)["@graph"] if node.get("@id") == "./")
+
+print(f"arctrl {importlib.metadata.version('arctrl')}\n")
+print("1) Input RO-Crate (minimal.json, no dates):")
+print(json.dumps(MINIMAL_ROCRATE, indent=2))
+print("\n2) After from_rocrate_json_string, set on ARC object:")
+print(f"  Title               = {arc.Title!r}")
+print(f"  SubmissionDate      = {arc.SubmissionDate!r}")
+print(f"  PublicReleaseDate   = {arc.PublicReleaseDate!r}")
+print("\n3) Output RO-Crate root after ToROCrateJsonString():")
+print(f"  dateCreated         = {root.get('dateCreated')!r}")
+print(f"  datePublished       = {root.get('datePublished')!r}")
+print(f"  sdDatePublished     = {root.get('sdDatePublished')!r}")
+print("\nISA date strings present anywhere in output JSON?")
+print(f"  {SUBMISSION_DATE!r} in output: {SUBMISSION_DATE in output_json}")
+print(f"  {PUBLIC_RELEASE_DATE!r} in output: {PUBLIC_RELEASE_DATE in output_json}")
+print("\n4) Full output RO-Crate JSON:")
+print(json.dumps(json.loads(output_json), indent=2))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,9 @@ explicit_package_bases = true
 namespace_packages = true
 mypy_path = "middleware/api/src:middleware/api_client/src:middleware/shared/src:middleware/api/tests/unit:middleware/api_client/tests:middleware/shared/tests"
 
+# Run scope is always the full tree: `uv run mypy --config-file pyproject.toml middleware/`
+# (pre-commit, CI reusable-code-quality.yml, IDE mypy-type-checker.reportingScope=workspace).
+
 # Exclude directories from type checking
 exclude = [
   ".venv",


### PR DESCRIPTION
- Introduced `content_hash.py` with functions to strip volatile fields from RO-Crate JSON and calculate a SHA-256 hash of the normalized content.
- Updated `couchdb.py` to utilize the new content hash functions, ensuring consistent change detection by excluding timestamp fields.
- Added unit tests in `test_content_hash.py` to verify the functionality of the new content hash utilities.
- Enhanced existing tests in `test_couchdb_store.py` to use the new content hash calculation method for improved accuracy in change detection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes harvest change-detection semantics and metadata hash updates for existing ARCs, which affects lifecycle events and statistics but is limited to document-store logic with solid test coverage.
> 
> **Overview**
> Fixes false **ARC_UPDATED** events when harvests resubmit the same ARC after **arctrl** refreshes `datePublished`, `sdDatePublished`, and `dateModified` on every `ToROCrateJsonString()` round-trip.
> 
> A new **`content_hash`** module strips those fields recursively and computes a stable SHA-256 over sorted JSON. **`CouchDB.store_arc`** uses it instead of hashing the raw document, compares **normalized** hashes of stored vs incoming content (so older CouchDB rows with legacy full-JSON `arc_hash` still match correctly), and refreshes `metadata.arc_hash` on unchanged resubmits without appending update events.
> 
> Tooling is aligned so **mypy** always type-checks the full `middleware/` tree via `pyproject.toml` in CI, pre-commit, and VS Code. Unit tests cover normalization and a timestamp-only resubmit scenario; a small **`repro_arctrl_rocrate_dates`** script documents the underlying arctrl behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e78cf619838ef173657500e0fdcce37a471bcc2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->