### PR TITLE
Update Helm chart documentation and values for appVersion and image t…

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -180,7 +180,7 @@ jobs:
               ${{ env.CHART_NAME }}-${{ env.CHART_VERSION }}.tgz
             ```
 
-            *(The `appVersion` and container image tag are defined in the chart's `values.yaml`.)*
+            *(The container image tag is the chart's `appVersion`, set at package time from the corresponding Docker image release. Override with `--set api.image.tag=...` if needed.)*
           files: ${{ steps.package_chart.outputs.chart-package }}
           draft: true
           prerelease: false

--- a/helmchart/fairagro-advanced-middleware-api-chart/Chart.yaml
+++ b/helmchart/fairagro-advanced-middleware-api-chart/Chart.yaml
@@ -21,8 +21,7 @@ type: application
 # This value reflects the last released version and serves as a reference for developers.
 version: 0.2.0
 
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
+# Application version (also used as the default container image tag).
+# CI overrides this at package time via `helm package --app-version <docker-tag>`.
+# This value reflects the last released version and serves as a reference for developers.
 appVersion: "0.3.0"

--- a/helmchart/fairagro-advanced-middleware-api-chart/values.yaml
+++ b/helmchart/fairagro-advanced-middleware-api-chart/values.yaml
@@ -73,7 +73,7 @@ api:
   image:
     repository: zalf/fairagro-advanced-middleware-api
     pullPolicy: IfNotPresent
-    tag: ""
+    # tag: omitted — defaults to Chart.AppVersion (set at package time via --app-version)
   service:
     type: ClusterIP
     port: 8000
@@ -137,7 +137,7 @@ celery:
   image:
     repository: zalf/fairagro-advanced-middleware-api
     pullPolicy: IfNotPresent
-    tag: ""
+    # tag: omitted — defaults to api.image.tag or Chart.AppVersion
   worker:
     enabled: true
     replicaCount: 1


### PR DESCRIPTION
…ag handling

- Clarified the relationship between the `appVersion` in `Chart.yaml` and the container image tag, specifying that it is set at package time.
- Updated comments in `values.yaml` to indicate that the image tag defaults to `Chart.AppVersion`, enhancing understanding of configuration options.
- Improved documentation in the GitHub Actions workflow file to reflect these changes and provide guidance on overriding the image tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and release-note changes only; no deployment or packaging behavior is modified.
> 
> **Overview**
> **Documentation-only** updates so Helm consumers understand how container image tags are chosen, without changing chart templates or CI packaging logic.
> 
> **`Chart.yaml`** now states that `appVersion` doubles as the default image tag and that CI sets it at package time with `helm package --app-version <docker-tag>` (aligned with the existing workflow that reads the latest `*-docker-v*` tag).
> 
> **`values.yaml`** drops explicit empty `api.image.tag` / `celery.image.tag` entries in favor of comments that tags are omitted on purpose and fall back to `Chart.AppVersion` (and for Celery, `api.image.tag` or `AppVersion`—matching existing template `default` behavior).
> 
> The **Helm release** draft body text is expanded to say the image tag equals the chart `appVersion` from the Docker release at package time, and to mention overriding via `--set api.image.tag=...`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c89614e33a0aca7b363f88d499395df011cdbe5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->