### PR TITLE
Enhance GitLab project description handling

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -15,7 +15,7 @@ COPY pyproject.toml uv.lock ./
 COPY middleware ./middleware
 
 # Upgrade pip and install uv
-RUN pip install --no-cache-dir --upgrade pip==26.1.2 uv==0.11.21
+RUN pip install --no-cache-dir --upgrade pip==26.1.2 uv==0.11.30
 
 # Build wheels
 RUN uv build --package fairagro-middleware-shared --wheel && \
@@ -29,14 +29,14 @@ RUN apk add --no-cache \
     build-base=0.5-r4 \
     libffi-dev=3.5.2-r1 \
     openssl-dev=3.5.7-r0 \
-    cargo=1.96.0-r0 \
+    cargo=1.96.1-r0 \
     musl-utils=1.2.6-r2 \
     libssl3=3.5.7-r0
 
 WORKDIR /build
 
 # Install uv and PyInstaller
-RUN pip install --no-cache-dir --upgrade pip==26.1.2 uv==0.11.21
+RUN pip install --no-cache-dir --upgrade pip==26.1.2 uv==0.11.30
 
 # Copy built wheel from package-builder stage
 COPY --from=package-builder /build/dist/*.whl /tmp/wheels/
@@ -98,7 +98,7 @@ ENV UVICORN_LOG_LEVEL=info
 
 # Create non-root user and group and fix permissions
 RUN apk add --no-cache --upgrade \
-        curl=8.20.0-r1 \
+        curl=8.21.0-r0 \
         git=2.54.0-r0 \
         zlib=1.3.2-r0 \
         tzdata \

--- a/middleware/api/spec/arc-store/design.md
+++ b/middleware/api/spec/arc-store/design.md
@@ -77,7 +77,7 @@ Mapping to GitLab project attributes:
 | ---------------- | ---------------- | ----- |
 | `path` | clone URL / slug | `arc_id` (stable) |
 | `name` | project list title | `identifier` (`{sanitized arc.Identifier} - {rdi}`) |
-| `description` | truncated preview in list; full text on project home | RO-Crate `name`, then `description` (when present) |
+| `description` | truncated preview in list; full text on project home | RO-Crate `name`, then `description` (when present), truncated to GitLab's 2000-character limit |
 | `topics` | tag chips in list | `rdi` in GitLab-topic form (lowercased; see below) |
 
 GitLab has no separate subtitle field. The project `description` is the right

--- a/middleware/api/spec/arc-store/spec.md
+++ b/middleware/api/spec/arc-store/spec.md
@@ -52,6 +52,10 @@ ARC identifier missing or malformed → raise permanent error before any Git ope
 RO-Crate root dataset has no `name` → pass `display_name=""`; the GitLab project
 description omits the name line but may still include the RO-Crate `description`.
 
+RO-Crate `name` + `description` exceed GitLab's 2000-character project
+description limit → truncate the combined description to 2000 characters before
+create/update. Do not fail the sync solely because the ARC summary is long.
+
 Unknown or disallowed `rdi` → rejected by the API before Git sync (see
 `arc-upload/` and `harvest-arc-upload/`). The Git store only receives
 already-validated `rdi` values.

--- a/middleware/api/src/middleware/api/arc_store/remote_git_provider.py
+++ b/middleware/api/src/middleware/api/arc_store/remote_git_provider.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 _GITLAB_TOPIC_RE = re.compile(r"[^a-z0-9-]+")
 GITLAB_PROJECT_NAME_MAX_LEN = 255
+GITLAB_PROJECT_DESCRIPTION_MAX_LEN = 2000
 _GITLAB_NAME_MAX_LEN = GITLAB_PROJECT_NAME_MAX_LEN
 _GITLAB_NAME_UNSAFE_RE = re.compile(r"[\r\n\t]+")
 _GITLAB_API_NAME_INVALID_RE = re.compile(r"[^a-zA-Z0-9_.+ \-]+", re.UNICODE)
@@ -138,13 +139,20 @@ def desired_gitlab_topics(metadata: GitProjectMetadata) -> list[str] | None:
 
 
 def build_gitlab_project_description(metadata: GitProjectMetadata) -> str:
-    """Build the GitLab project description shown in list preview and on the project home page."""
+    """Build the GitLab project description shown in list preview and on the project home page.
+
+    GitLab rejects project descriptions longer than 2000 characters; truncate to
+    stay within that API limit (same pattern as project name length handling).
+    """
     lines: list[str] = []
     if metadata.display_name:
         lines.append(metadata.display_name)
     if metadata.description:
         lines.append(metadata.description)
-    return "\n".join(lines)
+    description = "\n".join(lines)
+    if len(description) > GITLAB_PROJECT_DESCRIPTION_MAX_LEN:
+        return description[:GITLAB_PROJECT_DESCRIPTION_MAX_LEN]
+    return description
 
 
 def apply_gitlab_project_metadata(

--- a/middleware/api/tests/unit/test_remote_repo_manager.py
+++ b/middleware/api/tests/unit/test_remote_repo_manager.py
@@ -15,12 +15,14 @@ from gitlab.exceptions import GitlabAuthenticationError, GitlabGetError
 
 from middleware.api.arc_store import ArcStoreError
 from middleware.api.arc_store.remote_git_provider import (
+    GITLAB_PROJECT_DESCRIPTION_MAX_LEN,
     GITLAB_PROJECT_NAME_MAX_LEN,
     FileSystemGitProvider,
     GitlabGitProvider,
     GitProjectMetadata,
     RemoteGitProvider,
     apply_gitlab_project_metadata,
+    build_gitlab_project_description,
     build_gitlab_project_name,
     git_project_metadata_from_arc,
     normalize_gitlab_topic,
@@ -342,6 +344,20 @@ def test_build_gitlab_project_name_truncates_long_identifier() -> None:
     result = build_gitlab_project_name(long_id, rdi)
     assert result.endswith(f" - {rdi}")
     assert len(result) <= GITLAB_PROJECT_NAME_MAX_LEN
+
+
+def test_build_gitlab_project_description_truncates_to_gitlab_limit() -> None:
+    """GitLab rejects descriptions over 2000 characters; truncate instead of failing sync."""
+    metadata = GitProjectMetadata(
+        rdi="edal",
+        arc_id="abc123hash",
+        identifier="study - edal",
+        display_name="Short title",
+        description="d" * 3000,
+    )
+    result = build_gitlab_project_description(metadata)
+    assert len(result) == GITLAB_PROJECT_DESCRIPTION_MAX_LEN
+    assert result.startswith("Short title\n")
 
 
 def test_sanitize_gitlab_project_name_replaces_slashes() -> None:


### PR DESCRIPTION
- Updated the project description logic to truncate combined RO-Crate `name` and `description` to GitLab's 2000-character limit, ensuring compliance with API constraints.
- Modified the `build_gitlab_project_description` function to implement truncation and added a corresponding unit test to verify this behavior.
- Updated documentation to reflect the new truncation rule for project descriptions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized metadata formatting for GitLab API compliance; no changes to auth, Git push logic, or ARC parsing.
> 
> **Overview**
> Prevents ARC Git sync failures when RO-Crate **name** + **description** exceed GitLab’s **2000-character** project description limit.
> 
> `build_gitlab_project_description` now caps the combined `display_name` and `description` string (same approach as existing project **name** length handling). Arc-store **spec** and **design** document that truncation is intentional and sync must not fail solely because the summary is long. A unit test asserts the limit is enforced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b17f7bd265bac3159c7596cf5b997a847f4c7a91. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->