### PR TITLE
Refactor harvest reporting model to unify failure handling

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -91,13 +91,14 @@ postCreate installs Ruff via the Cursor or VS Code remote CLI (see
 Fallback / parity check:
 
 ```bash
-uv run ruff check middleware/
-uv run ruff format --check --diff middleware/
+uv run ruff check --config pyproject.toml middleware/
+uv run ruff format --check --diff --config pyproject.toml middleware/
 # or fix + re-check
 ./scripts/quality-fix.sh
 ```
 
 Do not recommend or enable `ms-python.autopep8` — it fights Ruff as the Python formatter.
+
 ## Local clone (no Dev Container)
 
 ```bash

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -91,10 +91,13 @@ postCreate installs Ruff via the Cursor or VS Code remote CLI (see
 Fallback / parity check:
 
 ```bash
+./scripts/quality-check.sh
+# or individually:
 uv run ruff check --config pyproject.toml middleware/
 uv run ruff format --check --diff --config pyproject.toml middleware/
 # or fix + re-check
 ./scripts/quality-fix.sh
+./scripts/quality-check.sh
 ```
 
 Do not recommend or enable `ms-python.autopep8` — it fights Ruff as the Python formatter.

--- a/.github/workflows/publish-ns-pages.yml
+++ b/.github/workflows/publish-ns-pages.yml
@@ -1,7 +1,7 @@
 # Publish vocabulary namespace (ns/) to GitHub Pages
 
 # Deploys only the `ns/` tree. Triggered by vocabulary tags such as
-# `ns/harvest-report/v1.0.0`. Does not publish `docs/` or application sources.
+# `ns/harvest-report/v1.0.0` or `ns/harvest-report/v2.0.0`. Does not publish `docs/` or application sources.
 #
 # Prerequisite (once per repo): Settings → Pages → Source = GitHub Actions.
 

--- a/.github/workflows/reusable-code-quality.yml
+++ b/.github/workflows/reusable-code-quality.yml
@@ -56,9 +56,9 @@ jobs:
       - name: Code formatting and linting
         if: ${{ !inputs.skip }}
         run: |
-          uv run ruff format --check --diff middleware/
-          uv run ruff check middleware/
-          uv run pylint middleware/
+          uv run ruff format --check --diff --config pyproject.toml middleware/
+          uv run ruff check --config pyproject.toml middleware/
+          uv run pylint --rcfile pyproject.toml middleware/
           uv run mypy --config-file pyproject.toml middleware/
 
       - name: Security check with bandit

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,11 @@
+{
+  "globs": ["**/*.md"],
+  "ignores": [
+    ".venv/**",
+    "node_modules/**",
+    // OpenSpec regenerates these on `openspec update` — do not hand-lint/edit.
+    ".cursor/**",
+    ".github/skills/**",
+    ".github/prompts/**"
+  ]
+}

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -3,3 +3,7 @@
 .cursor/commands/**
 .github/skills/**
 .github/prompts/**
+
+# Third-party / local environments
+.venv/**
+node_modules/**

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,9 +2,9 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 #
-# Ruff hooks: `uv run ruff` from the project venv + root pyproject.toml,
-# scoped to middleware/ — same as CI and the Cursor Ruff extension
-# (which must use .venv/bin/ruff, not `uv` as ruff.path).
+# Ruff hooks: `uv run ruff --config pyproject.toml` from the project venv,
+# scoped to middleware/ — same root config as CI and the Cursor Ruff extension
+# (ruff.configuration = workspace pyproject.toml, configurationPreference = editorOnly).
 
 repos:
   # Built-in hooks (no dependencies needed)
@@ -33,7 +33,7 @@ repos:
       # Ruff - Linting
       - id: ruff
         name: ruff lint
-        entry: uv run ruff check middleware/
+        entry: uv run ruff check --config pyproject.toml middleware/
         language: system
         files: ^middleware/
         pass_filenames: false
@@ -42,7 +42,7 @@ repos:
       # Ruff - Formatting
       - id: ruff-format
         name: ruff format
-        entry: uv run ruff format middleware/
+        entry: uv run ruff format --config pyproject.toml middleware/
         language: system
         files: ^middleware/
         pass_filenames: false
@@ -68,7 +68,7 @@ repos:
       # pylint - Code quality
       - id: pylint
         name: pylint
-        entry: uv run pylint
+        entry: uv run pylint --rcfile pyproject.toml
         language: system
         types: [python]
         files: ^middleware/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,8 +5,9 @@
   //
   // Code-quality parity: editor Ruff/Pylint/Mypy must use the same project
   // config and the same venv binaries as pre-commit and CI
-  // (`uv run ruff|pylint|mypy` → `.venv/bin/...`). Scope for Ruff CLI in
-  // hooks/CI is `middleware/` with root `pyproject.toml`.
+  // (`uv run ruff|pylint|mypy` → `.venv/bin/...`).
+  // Single source of truth for Ruff/Pylint/Mypy: workspace-root pyproject.toml
+  // (not middleware/*/pyproject.toml). Hooks/CI scope: `middleware/`.
 
   "python.testing.pytestArgs": [],
   "python.testing.unittestEnabled": false,
@@ -54,18 +55,20 @@
   ],
   "mypy-type-checker.importStrategy": "fromEnvironment",
 
-  // Ruff: same binary + config as `uv run ruff` / pre-commit / CI.
-  // IMPORTANT: ruff.path must be the ruff executable, NOT `uv run ruff`
-  // (path entries are treated as binaries; `uv` would be invoked as ruff).
+  // Ruff: same binary + root pyproject.toml as `uv run ruff --config pyproject.toml`
+  // / pre-commit / CI. editorOnly avoids per-package pyproject discovery (which
+  // previously used `[tool.ruff] extend = ...` and left the native server with
+  // empty rule sets → no Problems diagnostics).
   "ruff.enable": true,
   "ruff.nativeServer": "on",
   "ruff.path": ["${workspaceFolder}/.venv/bin/ruff"],
   "ruff.interpreter": ["${workspaceFolder}/.venv/bin/python"],
   "ruff.configuration": "${workspaceFolder}/pyproject.toml",
-  "ruff.configurationPreference": "filesystemFirst",
+  "ruff.configurationPreference": "editorOnly",
   "ruff.importStrategy": "fromEnvironment",
+  "ruff.lint.enable": true,
 
-  // Pylint: same rcfile + venv as pre-commit / `uv run pylint`
+  // Pylint: same rcfile + venv as pre-commit / `uv run pylint --rcfile pyproject.toml`
   "pylint.args": [
     "--rcfile=${workspaceFolder}/pyproject.toml"
   ],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,9 @@ uv run mypy --config-file pyproject.toml middleware/
 uv run ruff format --check --diff --config pyproject.toml middleware/
 uv run ruff check --config pyproject.toml middleware/
 
+# Full CI-parity quality gate (ruff + pylint + mypy + bandit; no pytest)
+./scripts/quality-check.sh
+
 # Install all dependecies
 uv sync --dev --all-packages
 ```
@@ -229,9 +232,12 @@ by the project's configured tools: **Ruff, Pylance, MyPy, Pylint, and Bandit**.
   extended rules → empty Problems tab while CLI still looks fine.
 - Lint diagnostics appear in Problems; **format** drift does not (Ruff applies
   format via Format on Save / `ruff format`). Before commit, run the same
-  checks as CI: `uv run ruff format --check --diff --config pyproject.toml middleware/`
-  and `uv run ruff check --config pyproject.toml middleware/` (or
-  `./scripts/quality-fix.sh` then pre-commit).
+  checks as CI via `./scripts/quality-check.sh` (ruff/pylint/mypy/bandit), or
+  the individual `uv run ruff format --check --diff --config pyproject.toml middleware/`
+  / `uv run ruff check --config pyproject.toml middleware/` commands (or
+  `./scripts/quality-fix.sh` then pre-commit / terminal `git commit`).
+  Note: Cursor Source Control Commit may skip git hooks (Cursor ≥3.15.6 bug);
+  prefer terminal commits until that is fixed.
 - Avoid partially staging a Python file (`MM` in `git status`): pre-commit may
   auto-format the index, then roll back when the stash conflicts with unstaged
   edits — leaving format failures invisible in the editor.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,12 +76,12 @@ uv run pytest middleware/shared/tests/unit/ -v
 uv run pytest middleware/api_client/tests/unit/ -v
 
 # Quality checks
-uv run ruff check .
-uv run mypy middleware/
+uv run ruff check --config pyproject.toml middleware/
+uv run mypy --config-file pyproject.toml middleware/
 
 # Ruff parity checks (local + pre-commit + CI)
-uv run ruff format --check --diff middleware/
-uv run ruff check middleware/
+uv run ruff format --check --diff --config pyproject.toml middleware/
+uv run ruff check --config pyproject.toml middleware/
 
 # Install all dependecies
 uv sync --dev --all-packages
@@ -216,17 +216,22 @@ by the project's configured tools: **Ruff, Pylance, MyPy, Pylint, and Bandit**.
 ### Ruff Execution Consistency
 
 - Keep Ruff behavior identical in Cursor/VS Code, pre-commit, and GitHub Actions
-  by using the same scope (`middleware/`), the same root config
-  (`pyproject.toml`), and the same binary (`.venv/bin/ruff` via `uv run ruff`).
+  by using the same scope (`middleware/`), the same **workspace-root** config
+  (`pyproject.toml` — not `middleware/*/pyproject.toml`), and the same binary
+  (`.venv/bin/ruff` via `uv run ruff --config pyproject.toml`).
 - Editor: `.vscode/settings.json` must set `ruff.path` to
-  `${workspaceFolder}/.venv/bin/ruff`. Do **not** set it to `["uv", "run",
-  "ruff"]` — `ruff.path` entries are treated as executables, so `uv` would be
-  launched as Ruff and the Problems tab stays empty.
+  `${workspaceFolder}/.venv/bin/ruff`, `ruff.configuration` to the root
+  `pyproject.toml`, and `ruff.configurationPreference` to `editorOnly`. Do
+  **not** set `ruff.path` to `["uv", "run", "ruff"]` — those entries are treated
+  as executables, so `uv` would be launched as Ruff and Problems stays empty.
+- Do not put `[tool.ruff]` (including `extend = ...`) in package pyprojects;
+  discovery would stop there and the Ruff native server often fails to apply
+  extended rules → empty Problems tab while CLI still looks fine.
 - Lint diagnostics appear in Problems; **format** drift does not (Ruff applies
   format via Format on Save / `ruff format`). Before commit, run the same
-  checks as CI: `uv run ruff format --check --diff middleware/` and
-  `uv run ruff check middleware/` (or `./scripts/quality-fix.sh` then
-  pre-commit).
+  checks as CI: `uv run ruff format --check --diff --config pyproject.toml middleware/`
+  and `uv run ruff check --config pyproject.toml middleware/` (or
+  `./scripts/quality-fix.sh` then pre-commit).
 - Avoid partially staging a Python file (`MM` in `git status`): pre-commit may
   auto-format the index, then roll back when the stash conflicts with unstaged
   edits — leaving format failures invisible in the editor.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,7 +301,7 @@ Before generating or modifying code, read the relevant specs:
 - **[`openspec/specs/harvest-report/`](openspec/specs/harvest-report/)** —
   Format-neutral harvest-run accumulator with repository scope counting and
   pluggable serializers (JSON-LD first): `HarvestReport`, `RepositoryScope`,
-  `RepositoryReport`, `FailedRecord`.
+  `RepositoryReport`, `HarvestIssue`.
 
 For the AI agent workflow documentation, see [`docs/ai_workflow.md`](docs/ai_workflow.md).
 

--- a/docs/architecture/couchdb-migration-plan.md
+++ b/docs/architecture/couchdb-migration-plan.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-Migrate from Redis-based state management to CouchDB-based ARC storage with comprehensive event-logging, harvest-run tracking, and intelligent change detection.
+Migrate from Redis-based state management to CouchDB-based ARC storage with
+comprehensive event-logging, harvest-run tracking, and intelligent change
+detection.
 
 ## Goals
 
@@ -242,9 +244,11 @@ Worker fetches full ARC from CouchDB using arc_id.
 
 #### [MODIFY] Files to update
 
-- [docker-compose.yml](file:///workspaces/m4.2_advanced_middleware_api-antigravity/docker-compose.yml) - Remove Redis service
-- [middleware/api/pyproject.toml](file:///workspaces/m4.2_advanced_middleware_api-antigravity/middleware/api/pyproject.toml) - Remove redis dependencies
-- [middleware/worker/pyproject.toml](file:///workspaces/m4.2_advanced_middleware_api-antigravity/middleware/worker/pyproject.toml) - Remove redis dependencies
+- [docker-compose.yml](../../dev_environment/compose.yaml) - Remove Redis service
+- [middleware/api/pyproject.toml](../../middleware/api/pyproject.toml) -
+  Remove redis dependencies
+- `middleware/worker/pyproject.toml` (historical path) - Remove redis
+  dependencies
 
 ### 6.2 API Cleanup
 

--- a/docs/architecture/logfire-and-couchdb-consolidation-plan.md
+++ b/docs/architecture/logfire-and-couchdb-consolidation-plan.md
@@ -1,12 +1,17 @@
 # Consolidating CouchDB Client and Tracing Refinement
 
-This plan addresses the redundancy in the `CouchDBClient` implementation and identifies the next steps for modernizing the observability stack using Pydantic Logfire.
+This plan addresses the redundancy in the `CouchDBClient` implementation and
+identifies the next steps for modernizing the observability stack using
+Pydantic Logfire.
 
 ## User Review Required
 
 > [!IMPORTANT]
-> I am proposing to replace the current OpenTelemetry (OTLP) tracing/logging boilerplate in `middleware/shared/src/middleware/shared/tracing.py` with **Pydantic Logfire**.
-> Logfire is built on OpenTelemetry but offers much deeper integration with Pydantic models, which are used extensively throughout this project.
+> I am proposing to replace the current OpenTelemetry (OTLP) tracing/logging
+> boilerplate in `middleware/shared/src/middleware/shared/tracing.py` with
+> **Pydantic Logfire**.
+> Logfire is built on OpenTelemetry but offers much deeper integration with
+> Pydantic models, which are used extensively throughout this project.
 >
 > **Benefits:**
 >
@@ -19,7 +24,8 @@ This plan addresses the redundancy in the `CouchDBClient` implementation and ide
 
 ### [Component] Shared Configuration & Client
 
-Move CouchDB related configuration and the "fixed" client implementation to the `shared` package to ensure consistency across the API and Workers.
+Move CouchDB related configuration and the "fixed" client implementation to the
+`shared` package to ensure consistency across the API and Workers.
 
 #### [MODIFY] [config_base.py](file:///workspaces/m4.2_advanced_middleware_api-antigravity/middleware/shared/src/middleware/shared/config/config_base.py)
 

--- a/middleware/api/README.md
+++ b/middleware/api/README.md
@@ -53,13 +53,20 @@ uv run uvicorn middleware.api.main:app --reload
 
 ## Deployment
 
-The API is containerized using Docker and is built as a standalone binary with PyInstaller within an Alpine Linux container to provide a minimal, secure runtime environment.
+The API is containerized using Docker and is built as a standalone binary with
+PyInstaller within an Alpine Linux container to provide a minimal, secure
+runtime environment.
 
 ### Scaling & Performance
 
-**Scaling must be done via horizontal replicas (multiple pods/containers) and NOT via internal worker processes.**
+**Scaling must be done via horizontal replicas (multiple pods/containers) and
+NOT via internal worker processes.**
 
-The application is bundled using PyInstaller on Python 3.12. Due to known issues with `importlib.metadata` and Pydantic v2's plugin system in "frozen" (PyInstaller) environments, using multiple Uvicorn workers (`--workers > 1`) can lead to startup crashes (e.g., `TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType`).
+The application is bundled using PyInstaller on Python 3.12. Due to known issues
+with `importlib.metadata` and Pydantic v2's plugin system in "frozen"
+(PyInstaller) environments, using multiple Uvicorn workers (`--workers > 1`)
+can lead to startup crashes (e.g.,
+`TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType`).
 
 To scale the API:
 
@@ -68,4 +75,7 @@ To scale the API:
 
 ### Build Configuration
 
-See `docker/Dockerfile.api` for the PyInstaller build configuration. Note that specific package metadata is explicitly included in the build (using `--copy-metadata`) to ensure compatibility with Pydantic and other metadata-sensitive libraries.
+See `docker/Dockerfile.api` for the PyInstaller build configuration. Note that
+specific package metadata is explicitly included in the build (using
+`--copy-metadata`) to ensure compatibility with Pydantic and other
+metadata-sensitive libraries.

--- a/middleware/api/pyproject.toml
+++ b/middleware/api/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 dependencies = [
   "fairagro-middleware-shared",
   "aiocouch>=4.0.1",
-  "arctrl>=3.0.0b15",
+  "arctrl>=3.1.1",
   "asn1crypto>=1.5.1",
   "celery>=5.3.6",
   "cryptography>=45.0.6",
@@ -28,9 +28,6 @@ middleware-couchdb-setup = "middleware.api.cli:main"
 
 [tool.uv.sources]
 fairagro-middleware-shared = { workspace = true }
-
-[tool.ruff]
-extend = "../../pyproject.toml"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/middleware"]

--- a/middleware/api/src/middleware/api/document_store/content_hash.py
+++ b/middleware/api/src/middleware/api/document_store/content_hash.py
@@ -12,9 +12,15 @@ type JsonValue = JsonPrimitive | list[JsonValue] | dict[str, JsonValue]
 # Top-level RO-Crate document stored in CouchDB (``@context``, ``@graph``, …).
 type RoCrateContent = dict[str, JsonValue]
 
-# arctrl ToROCrateJsonString() refreshes these on every serialization even when
-# semantic ARC content is unchanged (see arctrl round-trip behaviour).
-_VOLATILE_ROCRATE_FIELDS = frozenset({"datePublished", "sdDatePublished", "dateModified"})
+# Serialization / harvest timestamps that change without semantic ARC edits.
+# ISA RO-Crate profile: Submission Date → dateCreated, Public Release Date → datePublished.
+# arctrl ToROCrateJsonString() may also refresh datePublished / sdDatePublished / dateModified.
+_VOLATILE_ROCRATE_FIELDS = frozenset({
+    "dateCreated",
+    "datePublished",
+    "sdDatePublished",
+    "dateModified",
+})
 
 
 def strip_volatile_rocrate_fields(value: RoCrateContent) -> RoCrateContent:
@@ -34,8 +40,26 @@ def strip_volatile_rocrate_fields(value: RoCrateContent) -> RoCrateContent:
     return stripped
 
 
+def _graph_sort_key(node: JsonValue) -> tuple[str, str]:
+    """Stable sort key for ``@graph`` nodes (order must not affect the content hash)."""
+    if isinstance(node, dict):
+        node_id = node.get("@id")
+        id_part = node_id if isinstance(node_id, str) else ""
+        return (id_part, json.dumps(node, sort_keys=True))
+    return ("", json.dumps(node, sort_keys=True))
+
+
+def canonicalize_rocrate_for_hash(value: RoCrateContent) -> RoCrateContent:
+    """Strip volatile fields and order ``@graph`` for stable hashing."""
+    stripped = strip_volatile_rocrate_fields(value)
+    graph = stripped.get("@graph")
+    if isinstance(graph, list):
+        return {**stripped, "@graph": sorted(graph, key=_graph_sort_key)}
+    return stripped
+
+
 def calculate_arc_content_hash(arc_content: RoCrateContent) -> str:
-    """SHA-256 of normalized RO-Crate JSON (volatile timestamp fields excluded)."""
-    normalized = strip_volatile_rocrate_fields(arc_content)
+    """SHA-256 of normalized RO-Crate JSON (volatile timestamps excluded)."""
+    normalized = canonicalize_rocrate_for_hash(arc_content)
     json_str = json.dumps(normalized, sort_keys=True)
     return hashlib.sha256(json_str.encode("utf-8")).hexdigest()

--- a/middleware/api/src/middleware/api/document_store/couchdb_client.py
+++ b/middleware/api/src/middleware/api/document_store/couchdb_client.py
@@ -12,10 +12,48 @@ from urllib.parse import quote
 import aiohttp
 from aiocouch import CouchDB, Database
 from aiocouch.exception import ConflictError, NotFoundError, PreconditionFailedError
+from aiocouch.remote import RemoteServer
 
 from middleware.api.document_store.config import CouchDBConfig
 
 logger = logging.getLogger(__name__)
+
+_PATCH_MARKER = "_fairagro_encode_basic_auth"
+
+
+def _patch_aiocouch_aiohttp_auth() -> None:
+    """Make aiocouch use ``encode_basic_auth`` instead of deprecated ``BasicAuth``.
+
+    aiocouch 4.0.1 still builds ``aiohttp.BasicAuth`` and passes ``auth=`` into
+    ``ClientSession``. Both are deprecated in aiohttp 3.14+ (removed in 4.0) and
+    spam pytest with DeprecationWarnings on every connect. Patch once per process
+    until upstream adopts the new API.
+    """
+    if getattr(RemoteServer.__init__, _PATCH_MARKER, False):
+        return
+
+    def patched_init(
+        self: RemoteServer,
+        server: str,
+        *,
+        user: str | None = None,
+        password: str | None = None,
+        cookie: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self._server = server
+        headers: dict[str, str] = dict(kwargs.pop("headers", None) or {})
+        if cookie:
+            headers["Cookie"] = "AuthSession=" + cookie
+        if user and password:
+            headers["Authorization"] = aiohttp.encode_basic_auth(user, password)
+        self._http_session = aiohttp.ClientSession(
+            headers=headers if headers else None,
+            **kwargs,
+        )
+
+    setattr(patched_init, _PATCH_MARKER, True)
+    RemoteServer.__init__ = patched_init  # type: ignore[method-assign]
 
 
 class DocumentConflictError(RuntimeError):
@@ -61,6 +99,7 @@ class CouchDBClient:
             return
 
         try:
+            _patch_aiocouch_aiohttp_auth()
             self._client = CouchDB(
                 self._url,
                 user=self._user,

--- a/middleware/api/src/middleware/api/document_store/couchdb_client.py
+++ b/middleware/api/src/middleware/api/document_store/couchdb_client.py
@@ -45,7 +45,7 @@ def _patch_aiocouch_aiohttp_auth() -> None:
         headers: dict[str, str] = dict(kwargs.pop("headers", None) or {})
         if cookie:
             headers["Cookie"] = "AuthSession=" + cookie
-        if user and password:
+        if user is not None and password is not None:
             headers["Authorization"] = aiohttp.encode_basic_auth(user, password)
         self._http_session = aiohttp.ClientSession(
             headers=headers if headers else None,

--- a/middleware/api/tests/system_external/conftest.py
+++ b/middleware/api/tests/system_external/conftest.py
@@ -6,6 +6,7 @@ import subprocess
 import tempfile
 import time
 from collections.abc import Generator
+from datetime import timedelta
 from pathlib import Path
 from typing import Any
 
@@ -16,7 +17,10 @@ from dotenv import load_dotenv
 from fastapi.testclient import TestClient
 from gitlab import Gitlab, GitlabError
 from testcontainers.core.container import DockerContainer  # type: ignore[import-untyped]
-from testcontainers.core.wait_strategies import LogMessageWaitStrategy  # type: ignore[import-untyped]
+from testcontainers.core.wait_strategies import (  # type: ignore[import-untyped]
+    HttpWaitStrategy,
+    LogMessageWaitStrategy,
+)
 
 from middleware.api.api.fastapi_app import Api
 from middleware.api.config import Config
@@ -47,7 +51,10 @@ def external_services() -> Generator[dict[str, str], None, None]:
         .with_env("COUCHDB_USER", _COUCHDB_USER)
         .with_env("COUCHDB_PASSWORD", couchdb_password)
         .with_exposed_ports(_COUCHDB_PORT)
-        .waiting_for(LogMessageWaitStrategy("Apache CouchDB has started"))
+        # Prefer /_up over the startup log: log can appear before HTTP is ready.
+        .waiting_for(
+            HttpWaitStrategy(_COUCHDB_PORT, "/_up").for_status_code(200).with_startup_timeout(timedelta(seconds=60))
+        )
     )
     rabbitmq_container = (
         DockerContainer(_RABBITMQ_IMAGE)
@@ -180,12 +187,14 @@ def cleanup_gitlab_group(gitlab_group: Any, gitlab_api: Gitlab) -> None:  # pyli
 def worker_process(
     external_services: dict[str, str],
     config: dict[str, Any],
-) -> Generator[None, None, None]:
+) -> Generator[Path, None, None]:
     """Spawn a real Celery worker that consumes from the testcontainer RabbitMQ.
 
     The worker is started as a subprocess (no pytest in its sys.modules), so
     celery_app.py loads a proper WorkerConfig from a temporary YAML file
     pointing at the same CouchDB and RabbitMQ testcontainers used by the API.
+
+    Yields the worker log path so failing tests can include recent worker output.
     """
     gitlab_token = os.getenv("GITLAB_API_TOKEN", "")
     worker_cfg: dict[str, Any] = {
@@ -268,7 +277,7 @@ def worker_process(
         )
 
     try:
-        yield
+        yield log_path
     finally:
         proc.terminate()
         try:

--- a/middleware/api/tests/system_external/test_system_create_or_update_arcs.py
+++ b/middleware/api/tests/system_external/test_system_create_or_update_arcs.py
@@ -25,7 +25,6 @@ pytestmark = [
 
 @pytest.mark.asyncio
 @pytest.mark.system_external
-@pytest.mark.usefixtures("worker_process")
 @pytest.mark.parametrize(
     "json_info",
     [
@@ -39,6 +38,7 @@ async def test_create_arcs(
     json_info: dict[str, Any],
     gitlab_api: Gitlab,
     config: dict[str, Any],
+    worker_process: Path,
 ) -> None:
     """Test creating ARCs via the /v1/arcs endpoint."""
     cert_with_linebreaks = cert.replace("\\n", "\n")
@@ -59,7 +59,7 @@ async def test_create_arcs(
     assert "task_id" in body  # nosec
     assert body["status"] == "processing"  # nosec
 
-    _wait_for_gitlab_project(gitlab_api, config, json_info)
+    _wait_for_gitlab_project(gitlab_api, config, json_info, worker_log_path=worker_process)
 
 
 def _verify_gitlab_project(gitlab_api: Gitlab, config: dict[str, Any], json_info: dict[str, Any]) -> bool:
@@ -84,6 +84,7 @@ def _wait_for_gitlab_project(
     json_info: dict[str, Any],
     timeout_seconds: int = 180,
     poll_interval_seconds: int = 2,
+    worker_log_path: Path | None = None,
 ) -> None:
     """Poll GitLab until the ARC project and expected file are present."""
     timeout_seconds = int(os.getenv("SYSTEM_EXTERNAL_GITLAB_TIMEOUT", str(timeout_seconds)))
@@ -93,11 +94,15 @@ def _wait_for_gitlab_project(
             return
         time.sleep(poll_interval_seconds)
 
-    pytest.fail(
+    details = (
         "GitLab side effect not observed within timeout: expected project and "
         "isa.investigation.xlsx file were not found. "
         "Ensure the sync worker path is active for system_external tests."
     )
+    if worker_log_path is not None and worker_log_path.exists():
+        log_tail = worker_log_path.read_text(encoding="utf-8", errors="replace")[-4000:]
+        details = f"{details}\n\nCelery worker log (tail):\n{log_tail}"
+    pytest.fail(details)
 
 
 # ---------------------------------------------------------------------------

--- a/middleware/api/tests/system_local/test_system_couchdb_persistence.py
+++ b/middleware/api/tests/system_local/test_system_couchdb_persistence.py
@@ -11,11 +11,12 @@ through CouchDBClient, exactly as the production path looks.
 
 import uuid
 from collections.abc import AsyncGenerator, Generator
+from datetime import timedelta
 
 import pytest
 from pydantic import SecretStr
 from testcontainers.core.container import DockerContainer  # type: ignore[import-untyped]
-from testcontainers.core.wait_strategies import LogMessageWaitStrategy  # type: ignore[import-untyped]
+from testcontainers.core.wait_strategies import HttpWaitStrategy  # type: ignore[import-untyped]
 
 from middleware.api.document_store.config import CouchDBConfig
 from middleware.api.document_store.couchdb_client import CouchDBClient
@@ -40,9 +41,12 @@ def couchdb_container() -> Generator[DockerContainer, None, None]:
         .with_env("COUCHDB_USER", _COUCHDB_USER)
         .with_env("COUCHDB_PASSWORD", _COUCHDB_PASSWORD)
         .with_exposed_ports(_COUCHDB_PORT)
-        # Wait strategy must be set before __enter__ so the container
-        # blocks until CouchDB is fully initialised.
-        .waiting_for(LogMessageWaitStrategy("Apache CouchDB has started"))
+        # Wait for HTTP readiness, not the startup log line: with COUCHDB_USER set,
+        # CouchDB may log "Apache CouchDB has started" before the listener accepts
+        # connections (common flake on slower CI runners).
+        .waiting_for(
+            HttpWaitStrategy(_COUCHDB_PORT, "/_up").for_status_code(200).with_startup_timeout(timedelta(seconds=60))
+        )
     )
     with container:
         yield container

--- a/middleware/api/tests/unit/test_content_hash.py
+++ b/middleware/api/tests/unit/test_content_hash.py
@@ -6,6 +6,7 @@ import json
 from middleware.api.document_store.content_hash import (
     RoCrateContent,
     calculate_arc_content_hash,
+    canonicalize_rocrate_for_hash,
     strip_volatile_rocrate_fields,
 )
 
@@ -18,6 +19,7 @@ def test_strip_volatile_rocrate_fields_removes_timestamps_recursively() -> None:
             {
                 "@id": "./",
                 "identifier": "arc-1",
+                "dateCreated": "2026-01-01",
                 "datePublished": "2026-01-01T00:00:00.000",
                 "sdDatePublished": "2026-01-01T00:00:00.001",
             },
@@ -38,6 +40,7 @@ def test_strip_volatile_rocrate_fields_removes_timestamps_recursively() -> None:
     assert isinstance(root, dict)
     assert isinstance(study, dict)
 
+    assert "dateCreated" not in root
     assert "datePublished" not in root
     assert "sdDatePublished" not in root
     assert "dateModified" not in study
@@ -52,6 +55,7 @@ def test_calculate_arc_content_hash_ignores_timestamp_only_differences() -> None
             {
                 "@id": "./",
                 "identifier": "arc-1",
+                "dateCreated": "2024-01-15",
                 "datePublished": "2026-01-01T10:00:00.111",
                 "sdDatePublished": "2026-01-01T10:00:00.112",
             },
@@ -64,6 +68,7 @@ def test_calculate_arc_content_hash_ignores_timestamp_only_differences() -> None
             {
                 "@id": "./",
                 "identifier": "arc-1",
+                "dateCreated": "2026-08-11",
                 "datePublished": "2026-07-01T11:19:33.494",
                 "sdDatePublished": "2026-07-01T11:19:33.557",
             },
@@ -72,6 +77,29 @@ def test_calculate_arc_content_hash_ignores_timestamp_only_differences() -> None
     }
 
     assert calculate_arc_content_hash(base) == calculate_arc_content_hash(refreshed)
+
+
+def test_calculate_arc_content_hash_ignores_graph_order() -> None:
+    """``@graph`` node order must not affect the content hash."""
+    first: RoCrateContent = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {"@id": "./", "identifier": "arc-1"},
+            {"@id": "#study", "name": "Study"},
+        ],
+    }
+    reordered: RoCrateContent = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {"@id": "#study", "name": "Study"},
+            {"@id": "./", "identifier": "arc-1"},
+        ],
+    }
+
+    assert calculate_arc_content_hash(first) == calculate_arc_content_hash(reordered)
+    assert calculate_arc_content_hash(first) == calculate_arc_content_hash(
+        canonicalize_rocrate_for_hash(reordered)
+    )
 
 
 def test_calculate_arc_content_hash_detects_real_content_changes() -> None:

--- a/middleware/api/tests/unit/test_content_hash.py
+++ b/middleware/api/tests/unit/test_content_hash.py
@@ -97,9 +97,7 @@ def test_calculate_arc_content_hash_ignores_graph_order() -> None:
     }
 
     assert calculate_arc_content_hash(first) == calculate_arc_content_hash(reordered)
-    assert calculate_arc_content_hash(first) == calculate_arc_content_hash(
-        canonicalize_rocrate_for_hash(reordered)
-    )
+    assert calculate_arc_content_hash(first) == calculate_arc_content_hash(canonicalize_rocrate_for_hash(reordered))
 
 
 def test_calculate_arc_content_hash_detects_real_content_changes() -> None:

--- a/middleware/api/tests/unit/test_couchdb_client.py
+++ b/middleware/api/tests/unit/test_couchdb_client.py
@@ -66,6 +66,20 @@ async def test_aiocouch_remote_server_avoids_basicauth_deprecation() -> None:
 
 
 @pytest.mark.asyncio
+async def test_aiocouch_remote_server_encodes_empty_string_credentials() -> None:
+    """Empty-string user/password are set values and must still yield Basic auth."""
+    _patch_aiocouch_aiohttp_auth()
+
+    server = RemoteServer("http://localhost:5984", user="", password="")
+    try:
+        auth = server._http_session._default_headers.get("Authorization")  # noqa: SLF001
+        assert auth is not None
+        assert str(auth).startswith("Basic ")
+    finally:
+        await server.close()
+
+
+@pytest.mark.asyncio
 async def test_couchdb_client_connect_success(couchdb_client: CouchDBClient) -> None:
     """Test successful connection to CouchDB.
 

--- a/middleware/api/tests/unit/test_couchdb_client.py
+++ b/middleware/api/tests/unit/test_couchdb_client.py
@@ -1,14 +1,20 @@
 """Unit tests for CouchDB client."""
 
+import warnings
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiocouch import CouchDB
 from aiocouch.exception import NotFoundError, PreconditionFailedError
+from aiocouch.remote import RemoteServer
 from pydantic import SecretStr
 
 from middleware.api.document_store.config import CouchDBConfig
-from middleware.api.document_store.couchdb_client import CouchDBClient, DocumentConflictError
+from middleware.api.document_store.couchdb_client import (
+    CouchDBClient,
+    DocumentConflictError,
+    _patch_aiocouch_aiohttp_auth,
+)
 
 
 @pytest.fixture
@@ -38,6 +44,25 @@ def couchdb_client(couchdb_config: CouchDBConfig) -> CouchDBClient:
         An instance of CouchDBClient initialized with the provided configuration.
     """
     return CouchDBClient.from_config(couchdb_config)
+
+
+@pytest.mark.asyncio
+async def test_aiocouch_remote_server_avoids_basicauth_deprecation() -> None:
+    """Patched aiocouch must not trigger aiohttp BasicAuth / auth= deprecations."""
+    _patch_aiocouch_aiohttp_auth()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        server = RemoteServer("http://localhost:5984", user="admin", password="secret")
+        await server.close()
+
+    auth_warnings = [
+        w
+        for w in caught
+        if issubclass(w.category, DeprecationWarning)
+        and ("BasicAuth" in str(w.message) or "auth' parameter is deprecated" in str(w.message))
+    ]
+    assert auth_warnings == []
 
 
 @pytest.mark.asyncio

--- a/middleware/api_client/pyproject.toml
+++ b/middleware/api_client/pyproject.toml
@@ -36,9 +36,6 @@ markers = [
 [tool.hatch.build.targets.wheel]
 packages = ["src/middleware"]
 
-[tool.ruff]
-extend = "../../pyproject.toml"
-
 [tool.hatch.version]
 source = "vcs"
 raw-options = { root = "../..", fallback_version = "0.0.0", tag_regex = "^(?:v|.*-(?:chart|docker)-v)(?P<version>\\d+\\.\\d+\\.\\d+)(?:$|[-+].*)" }

--- a/middleware/shared/pyproject.toml
+++ b/middleware/shared/pyproject.toml
@@ -16,9 +16,6 @@ dependencies = [
 [tool.hatch.build.targets.wheel]
 packages = ["src/middleware"]
 
-[tool.ruff]
-extend = "../../pyproject.toml"
-
 [tool.hatch.version]
 source = "vcs"
 raw-options = { root = "../..", fallback_version = "0.0.0", tag_regex = "^(?:v|.*-(?:chart|docker)-v)(?P<version>\\d+\\.\\d+\\.\\d+)(?:$|[-+].*)" }

--- a/middleware/shared/src/middleware/shared/report/__init__.py
+++ b/middleware/shared/src/middleware/shared/report/__init__.py
@@ -2,12 +2,19 @@
 
 from middleware.shared.report.formats.base import ReportSerializer
 from middleware.shared.report.formats.jsonld import FAIRAGRO_HARVEST_REPORT_NS, JsonLdReportSerializer
-from middleware.shared.report.model import FailedRecord, HarvestReport, RepositoryReport, RepositoryScope
+from middleware.shared.report.model import (
+    HarvestIssue,
+    HarvestReport,
+    IssueKind,
+    RepositoryReport,
+    RepositoryScope,
+)
 
 __all__ = [
     "FAIRAGRO_HARVEST_REPORT_NS",
-    "FailedRecord",
+    "HarvestIssue",
     "HarvestReport",
+    "IssueKind",
     "JsonLdReportSerializer",
     "ReportSerializer",
     "RepositoryReport",

--- a/middleware/shared/src/middleware/shared/report/formats/jsonld.py
+++ b/middleware/shared/src/middleware/shared/report/formats/jsonld.py
@@ -6,7 +6,7 @@ import json
 from datetime import UTC, datetime
 from typing import Any
 
-from middleware.shared.report.model import FailedRecord, HarvestReport, RepositoryReport
+from middleware.shared.report.model import HarvestIssue, HarvestReport, RepositoryReport
 
 FAIRAGRO_HARVEST_REPORT_NS = "https://fairagro.github.io/m4.2_advanced_middleware_api/ns/harvest-report/v1/#"
 
@@ -32,12 +32,15 @@ def _format_iso_timestamp(value: datetime) -> str:
     return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
 
 
-def _failed_record_node(record: FailedRecord) -> dict[str, Any]:
-    node: dict[str, Any] = {"fairagro:message": record.message}
-    if record.record_id is not None:
-        node["fairagro:recordId"] = record.record_id
-    if record.url is not None:
-        node["fairagro:url"] = record.url
+def _failure_node(issue: HarvestIssue) -> dict[str, Any]:
+    node: dict[str, Any] = {
+        "fairagro:message": issue.message,
+        "fairagro:kind": issue.kind.value,
+    }
+    if issue.record_id is not None:
+        node["fairagro:recordId"] = issue.record_id
+    if issue.url is not None:
+        node["fairagro:url"] = issue.url
     return node
 
 
@@ -59,8 +62,8 @@ def _entry_point(repo: RepositoryReport) -> dict[str, Any]:
         entry["fairagro:totalStudies"] = repo.total_studies
     if repo.total_assays is not None:
         entry["fairagro:totalAssays"] = repo.total_assays
-    if repo.failed_records:
-        entry["fairagro:failedRecords"] = [_failed_record_node(r) for r in repo.failed_records]
+    if repo.failures:
+        entry["fairagro:failures"] = [_failure_node(issue) for issue in repo.failures]
     return entry
 
 

--- a/middleware/shared/src/middleware/shared/report/formats/jsonld.py
+++ b/middleware/shared/src/middleware/shared/report/formats/jsonld.py
@@ -1,4 +1,4 @@
-"""JSON-LD serializer for HarvestReport (harvester-compatible wire shape)."""
+"""JSON-LD serializer for HarvestReport (vocabulary v2 wire shape)."""
 
 from __future__ import annotations
 

--- a/middleware/shared/src/middleware/shared/report/formats/jsonld.py
+++ b/middleware/shared/src/middleware/shared/report/formats/jsonld.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from middleware.shared.report.model import HarvestIssue, HarvestReport, RepositoryReport
 
-FAIRAGRO_HARVEST_REPORT_NS = "https://fairagro.github.io/m4.2_advanced_middleware_api/ns/harvest-report/v1/#"
+FAIRAGRO_HARVEST_REPORT_NS = "https://fairagro.github.io/m4.2_advanced_middleware_api/ns/harvest-report/v2/#"
 
 _JSON_LD_CONTEXT: dict[str, Any] = {
     "@vocab": "https://schema.org/",

--- a/middleware/shared/src/middleware/shared/report/model.py
+++ b/middleware/shared/src/middleware/shared/report/model.py
@@ -31,6 +31,16 @@ class HarvestIssue:
     record_id: str | None = None
     url: str | None = None
 
+    def __post_init__(self) -> None:
+        """Normalize ``kind`` and reject ``record_id`` on repository issues."""
+        try:
+            kind = self.kind if isinstance(self.kind, IssueKind) else IssueKind(self.kind)
+        except ValueError as exc:
+            raise ValueError(f"invalid issue kind: {self.kind!r}") from exc
+        object.__setattr__(self, "kind", kind)
+        if kind is IssueKind.REPOSITORY and self.record_id is not None:
+            raise ValueError("record_id is only valid for dataset-scoped issues")
+
 
 @dataclass(frozen=True)
 class RepositoryReport:  # pylint: disable=too-many-instance-attributes

--- a/middleware/shared/src/middleware/shared/report/model.py
+++ b/middleware/shared/src/middleware/shared/report/model.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import threading
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from enum import StrEnum
 
 
 def _require_aware_utc(value: datetime, *, what: str) -> datetime:
@@ -14,11 +15,19 @@ def _require_aware_utc(value: datetime, *, what: str) -> datetime:
     return value.astimezone(UTC)
 
 
+class IssueKind(StrEnum):
+    """Classification of a harvest issue for operator reports."""
+
+    DATASET = "dataset"
+    REPOSITORY = "repository"
+
+
 @dataclass(frozen=True)
-class FailedRecord:
-    """A single dataset that failed during harvesting."""
+class HarvestIssue:
+    """One harvest issue (dataset failure or repository-level problem)."""
 
     message: str
+    kind: IssueKind = IssueKind.DATASET
     record_id: str | None = None
     url: str | None = None
 
@@ -34,7 +43,7 @@ class RepositoryReport:  # pylint: disable=too-many-instance-attributes
     harvested_datasets: int = 0
     failed_datasets: int = 0
     skipped_datasets: int = 0
-    failed_records: tuple[FailedRecord, ...] = ()
+    failures: tuple[HarvestIssue, ...] = ()
     total_studies: int | None = None
     total_assays: int | None = None
 
@@ -48,7 +57,7 @@ class _DatasetCounts:
     harvested_datasets: int = 0
     failed_datasets: int = 0
     skipped_datasets: int = 0
-    failed_records: list[FailedRecord] = field(default_factory=list)
+    failures: list[HarvestIssue] = field(default_factory=list)
 
 
 @dataclass
@@ -111,10 +120,28 @@ class RepositoryScope:
         record_id: str | None = None,
         url: str | None = None,
     ) -> None:
-        """Record one failed dataset and append a failed-record detail."""
+        """Record one failed dataset and append a dataset-scoped issue."""
         with self._lock:
             self._datasets.failed_datasets += 1
-            self._datasets.failed_records.append(FailedRecord(message=message, record_id=record_id, url=url))
+            self._datasets.failures.append(
+                HarvestIssue(
+                    message=message,
+                    kind=IssueKind.DATASET,
+                    record_id=record_id,
+                    url=url,
+                )
+            )
+
+    def record_repository_issue(self, message: str, *, url: str | None = None) -> None:
+        """Append a repository-level issue without incrementing failed datasets."""
+        with self._lock:
+            self._datasets.failures.append(
+                HarvestIssue(
+                    message=message,
+                    kind=IssueKind.REPOSITORY,
+                    url=url,
+                )
+            )
 
     def record_skipped(self) -> None:
         """Record one intentionally skipped dataset."""
@@ -156,7 +183,7 @@ class RepositoryScope:
                 harvested_datasets=datasets.harvested_datasets,
                 failed_datasets=datasets.failed_datasets,
                 skipped_datasets=datasets.skipped_datasets,
-                failed_records=tuple(datasets.failed_records),
+                failures=tuple(datasets.failures),
                 total_studies=total_studies,
                 total_assays=total_assays,
             )

--- a/middleware/shared/tests/unit/test_harvest_report.py
+++ b/middleware/shared/tests/unit/test_harvest_report.py
@@ -96,6 +96,28 @@ def test_harvest_issue_message_only() -> None:
     assert issue.url is None
 
 
+def test_harvest_issue_coerces_kind_string() -> None:
+    """String kind values are normalized to IssueKind."""
+    issue = HarvestIssue(message="boom", kind="repository")  # type: ignore[arg-type]
+    assert issue.kind is IssueKind.REPOSITORY
+
+
+def test_harvest_issue_rejects_invalid_kind() -> None:
+    """Unknown kind values raise ValueError."""
+    with pytest.raises(ValueError, match="invalid issue kind"):
+        HarvestIssue(message="boom", kind="nope")  # type: ignore[arg-type]
+
+
+def test_harvest_issue_rejects_record_id_for_repository() -> None:
+    """Repository issues must not carry a dataset record id."""
+    with pytest.raises(ValueError, match="record_id"):
+        HarvestIssue(
+            message="sitemap failed",
+            kind=IssueKind.REPOSITORY,
+            record_id="should-not-exist",
+        )
+
+
 def test_mutable_run_records_start_time() -> None:
     """Creating a report records an authoritative start timestamp."""
     report = HarvestReport(start_time=_START)

--- a/middleware/shared/tests/unit/test_harvest_report.py
+++ b/middleware/shared/tests/unit/test_harvest_report.py
@@ -267,7 +267,7 @@ def test_jsonld_context_and_types() -> None:
     assert document["@context"]["@vocab"] == "https://schema.org/"
     assert document["@context"]["schema"] == "https://schema.org/"
     assert document["@context"]["fairagro"] == FAIRAGRO_HARVEST_REPORT_NS
-    assert document["@context"]["fairagro"].endswith("/ns/harvest-report/v1/#")
+    assert document["@context"]["fairagro"].endswith("/ns/harvest-report/v2/#")
     assert document["@type"] == "schema:Action"
     assert document["schema:result"][0]["@type"] == "schema:EntryPoint"
 

--- a/middleware/shared/tests/unit/test_harvest_report.py
+++ b/middleware/shared/tests/unit/test_harvest_report.py
@@ -14,8 +14,9 @@ import pytest
 
 from middleware.shared.report import (
     FAIRAGRO_HARVEST_REPORT_NS,
-    FailedRecord,
+    HarvestIssue,
     HarvestReport,
+    IssueKind,
     JsonLdReportSerializer,
     RepositoryScope,
 )
@@ -73,19 +74,26 @@ def _open_sample_scope(report: HarvestReport) -> None:
     scope.close(closed_at=_SCOPE_CLOSE)
 
 
-def test_failed_record_with_optional_identifiers() -> None:
-    """Failed records expose message, record id, and URL when provided."""
-    record = FailedRecord(message="boom", record_id="id-1", url="https://x.test")
-    assert record.message == "boom"
-    assert record.record_id == "id-1"
-    assert record.url == "https://x.test"
+def test_harvest_issue_with_optional_identifiers() -> None:
+    """Harvest issues expose message, kind, record id, and URL when provided."""
+    issue = HarvestIssue(
+        message="boom",
+        kind=IssueKind.DATASET,
+        record_id="id-1",
+        url="https://x.test",
+    )
+    assert issue.message == "boom"
+    assert issue.kind is IssueKind.DATASET
+    assert issue.record_id == "id-1"
+    assert issue.url == "https://x.test"
 
 
-def test_failed_record_message_only() -> None:
-    """Optional identifiers are unset when omitted."""
-    record = FailedRecord(message="boom")
-    assert record.record_id is None
-    assert record.url is None
+def test_harvest_issue_message_only() -> None:
+    """Optional identifiers default to unset; kind defaults to dataset."""
+    issue = HarvestIssue(message="boom")
+    assert issue.kind is IssueKind.DATASET
+    assert issue.record_id is None
+    assert issue.url is None
 
 
 def test_mutable_run_records_start_time() -> None:
@@ -159,7 +167,33 @@ def test_counting_increments() -> None:
     assert snap.skipped_datasets == 1
     assert snap.total_studies == _STUDIES
     assert snap.total_assays == _ASSAYS
-    assert snap.failed_records == (FailedRecord(message="bad", record_id="r1", url="https://x.test/r1"),)
+    assert snap.failures == (
+        HarvestIssue(
+            message="bad",
+            kind=IssueKind.DATASET,
+            record_id="r1",
+            url="https://x.test/r1",
+        ),
+    )
+
+
+def test_repository_issue_does_not_increment_failed_datasets() -> None:
+    """Repository-level issues append to failures without counting datasets."""
+    report = HarvestReport(start_time=_START)
+    scope = report.open_repository("publisso")
+    scope.record_repository_issue(
+        "Sitemap discovery failed for https://frl.publisso.de/find",
+        url="https://frl.publisso.de/find",
+    )
+    snap = scope.snapshot()
+    assert snap.failed_datasets == 0
+    assert snap.failures == (
+        HarvestIssue(
+            message="Sitemap discovery failed for https://frl.publisso.de/find",
+            kind=IssueKind.REPOSITORY,
+            url="https://frl.publisso.de/find",
+        ),
+    )
 
 
 def test_study_assay_omit_when_both_zero() -> None:
@@ -248,8 +282,8 @@ def test_jsonld_timestamps_and_durations() -> None:
     assert document["schema:result"][0]["schema:duration"].startswith("PT")
 
 
-def test_jsonld_metrics_and_failed_records() -> None:
-    """Fairagro metrics and nested failed records are emitted."""
+def test_jsonld_metrics_and_failures() -> None:
+    """Fairagro metrics and nested failure issues are emitted."""
     report = _finished_report(populate=_open_sample_scope)
     entry = json.loads(JsonLdReportSerializer().render(report))["schema:result"][0]
     assert entry["@id"] == "bonares"
@@ -258,11 +292,35 @@ def test_jsonld_metrics_and_failed_records() -> None:
     assert entry["fairagro:harvestedDatasets"] == _SAMPLE_HARVESTED
     assert entry["fairagro:failedDatasets"] == _SAMPLE_FAILED
     assert entry["fairagro:skippedDatasets"] == _SAMPLE_SKIPPED
-    assert entry["fairagro:failedRecords"][0] == {
+    assert entry["fairagro:failures"][0] == {
         "fairagro:message": "map failed",
+        "fairagro:kind": "dataset",
         "fairagro:recordId": "frl:123",
         "fairagro:url": "https://example.test/frl:123",
     }
+
+
+def test_jsonld_repository_issue_without_failed_datasets() -> None:
+    """Repository issues appear under failures while failedDatasets stays 0."""
+
+    def populate(report: HarvestReport) -> None:
+        scope = report.open_repository("publisso")
+        scope.record_repository_issue(
+            "Sitemap discovery failed",
+            url="https://frl.publisso.de/find",
+        )
+        scope.close(closed_at=_SCOPE_CLOSE)
+
+    report = _finished_report(populate=populate)
+    entry = json.loads(JsonLdReportSerializer().render(report))["schema:result"][0]
+    assert entry["fairagro:failedDatasets"] == 0
+    assert entry["fairagro:failures"] == [
+        {
+            "fairagro:message": "Sitemap discovery failed",
+            "fairagro:kind": "repository",
+            "fairagro:url": "https://frl.publisso.de/find",
+        }
+    ]
 
 
 def test_jsonld_optional_study_and_assay_totals() -> None:
@@ -312,8 +370,8 @@ def test_jsonld_harvest_id_null_when_unset() -> None:
     assert entry["fairagro:harvestId"] is None
 
 
-def test_jsonld_omits_empty_failed_records() -> None:
-    """Empty failed-record lists are omitted from JSON-LD."""
+def test_jsonld_omits_empty_failures() -> None:
+    """Empty failure lists are omitted from JSON-LD."""
 
     def populate(report: HarvestReport) -> None:
         scope = report.open_repository("bonares")
@@ -321,7 +379,7 @@ def test_jsonld_omits_empty_failed_records() -> None:
 
     report = _finished_report(populate=populate)
     entry = json.loads(JsonLdReportSerializer().render(report))["schema:result"][0]
-    assert "fairagro:failedRecords" not in entry
+    assert "fairagro:failures" not in entry
 
 
 def test_jsonld_empty_result_array() -> None:

--- a/middleware/tools/README.md
+++ b/middleware/tools/README.md
@@ -73,11 +73,13 @@ python rocrate2arc.py my_research_rocrate.json restored_research.arc
 
 ## Performance Profiling
 
-The `rocrate2arc.py` tool includes built-in profiling that generates detailed performance statistics. After running the conversion, check the `profile.stats` file and the console output for the top 20 most time-consuming operations.
+The `rocrate2arc.py` tool includes built-in profiling that generates detailed
+performance statistics. After running the conversion, check the `profile.stats`
+file and the console output for the top 20 most time-consuming operations.
 
 ## Dependencies
 
-- `arctrl>=3.0.0b15` - ARC and RO-Crate conversion library
+- `arctrl>=3.1.1` - ARC and RO-Crate conversion library
 
 ## Requirements
 
@@ -85,7 +87,8 @@ The `rocrate2arc.py` tool includes built-in profiling that generates detailed pe
 
 ## Development
 
-This package is part of the FAIRagro Advanced Middleware project and is used for testing and development of ARC conversion workflows.
+This package is part of the FAIRagro Advanced Middleware project and is used for
+testing and development of ARC conversion workflows.
 
 ## License
 

--- a/middleware/tools/pyproject.toml
+++ b/middleware/tools/pyproject.toml
@@ -5,14 +5,11 @@ description = "ARC conversion tools"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "arctrl>=3.0.0b15",
+    "arctrl>=3.1.1",
 ]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/middleware"]
-
-[tool.ruff]
-extend = "../../pyproject.toml"
 
 [tool.hatch.version]
 source = "vcs"

--- a/ns/harvest-report/v1/README.md
+++ b/ns/harvest-report/v1/README.md
@@ -20,10 +20,11 @@ report (`middleware.shared.report`). Schema.org terms (`Action`, `EntryPoint`,
 | `harvestedDatasets` | Datasets successfully harvested and forwarded to the API |
 | `failedDatasets` | Datasets that failed during harvest or upload |
 | `skippedDatasets` | Datasets intentionally skipped |
-| `failedRecords` | Ordered list of per-record failure objects |
-| `message` | Human-readable failure message on a failed record |
-| `recordId` | Optional source record identifier |
-| `url` | Optional URL related to the failed record |
+| `failures` | Ordered list of harvest issues (dataset or repository) |
+| `kind` | Issue kind: `dataset` or `repository` |
+| `message` | Human-readable failure message on an issue |
+| `recordId` | Optional source record identifier (dataset issues) |
+| `url` | Optional URL related to the issue |
 | `totalStudies` | Optional count of studies produced for a repository |
 | `totalAssays` | Optional count of assays produced for a repository |
 

--- a/ns/harvest-report/v1/context.jsonld
+++ b/ns/harvest-report/v1/context.jsonld
@@ -28,9 +28,13 @@
       "@id": "fairagro:skippedDatasets",
       "@type": "xsd:integer"
     },
-    "failedRecords": {
-      "@id": "fairagro:failedRecords",
+    "failures": {
+      "@id": "fairagro:failures",
       "@container": "@list"
+    },
+    "kind": {
+      "@id": "fairagro:kind",
+      "@type": "xsd:string"
     },
     "message": {
       "@id": "fairagro:message",

--- a/ns/harvest-report/v2/README.md
+++ b/ns/harvest-report/v2/README.md
@@ -1,8 +1,8 @@
-# Harvest report vocabulary (v1)
+# Harvest report vocabulary (v2)
 
 Canonical namespace IRI:
 
-`https://fairagro.github.io/m4.2_advanced_middleware_api/ns/harvest-report/v1/#`
+`https://fairagro.github.io/m4.2_advanced_middleware_api/ns/harvest-report/v2/#`
 
 Machine-readable JSON-LD context: [context.jsonld](./context.jsonld)
 
@@ -10,8 +10,9 @@ This vocabulary defines FAIRagro-specific terms used in the shared harvest-run
 report (`middleware.shared.report`). Schema.org terms (`Action`, `EntryPoint`,
 `startTime`, …) are not redefined here.
 
-**Frozen major:** v1 keeps `failedRecords`. The current serializer and successor
-terms (`failures`, `kind`) live under [v2](../v2/).
+**Breaking vs [v1](../v1/):** `failedRecords` is replaced by `failures` (dataset
+or repository issues) plus `kind` (`dataset` | `repository`).
+`failedDatasets` still counts only dataset failures.
 
 ## Terms
 
@@ -23,18 +24,19 @@ terms (`failures`, `kind`) live under [v2](../v2/).
 | `harvestedDatasets` | Datasets successfully harvested and forwarded to the API |
 | `failedDatasets` | Datasets that failed during harvest or upload |
 | `skippedDatasets` | Datasets intentionally skipped |
-| `failedRecords` | Ordered list of per-record failure objects |
-| `message` | Human-readable failure message on a failed record |
-| `recordId` | Optional source record identifier |
-| `url` | Optional URL related to the failed record |
+| `failures` | Ordered list of harvest issues (dataset or repository) |
+| `kind` | Issue kind: `dataset` or `repository` |
+| `message` | Human-readable failure message on an issue |
+| `recordId` | Optional source record identifier (dataset issues) |
+| `url` | Optional URL related to the issue |
 | `totalStudies` | Optional count of studies produced for a repository |
 | `totalAssays` | Optional count of assays produced for a repository |
 
 ## Versioning
 
-- Path `v1` is a frozen vocabulary **major** version.
-- Incompatible changes require a new major path (`v2/`) and a new IRI.
-- Compatible additions may update files under `v1/` and be published with a new
+- Path `v2` is the vocabulary **major** version used by the current serializer.
+- Incompatible changes require a new major path (`v3/`) and a new IRI.
+- Compatible additions may update files under `v2/` and be published with a new
   patch/minor tag.
 
 ## Publishing
@@ -43,7 +45,7 @@ Do **not** enable GitHub Pages from branch `/docs`. Vocabulary publication is
 tag-gated:
 
 1. Tag: `ns/harvest-report/v<major>.<minor>.<patch>` (example:
-   `ns/harvest-report/v1.0.0`)
+   `ns/harvest-report/v2.0.0`)
 2. Workflow [publish-ns-pages.yml](../../../.github/workflows/publish-ns-pages.yml)
    deploys **only** the `ns/` tree to GitHub Pages (Actions source).
 3. Repo setting: Pages → Source = **GitHub Actions** (once).

--- a/ns/harvest-report/v2/context.jsonld
+++ b/ns/harvest-report/v2/context.jsonld
@@ -3,7 +3,7 @@
     "@vocab": "https://schema.org/",
     "schema": "https://schema.org/",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
-    "fairagro": "https://fairagro.github.io/m4.2_advanced_middleware_api/ns/harvest-report/v1/#",
+    "fairagro": "https://fairagro.github.io/m4.2_advanced_middleware_api/ns/harvest-report/v2/#",
     "harvestDurationSeconds": {
       "@id": "fairagro:harvestDurationSeconds",
       "@type": "xsd:double"
@@ -28,9 +28,13 @@
       "@id": "fairagro:skippedDatasets",
       "@type": "xsd:integer"
     },
-    "failedRecords": {
-      "@id": "fairagro:failedRecords",
+    "failures": {
+      "@id": "fairagro:failures",
       "@container": "@list"
+    },
+    "kind": {
+      "@id": "fairagro:kind",
+      "@type": "xsd:string"
     },
     "message": {
       "@id": "fairagro:message",

--- a/ns/harvest-report/v2/index.html
+++ b/ns/harvest-report/v2/index.html
@@ -2,25 +2,25 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>FAIRagro harvest-report vocabulary v1</title>
+    <title>FAIRagro harvest-report vocabulary v2</title>
     <meta
       name="description"
-      content="Namespace for FAIRagro harvest-run report JSON-LD terms (v1)."
+      content="Namespace for FAIRagro harvest-run report JSON-LD terms (v2)."
     />
     <link rel="alternate" type="application/ld+json" href="./context.jsonld" />
   </head>
   <body>
-    <h1>FAIRagro harvest-report vocabulary (v1)</h1>
+    <h1>FAIRagro harvest-report vocabulary (v2)</h1>
     <p>
       Canonical namespace IRI:
       <code
-        >https://fairagro.github.io/m4.2_advanced_middleware_api/ns/harvest-report/v1/#</code
+        >https://fairagro.github.io/m4.2_advanced_middleware_api/ns/harvest-report/v2/#</code
       >
     </p>
     <ul>
       <li><a href="./context.jsonld">JSON-LD context</a></li>
       <li><a href="./README.md">Term descriptions</a></li>
-      <li><a href="../v2/">Successor vocabulary (v2)</a></li>
+      <li><a href="../v1/">Previous vocabulary (v1)</a></li>
     </ul>
   </body>
 </html>

--- a/openspec/changes/shared-harvest-report/design.md
+++ b/openspec/changes/shared-harvest-report/design.md
@@ -96,10 +96,13 @@ run, and serialize. Wire shape remains the harvester JSON-LD baseline.
    implementations, not changes to the accumulator API. Writing the string
    (stdout, files, logs) stays in the calling tool.
 
-8. **JSON-LD wire shape = harvester baseline**
+8. **JSON-LD wire shape = harvester baseline (vocab v2)**
    — Newer multi-RDI shape, richer failures, `https://schema.org/`, documented
    omit semantics. SQL-to-ARC maps to one `EntryPoint` in `result[]`. Compact
    unprefixed keys and PROV-only terms are rejected for the shared wire format.
+   Emitting `fairagro:failures` under the v2 IRI is an **intentional breaking**
+   change vs v1 `failedRecords`; there is no legacy dual-field / v1 serializer
+   mode. Consumers MUST target v2 (or keep an older shared package for v1).
 
 9. **Optional study/assay totals on repository entries**
    — Preserves SQL-to-ARC operator value without overloading `schema:result`.

--- a/openspec/changes/shared-harvest-report/design.md
+++ b/openspec/changes/shared-harvest-report/design.md
@@ -78,10 +78,10 @@ run, and serialize. Wire shape remains the harvester JSON-LD baseline.
 5. **Names: `HarvestReport` (run), repository scope / handle, `HarvestIssue`**
    — Align with harvester/operator vocabulary. One failure list covers both
    dataset and repository-level problems (`IssueKind`); `failedDatasets` counts
-   only dataset failures. Wire term is `fairagro:failures` (not
-   `failedRecords`). Exact type and method names live in code; requirements
-   speak in domain events. A thin frozen view for serializers is an
-   implementation detail as long as counting remains the public write path.
+   only dataset failures. Wire term is `fairagro:failures` under vocabulary
+   **v2** (v1 used `failedRecords`). Exact type and method names live in code;
+   requirements speak in domain events. A thin frozen view for serializers is
+   an implementation detail as long as counting remains the public write path.
 
 6. **Concurrency: same-handle asyncio safety; multi-handle isolation**
    — SQL-to-ARC mutates one stats object from concurrent tasks. Counting on
@@ -110,10 +110,11 @@ run, and serialize. Wire shape remains the harvester JSON-LD baseline.
     `openspec/config.yaml`.
 
 11. **Versioned namespace IRI; vocab under `ns/` (not `docs/`)**
-    — Canonical IRI:
-      `https://fairagro.github.io/m4.2_advanced_middleware_api/ns/harvest-report/v1/#`
-    — Source: `ns/harvest-report/v1/{context.jsonld,README.md,index.html}`.
-    — Serializer embeds compact `@context` with that IRI; body keys stay
+    — Canonical IRI (current serializer):
+      `https://fairagro.github.io/m4.2_advanced_middleware_api/ns/harvest-report/v2/#`
+    — Source: `ns/harvest-report/v2/{context.jsonld,README.md,index.html}`.
+    — v1 remains frozen under `ns/harvest-report/v1/` with `failedRecords`.
+    — Serializer embeds compact `@context` with the v2 IRI; body keys stay
       prefixed. Unversioned or `docs/`-hosted IRIs are rejected.
 
 12. **Publish only `ns/` via GitHub Actions on vocabulary tags**

--- a/openspec/changes/shared-harvest-report/design.md
+++ b/openspec/changes/shared-harvest-report/design.md
@@ -63,7 +63,10 @@ run, and serialize. Wire shape remains the harvester JSON-LD baseline.
    - set expected dataset count (optional; harvester pre-fetch)
    - set harvest id (nullable until assigned)
    - record harvested dataset (definitive success / sql_to_arc found)
-   - record failed dataset (message; optional record id; optional URL)
+   - record failed dataset (message; optional record id; optional URL; bumps
+     failedDatasets and appends a `dataset` issue)
+   - record repository-level issue (message; optional URL; appends a
+     `repository` issue without bumping failedDatasets)
    - record skipped dataset (harvester `SkippedRecord`; always-on wire field)
    - add studies / add assays (sql_to_arc batch totals)
    Callers signal these events on the correct handle; the run aggregates
@@ -72,11 +75,13 @@ run, and serialize. Wire shape remains the harvester JSON-LD baseline.
    `harvest_arcs` / upload result), so duplicate or submission failures are
    recorded as failures only, never as a correction of a prior success count.
 
-5. **Names: `HarvestReport` (run), repository scope / handle, `FailedRecord`**
-   — Align with harvester/operator vocabulary. Exact type and method names live
-   in code; requirements speak in domain events. A thin frozen view for
-   serializers is an implementation detail as long as counting remains the
-   public write path.
+5. **Names: `HarvestReport` (run), repository scope / handle, `HarvestIssue`**
+   — Align with harvester/operator vocabulary. One failure list covers both
+   dataset and repository-level problems (`IssueKind`); `failedDatasets` counts
+   only dataset failures. Wire term is `fairagro:failures` (not
+   `failedRecords`). Exact type and method names live in code; requirements
+   speak in domain events. A thin frozen view for serializers is an
+   implementation detail as long as counting remains the public write path.
 
 6. **Concurrency: same-handle asyncio safety; multi-handle isolation**
    — SQL-to-ARC mutates one stats object from concurrent tasks. Counting on

--- a/openspec/changes/shared-harvest-report/proposal.md
+++ b/openspec/changes/shared-harvest-report/proposal.md
@@ -31,7 +31,7 @@ Work remains scoped to this repository; consumer migrations happen separately.
   ApiClient result), not optimistically before upload outcomes.
 - Keep pluggable serialization (JSON-LD first) that returns a document string;
   wire shape stays the harvester baseline (`schema:Action` + `schema:result` of
-  `EntryPoint`s, versioned `fairagro:` vocabulary under `ns/harvest-report/v1/`).
+  `EntryPoint`s, versioned `fairagro:` vocabulary under `ns/harvest-report/v2/`).
   Callers own stdout/logging of that string.
 - Update Spec-to-Code mapping in `AGENTS.md` for the domain.
 - **Non-goals:** changing `middleware/api` or `api_client` behavior; migrating
@@ -55,8 +55,8 @@ Work remains scoped to this repository; consumer migrations happen separately.
 
 - **Code:** `middleware/shared/.../report/` becomes a start/count/finish API
   plus serializers (existing snapshot-only API is superseded in this change).
-- **Vocab / Pages:** unchanged intent (`ns/harvest-report/v1/`, tag-gated
-  publish of `ns/` only).
+- **Vocab / Pages:** current serializer uses `ns/harvest-report/v2/` (v1 frozen
+  with `failedRecords`); tag-gated publish of `ns/` only.
 - **Package:** `fairagro-middleware-shared` public report API.
 - **Specs:** delta under `openspec/changes/shared-harvest-report/`; main
   `openspec/specs/harvest-report/` after archive.

--- a/openspec/changes/shared-harvest-report/proposal.md
+++ b/openspec/changes/shared-harvest-report/proposal.md
@@ -56,7 +56,9 @@ Work remains scoped to this repository; consumer migrations happen separately.
 - **Code:** `middleware/shared/.../report/` becomes a start/count/finish API
   plus serializers (existing snapshot-only API is superseded in this change).
 - **Vocab / Pages:** current serializer uses `ns/harvest-report/v2/` (v1 frozen
-  with `failedRecords`); tag-gated publish of `ns/` only.
+  with `failedRecords`); tag-gated publish of `ns/` only. The v2 wire
+  (`fairagro:failures`) is intentionally not backward-compatible with v1
+  `failedRecords`; no dual-emit / legacy serializer mode.
 - **Package:** `fairagro-middleware-shared` public report API.
 - **Specs:** delta under `openspec/changes/shared-harvest-report/`; main
   `openspec/specs/harvest-report/` after archive.

--- a/openspec/changes/shared-harvest-report/specs/harvest-report/spec.md
+++ b/openspec/changes/shared-harvest-report/specs/harvest-report/spec.md
@@ -311,7 +311,9 @@ and `fairagro:failures` as an array of issue objects (each with
 ### Requirement: Versioned vocabulary IRI
 
 The JSON-LD `@context` entry for `fairagro` SHALL use
-`https://fairagro.github.io/m4.2_advanced_middleware_api/ns/harvest-report/v1/#`
+`https://fairagro.github.io/m4.2_advanced_middleware_api/ns/harvest-report/v2/#`
 (hash fragment on the versioned path). Bumps that break term compatibility use
-a new version segment; documentation lives under `ns/harvest-report/v1/` and is
+a new version segment; documentation lives under `ns/harvest-report/v2/` and is
 published via GitHub Pages from tags without publishing unrelated `docs/` trees.
+The v1 vocabulary under `ns/harvest-report/v1/` remains frozen (`failedRecords`)
+and MUST NOT be altered by this rename.

--- a/openspec/changes/shared-harvest-report/specs/harvest-report/spec.md
+++ b/openspec/changes/shared-harvest-report/specs/harvest-report/spec.md
@@ -160,6 +160,19 @@ single dataset.
 - **THEN** the failed dataset count remains F
 - **AND** the failure list includes an entry with kind `repository`, M, and U
 
+### Requirement: Harvest issue construction constraints
+
+Constructing a harvest issue SHALL normalize `kind` to `dataset` or
+`repository` and SHALL reject a `record_id` when `kind` is `repository`
+(record identifiers apply only to dataset-scoped issues).
+
+#### Scenario: Repository issue with record id rejected
+
+- **GIVEN** a caller constructs a harvest issue with kind `repository` and a
+  non-null record id
+- **WHEN** construction is attempted
+- **THEN** construction fails with an error
+
 ### Requirement: Record skipped dataset
 
 The report SHALL provide a counting method on a repository scope handle that

--- a/openspec/changes/shared-harvest-report/specs/harvest-report/spec.md
+++ b/openspec/changes/shared-harvest-report/specs/harvest-report/spec.md
@@ -124,24 +124,41 @@ this method instead of maintaining their own harvested counter for the report.
 
 The report SHALL provide a counting method on a repository scope handle that
 records one failed dataset: increment that scope’s failed count by one and
-append a failed record carrying a human-readable message and optional record
-identifier and optional URL. Callers MUST use this method instead of
-maintaining parallel failure counters or failure lists for the report.
+append a harvest issue of kind `dataset` carrying a human-readable message and
+optional record identifier and optional URL. Callers MUST use this method
+instead of maintaining parallel failure counters or failure lists for the
+report.
 
 #### Scenario: Failure with record id and URL
 
 - **GIVEN** an open repository scope handle
-- **WHEN** the caller records a failure with message M, record id R, and URL U
+- **WHEN** the caller records a dataset failure with message M, record id R,
+  and URL U
 - **THEN** the failed count increases by one
-- **AND** the failure list includes an entry with M, R, and U
+- **AND** the failure list includes an entry with kind `dataset`, M, R, and U
 
 #### Scenario: Failure with message only
 
 - **GIVEN** an open repository scope handle
-- **WHEN** the caller records a failure with only a message
+- **WHEN** the caller records a dataset failure with only a message
 - **THEN** the failed count increases by one
-- **AND** the failure entry omits unset optional fields on the wire as
-  specified for failed records
+- **AND** the failure entry has kind `dataset` and omits unset optional fields
+  on the wire as specified for failures
+
+### Requirement: Record repository-level issue
+
+The report SHALL provide a method on a repository scope handle that appends a
+harvest issue of kind `repository` with a human-readable message and optional
+URL, without incrementing the failed dataset count. Callers MUST use this
+method for RDI-global or discovery failures that are not attributable to a
+single dataset.
+
+#### Scenario: Sitemap discovery failure
+
+- **GIVEN** an open repository scope handle with failed dataset count F
+- **WHEN** the caller records a repository-level issue with message M and URL U
+- **THEN** the failed dataset count remains F
+- **AND** the failure list includes an entry with kind `repository`, M, and U
 
 ### Requirement: Record skipped dataset
 
@@ -217,8 +234,8 @@ different open handles on the same run MUST remain isolated from each other.
 After or during a run, serializers SHALL be able to read repository
 statistics without depending on a particular wire format: RDI, harvest id
 (nullable), duration, expected (optional), harvested, failed, skipped, optional
-study/assay totals, and the list of failed records (message; optional id and
-URL).
+study/assay totals, and the list of harvest issues (kind; message; optional id
+and URL).
 
 #### Scenario: Serializer reads counted state
 
@@ -269,16 +286,27 @@ identifier; `schema:duration` as ISO 8601 duration for that scope;
 `fairagro:failedDatasets` as integers; `fairagro:skippedDatasets` as integer
 (including 0); `fairagro:expectedDatasets` only when set; optional
 `fairagro:totalStudies` / `fairagro:totalAssays` per the studies/assays rule;
-and `fairagro:failedRecords` as an array of failed-record objects.
+and `fairagro:failures` as an array of issue objects (each with
+`fairagro:kind` of `dataset` or `repository`, `fairagro:message`, and optional
+`fairagro:recordId` / `fairagro:url`).
 
 #### Scenario: Complete entry with expected and failures
 
 - **GIVEN** a repository scope with expected set, non-zero harvested/failed,
-  skipped zero, and at least one failed record with message and record id
+  skipped zero, and at least one dataset failure with message and record id
 - **WHEN** JSON-LD is produced for that entry
 - **THEN** the mapped properties above are present with those values
 - **AND** `fairagro:expectedDatasets` is present
 - **AND** `fairagro:skippedDatasets` is 0
+- **AND** `fairagro:failures` entries include `fairagro:kind`
+
+#### Scenario: Repository issue does not inflate failedDatasets
+
+- **GIVEN** a repository scope with only a repository-level issue recorded
+- **WHEN** JSON-LD is produced for that entry
+- **THEN** `fairagro:failedDatasets` is 0
+- **AND** `fairagro:failures` contains one entry with `fairagro:kind`
+  `repository`
 
 ### Requirement: Versioned vocabulary IRI
 

--- a/openspec/changes/shared-harvest-report/tasks.md
+++ b/openspec/changes/shared-harvest-report/tasks.md
@@ -40,10 +40,14 @@
       IRI, tag/publish notes) and optional `index.html` for browser resolution
 - [x] 4.3 Point `JsonLdReportSerializer` `fairagro` prefix at
       `https://fairagro.github.io/m4.2_advanced_middleware_api/ns/harvest-report/v1/#`
+      _(Superseded by 4.7 — serializer now uses v2.)_
 - [x] 4.4 Add GitHub Actions workflow: on tags `ns/harvest-report/v*`, publish
       only `ns/` to GitHub Pages (Actions source—not branch `/docs`)
 - [x] 4.5 Update unit tests for the versioned namespace IRI
 - [x] 4.6 Run `uv run pytest middleware/shared/tests/` and ruff on touched code
+- [x] 4.7 Bump vocabulary to `ns/harvest-report/v2/` for `failures`/`kind`
+      (incompatible with v1 `failedRecords`); freeze v1; point serializer and
+      tests at the v2 IRI
 
 ## 5. Accumulator redesign (counting API)
 

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -7,7 +7,7 @@ context: |
   Specs live under `openspec/specs/<domain>/` (kebab-case domains).
   Foundation contract: `openspec/principles.md` (read before proposing changes).
   Spec-to-code mapping is maintained in `AGENTS.md`.
-  Quality gates: `uv run ruff format/check middleware/`, mypy, pylint, bandit, pytest.
+  Quality gates: `uv run ruff format/check --config pyproject.toml middleware/`, mypy, pylint, bandit, pytest.
   Scale: one worker process per container; horizontal via Kubernetes replicas.
   Client certificates are optional; SSL verification on by default.
   Modules: middleware/api (primary), middleware/shared, middleware/api_client
@@ -35,7 +35,7 @@ operations:
   apply:
     guidance:
       - Run focused tests with `uv run pytest` on affected packages before the full suite.
-      - Run `uv run ruff format middleware/` and `uv run ruff check middleware/` on touched code.
+      - Run `uv run ruff format --config pyproject.toml middleware/` and `uv run ruff check --config pyproject.toml middleware/` on touched code.
       - >-
         Prefer real fixes over "# noqa" / "# type: ignore" / "# pylint: disable".
   archive:

--- a/openspec/principles.md
+++ b/openspec/principles.md
@@ -70,10 +70,10 @@ middleware/api_client/   ← optional client library for API consumers
 
 All code must pass:
 
-- `uv run ruff format --check middleware/` — formatting
-- `uv run ruff check middleware/` — linting
-- `uv run mypy middleware/` — static type checking
-- `uv run pylint middleware/` — style and code smells
+- `uv run ruff format --check --config pyproject.toml middleware/` — formatting
+- `uv run ruff check --config pyproject.toml middleware/` — linting
+- `uv run mypy --config-file pyproject.toml middleware/` — static type checking
+- `uv run pylint --rcfile pyproject.toml middleware/` — style and code smells
 - `uv run bandit -r middleware/ -c .bandit` — security (low findings logged, medium/high fail)
 
 **Suppression comments** (`# noqa`, `# type: ignore`, `# pylint: disable`) are

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,8 @@ force-single-line = false
 combine-as-imports = true
 
 [tool.ruff.lint.per-file-ignores]
-"middleware/*/tests/**/*.py" = ["SLF001"]
+# Pytest injects fixtures as function arguments; argument-count rules are noise there.
+"middleware/*/tests/**/*.py" = ["SLF001", "PLR0913", "PLR0917"]
 
 # Black and isort replaced by ruff format - configurations removed to avoid conflicts
 

--- a/scripts/diff_arc_content_hash.py
+++ b/scripts/diff_arc_content_hash.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+r"""Compare two RO-Crate payloads the same way middleware change detection does.
+
+Use this when GitLab shows daily ``Update ARC …`` commits and you need to see
+*why* ``has_changes`` became true: which JSON paths still differ after volatile
+timestamp stripping and ``@graph`` canonicalization.
+
+Examples:
+    # Two harvest payloads / exports
+    uv run python scripts/diff_arc_content_hash.py --a old.json --b new.json
+
+    # Stored CouchDB document vs a new harvest file
+    uv run python scripts/diff_arc_content_hash.py \
+        --arc-id 83e3f3a60b3defb46413f9fe873ac0c323581f95654389b6ecd711607d6070bf \
+        --b harvest.json \
+        --couchdb-url http://localhost:5984 \
+        --couchdb-user admin \
+        --couchdb-password secret
+
+Environment (optional CouchDB defaults):
+    COUCHDB_URL, COUCHDB_USER, COUCHDB_PASSWORD, COUCHDB_DB_NAME
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+from pydantic import SecretStr
+
+from middleware.api.document_store.config import CouchDBConfig
+from middleware.api.document_store.content_hash import (
+    RoCrateContent,
+    calculate_arc_content_hash,
+    canonicalize_rocrate_for_hash,
+    strip_volatile_rocrate_fields,
+)
+from middleware.api.document_store.couchdb_client import CouchDBClient
+
+
+def _iter_json_diffs(left: Any, right: Any, path: str = "$") -> Iterator[tuple[str, Any, Any]]:
+    """Yield ``(json_path, left_value, right_value)`` for leaves that differ."""
+    if type(left) is not type(right):
+        yield path, left, right
+        return
+
+    if isinstance(left, dict) and isinstance(right, dict):
+        keys = set(left) | set(right)
+        for key in sorted(keys):
+            child = f"{path}.{key}"
+            if key not in left:
+                yield child, None, right[key]
+            elif key not in right:
+                yield child, left[key], None
+            else:
+                yield from _iter_json_diffs(left[key], right[key], child)
+        return
+
+    if isinstance(left, list) and isinstance(right, list):
+        for index, (left_item, right_item) in enumerate(zip(left, right, strict=False)):
+            yield from _iter_json_diffs(left_item, right_item, f"{path}[{index}]")
+        if len(left) != len(right):
+            yield f"{path}.length", len(left), len(right)
+        return
+
+    if left != right:
+        yield path, left, right
+
+
+def _load_json(path: Path) -> RoCrateContent:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        msg = f"{path} must contain a JSON object"
+        raise TypeError(msg)
+    return data
+
+
+async def _load_couchdb_arc(
+    arc_id: str,
+    *,
+    url: str,
+    user: str | None,
+    password: str | None,
+    db_name: str,
+) -> RoCrateContent:
+
+    client = CouchDBClient(
+        CouchDBConfig(
+            url=url,
+            db_name=db_name,
+            user=user,
+            password=SecretStr(password) if password else None,
+        )
+    )
+    await client.connect()
+    try:
+        doc = await client.get_document(f"arc_{arc_id}")
+    finally:
+        await client.close()
+
+    if doc is None:
+        msg = f"CouchDB document 'arc_{arc_id}' not found in database '{db_name}'"
+        raise SystemExit(msg)
+    content = doc.get("arc_content")
+    if not isinstance(content, dict):
+        msg = f"Document 'arc_{arc_id}' has no object field 'arc_content'"
+        raise SystemExit(msg)
+    return content
+
+
+def _summarize(label: str, content: RoCrateContent) -> None:
+    raw_hash = calculate_arc_content_hash(content)
+    print(f"{label}:")
+    print(f"  content_hash = {raw_hash}")
+    volatile_only = strip_volatile_rocrate_fields(content)
+    print(f"  keys_after_strip (top-level) = {sorted(volatile_only)}")
+
+
+def _print_diffs(left: RoCrateContent, right: RoCrateContent, *, limit: int) -> int:
+    left_c = canonicalize_rocrate_for_hash(left)
+    right_c = canonicalize_rocrate_for_hash(right)
+    diffs = list(_iter_json_diffs(left_c, right_c))
+    print(f"canonicalized diffs: {len(diffs)}")
+    for path, old, new in diffs[:limit]:
+        print(f"  {path}")
+        print(f"    a = {old!r}")
+        print(f"    b = {new!r}")
+    if len(diffs) > limit:
+        print(f"  … {len(diffs) - limit} more")
+    return len(diffs)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint: compare two RO-Crates and print hash / path diffs."""
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--a", type=Path, help="Left RO-Crate JSON file (or omit when using --arc-id)")
+    parser.add_argument("--b", type=Path, required=True, help="Right RO-Crate JSON file")
+    parser.add_argument("--arc-id", help="Load left side from CouchDB document arc_{arc_id}")
+    parser.add_argument("--couchdb-url", default=os.getenv("COUCHDB_URL", "http://localhost:5984"))
+    parser.add_argument("--couchdb-user", default=os.getenv("COUCHDB_USER"))
+    parser.add_argument("--couchdb-password", default=os.getenv("COUCHDB_PASSWORD"))
+    parser.add_argument("--couchdb-db", default=os.getenv("COUCHDB_DB_NAME", "middleware"))
+    parser.add_argument("--limit", type=int, default=50, help="Max diff paths to print")
+    args = parser.parse_args(argv)
+
+    if bool(args.a) == bool(args.arc_id):
+        parser.error("Provide exactly one of --a or --arc-id")
+
+    right = _load_json(args.b)
+    if args.a is not None:
+        left = _load_json(args.a)
+    else:
+        assert args.arc_id is not None
+        left = asyncio.run(
+            _load_couchdb_arc(
+                args.arc_id,
+                url=args.couchdb_url,
+                user=args.couchdb_user,
+                password=args.couchdb_password,
+                db_name=args.couchdb_db,
+            )
+        )
+
+    _summarize("a", left)
+    _summarize("b", right)
+    equal = calculate_arc_content_hash(left) == calculate_arc_content_hash(right)
+    print(f"hashes_equal = {equal}")
+    if equal:
+        return 0
+    count = _print_diffs(left, right, limit=args.limit)
+    return 1 if count else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/list_failed_arc_json_jobs.py
+++ b/scripts/list_failed_arc_json_jobs.py
@@ -60,8 +60,9 @@ if TYPE_CHECKING:
 DEFAULT_GITLAB_URL = "https://datahub.ipk-gatersleben.de"
 DEFAULT_GROUP = "fairagro-advanced-middleware"
 DEFAULT_STAGE = "arc_json"
-DEFAULT_FAILED_JOB_LIMIT = 5
+DEFAULT_FAILED_JOB_LIMIT = 50
 DEFAULT_WORKERS = 20
+JOB_LIST_PAGE_SIZE = 100
 DEFAULT_PROJECT_CACHE = "gitlab-failed-arc-json-projects.cache.json"
 DEFAULT_REPORT_FILE = "gitlab-failed-arc-json-report.md"
 DEFAULT_REPORT_JSON = "gitlab-failed-arc-json-report.json"
@@ -538,18 +539,36 @@ def _job_trace(project: Project, job: Any) -> str:
         return _decode_trace(project.jobs.get(job.id, lazy=True).trace())
 
 
+def _pipeline_fields(job: Any) -> tuple[int | None, str | None]:
+    pipeline_id = getattr(job, "pipeline", None)
+    if isinstance(pipeline_id, dict):
+        raw_id = pipeline_id.get("id")
+        pipeline_id_value = int(raw_id) if raw_id is not None else None
+        return pipeline_id_value, pipeline_id.get("web_url")
+    if pipeline_id is None:
+        return None, None
+    return int(pipeline_id), None
+
+
 def _find_failed_job(project: Project, filters: JobMatchFilter) -> FailedJobMatch | None:
-    """Return the newest failed job matching stage/name filters."""
-    # Prefer the jobs API with scope=failed. Stage is typically ``arc_json``;
-    # the job *name* is often ``ARC RO-Crate`` (not ``arc_json``).
+    """Return the newest failed job matching stage/name filters.
+
+    Scans newest-first through failed jobs (paginated). Newer failures in other
+    stages do not hide an older matching ``arc_json`` failure within the scan
+    budget (``failed_job_limit``).
+    """
     failed_jobs = project.jobs.list(
-        get_all=False,
-        per_page=filters.failed_job_limit,
+        iterator=True,
+        per_page=min(JOB_LIST_PAGE_SIZE, filters.failed_job_limit),
         scope=["failed"],
         order_by="id",
         sort="desc",
     )
-    for job in failed_jobs[: filters.failed_job_limit]:
+    inspected = 0
+    for job in failed_jobs:
+        inspected += 1
+        if inspected > filters.failed_job_limit:
+            break
         if not _job_matches(
             job,
             stage=filters.stage,
@@ -559,17 +578,7 @@ def _find_failed_job(project: Project, filters: JobMatchFilter) -> FailedJobMatc
             continue
         trace = _job_trace(project, job)
         extracted = _extract_error_cause(trace)
-        pipeline_id = getattr(job, "pipeline", None)
-        pipeline_id_value: int | None
-        pipeline_url: str | None = None
-        if isinstance(pipeline_id, dict):
-            raw_id = pipeline_id.get("id")
-            pipeline_id_value = int(raw_id) if raw_id is not None else None
-            pipeline_url = pipeline_id.get("web_url")
-        elif pipeline_id is None:
-            pipeline_id_value = None
-        else:
-            pipeline_id_value = int(pipeline_id)
+        pipeline_id_value, pipeline_url = _pipeline_fields(job)
         return FailedJobMatch(
             project_id=filters.project_id,
             path_with_namespace=filters.path_with_namespace,
@@ -947,7 +956,11 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         "--failed-job-limit",
         type=int,
         default=DEFAULT_FAILED_JOB_LIMIT,
-        help=(f"How many newest failed jobs per project to inspect (default: {DEFAULT_FAILED_JOB_LIMIT})"),
+        help=(
+            "Max newest failed jobs to scan per project when looking for a "
+            f"stage/name match (default: {DEFAULT_FAILED_JOB_LIMIT}; "
+            "avoids missing arc_json behind newer non-matching failures)"
+        ),
     )
     parser.add_argument(
         "--workers",

--- a/scripts/list_failed_arc_json_jobs.py
+++ b/scripts/list_failed_arc_json_jobs.py
@@ -1,0 +1,1129 @@
+#!/usr/bin/env python3
+r"""List group projects with failed CI jobs and summarize error causes.
+
+Scans projects in a GitLab group, finds recent **failed** CI jobs via the
+project jobs API (``scope=failed``), extracts a root-cause message from each
+job log, and prints:
+
+* how often each **classified** cause occurs (with project list)
+* a **remainder** bucket for failures that could not be classified, with a
+  short concrete excerpt per project (not the full log)
+
+ARC pipelines use stage ``arc_json``; the job *name* is typically
+``ARC RO-Crate`` (not ``arc_json``). Default filter is ``--stage arc_json``.
+
+By default only middleware ARC-hash projects are considered (64-character
+SHA256 path). Use ``--all-projects`` to include every project in the group.
+
+``--project`` resolves a single project via the projects API and does **not**
+list the whole group (fast path for debugging).
+
+Environment:
+    GITLAB_TOKEN: Personal access token with ``api`` / ``read_api`` scope
+        (used when ``--token`` is omitted).
+
+Examples:
+    # Fast group scan: only projects active in the last 90 days, more workers
+    uv run python scripts/list_failed_arc_json_jobs.py --active-since-days 90 --workers 20
+
+    # Reuse cached project list from a previous run (skips the slow group listing)
+    uv run python scripts/list_failed_arc_json_jobs.py --project-cache \\
+        gitlab-failed-arc-json-projects.cache.json
+
+    # Reports are written to markdown/JSON files (stdout stays short)
+    # default: gitlab-failed-arc-json-report.md / .json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+import threading
+import time
+from collections import defaultdict
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import gitlab
+from gitlab.exceptions import GitlabError
+
+if TYPE_CHECKING:
+    from gitlab.v4.objects import Group, GroupProject, Project
+
+DEFAULT_GITLAB_URL = "https://datahub.ipk-gatersleben.de"
+DEFAULT_GROUP = "fairagro-advanced-middleware"
+DEFAULT_STAGE = "arc_json"
+DEFAULT_FAILED_JOB_LIMIT = 5
+DEFAULT_WORKERS = 20
+DEFAULT_PROJECT_CACHE = "gitlab-failed-arc-json-projects.cache.json"
+DEFAULT_REPORT_FILE = "gitlab-failed-arc-json-report.md"
+DEFAULT_REPORT_JSON = "gitlab-failed-arc-json-report.json"
+CACHE_PROJECT_ENTRY_LEN = 2
+
+LOG_FILE = "gitlab-failed-arc-json.log"
+LIST_PROGRESS_INTERVAL = 1000
+CHECK_PROGRESS_INTERVAL = 100
+
+_THREAD_LOCAL = threading.local()
+
+ARC_PATH_RE = re.compile(r"^[a-f0-9]{64}$")
+ARC_PENDING_DELETION_RE = re.compile(r"^[a-f0-9]{64}-deletion_scheduled-\d+$")
+INTERNAL_ERROR_MAX_FOLLOW_LINES = 3
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+INTERNAL_ERROR_HEADER_RE = re.compile(r"^Internal Error:\s*$", re.IGNORECASE)
+NOISE_LINE_RE = re.compile(
+    r"(?i)^(?:"
+    r"section_(?:start|end):|"
+    r"Running with gitlab-runner|"
+    r"Preparing |Using |Pulling |Getting source|"
+    r"Fetching changes|Initialized empty|Created fresh|"
+    r"Checking out |Skipping Git|Gitaly correlation|"
+    r"Executing |Uploading artifacts|"
+    r"WARNING: |"
+    r"Cleaning up |"
+    r"ERROR: No files to upload|"
+    r"ERROR: Job failed|"
+    r"Job succeeded|"
+    r"Start arc-export|"
+    r"Loading ARC from|"
+    r"It is writing here|"
+    r"Writing ARC RO-Crate metadata to|"
+    r"\$ |"
+    r"curl:"
+    r")"
+)
+SECONDARY_FAILURE_RE = re.compile(
+    r"(?i)^(?:"
+    r"curl:|"
+    r"WARNING: .*no matching files|"
+    r"ERROR: No files to upload|"
+    r"ERROR: Job failed"
+    r")"
+)
+CAUSE_HINT_RE = re.compile(
+    r"(?i)(?:\berror\b|\bexception\b|\bfatal\b|\bfailed\b|\bmust have\b|"
+    r"\binvalid\b|\bmissing\b|\bnot found\b|\bunable to\b|\bcannot\b)"
+)
+UNKNOWN_CAUSE = "(no usable log lines)"
+REMAINDER_BUCKET_LABEL = "(remainder — not classified)"
+EXCERPT_MAX_LINES = 3
+EXCERPT_MAX_CHARS = 240
+
+
+@dataclass(frozen=True)
+class ExtractedCause:
+    """Parsed failure message and whether it is a classified cause."""
+
+    cause: str
+    classified: bool
+    excerpt: str
+
+
+@dataclass(frozen=True)
+class FailedJobMatch:
+    """One project with a failed CI job matching the filter."""
+
+    project_id: int
+    path_with_namespace: str
+    pipeline_id: int | None
+    pipeline_web_url: str | None
+    job_id: int
+    job_name: str
+    job_web_url: str | None
+    finished_at: str | None
+    stage: str | None
+    trace: str | None
+    cause: str
+    classified: bool
+    excerpt: str
+
+
+@dataclass(frozen=True)
+class ProjectCheckJob:
+    """Parameters for inspecting one GitLab project."""
+
+    gitlab_url: str
+    token: str
+    project_id: int
+    path_with_namespace: str
+    stage: str | None
+    job_name: str | None
+    job_name_contains: str | None
+    failed_job_limit: int
+    keep_trace: bool
+
+
+def _thread_gitlab(url: str, token: str) -> gitlab.Gitlab:
+    """Reuse one Gitlab client per worker thread (keeps HTTP connections warm)."""
+    cached_url = getattr(_THREAD_LOCAL, "url", None)
+    cached_token = getattr(_THREAD_LOCAL, "token", None)
+    client: gitlab.Gitlab | None = getattr(_THREAD_LOCAL, "client", None)
+    if client is None or cached_url != url or cached_token != token:
+        client = gitlab.Gitlab(url, private_token=token, per_page=100)
+        _THREAD_LOCAL.client = client
+        _THREAD_LOCAL.url = url
+        _THREAD_LOCAL.token = token
+    return client
+
+
+def _configure_logging() -> logging.Logger:
+    log = logging.getLogger("list_failed_arc_json_jobs")
+    log.setLevel(logging.INFO)
+    formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+    file_handler = logging.FileHandler(LOG_FILE, encoding="utf-8")
+    file_handler.setFormatter(formatter)
+    log.addHandler(stream_handler)
+    log.addHandler(file_handler)
+    return log
+
+
+def _is_arc_project_path(path: str) -> bool:
+    return bool(ARC_PATH_RE.fullmatch(path) or ARC_PENDING_DELETION_RE.fullmatch(path))
+
+
+def _job_matches(
+    job: Any,
+    *,
+    stage: str | None,
+    job_name: str | None,
+    job_name_contains: str | None,
+) -> bool:
+    if stage is not None and getattr(job, "stage", None) != stage:
+        return False
+    name = job.name
+    if job_name is not None and name != job_name:
+        return False
+    return job_name_contains is None or job_name_contains in name
+
+
+@dataclass(frozen=True)
+class CollectConfig:
+    """Options for selecting which group projects to inspect."""
+
+    all_projects: bool
+    include_subgroups: bool
+    max_projects: int | None
+    active_since: datetime | None
+
+
+def _parse_last_activity(value: Any) -> datetime | None:
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+    except ValueError:
+        return None
+
+
+def _resolve_single_project(
+    gl: gitlab.Gitlab,
+    group: Group,
+    project_ref: str,
+    log: logging.Logger,
+) -> list[tuple[int, str]]:
+    """Resolve ``--project`` via the projects API (no full group listing)."""
+    candidates: list[str | int] = []
+    if project_ref.isdigit():
+        candidates.append(int(project_ref))
+    candidates.append(project_ref)
+    if "/" not in project_ref:
+        candidates.append(f"{group.full_path}/{project_ref}")
+
+    seen: set[str | int] = set()
+    for candidate in candidates:
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        try:
+            project = gl.projects.get(candidate, lazy=False)
+        except GitlabError:
+            continue
+        log.info(
+            "Resolved --project %r -> %s (id=%s) without listing the group",
+            project_ref,
+            project.path_with_namespace,
+            project.id,
+        )
+        return [(project.id, project.path_with_namespace)]
+
+    log.error(
+        "Could not resolve --project %r (tried id/path and %s/<path>)",
+        project_ref,
+        group.full_path,
+    )
+    return []
+
+
+def _iter_group_projects(
+    group: Group,
+    log: logging.Logger,
+    *,
+    include_subgroups: bool,
+    order_by_activity: bool,
+) -> Any:
+    """Iterate group projects using a lighter listing."""
+    list_kwargs: dict[str, Any] = {
+        "get_all": False,
+        "include_subgroups": include_subgroups,
+        "simple": True,
+        "per_page": 100,
+        "include_pending_delete": True,
+    }
+    if order_by_activity:
+        # Offset pagination: allows early-stop once activity falls below --active-since-days.
+        yield from group.projects.list(
+            iterator=True,
+            order_by="last_activity_at",
+            sort="desc",
+            **list_kwargs,
+        )
+        return
+
+    try:
+        yield from group.projects.list(
+            iterator=True,
+            pagination="keyset",
+            order_by="id",
+            sort="asc",
+            **list_kwargs,
+        )
+    except GitlabError as exc:
+        log.warning("Keyset pagination unavailable (%s); falling back to offset pagination", exc)
+        yield from group.projects.list(iterator=True, **list_kwargs)
+
+
+def _collect_projects(
+    group: Group,
+    log: logging.Logger,
+    config: CollectConfig,
+) -> list[tuple[int, str]]:
+    """Return ``(project_id, path_with_namespace)`` entries to inspect."""
+    targets: list[tuple[int, str]] = []
+    scanned = 0
+    skipped = 0
+    skipped_inactive = 0
+    start = time.monotonic()
+    order_by_activity = config.active_since is not None
+    log.info(
+        "Listing projects (simple, include_subgroups=%s, order_by_activity=%s)...",
+        config.include_subgroups,
+        order_by_activity,
+    )
+    for project in _iter_group_projects(
+        group,
+        log,
+        include_subgroups=config.include_subgroups,
+        order_by_activity=order_by_activity,
+    ):
+        scanned += 1
+        group_project: GroupProject = project
+        path = group_project.path
+        path_with_namespace = group_project.path_with_namespace
+        activity = _parse_last_activity(group_project.attributes.get("last_activity_at"))
+
+        if config.active_since is not None and activity is not None and activity < config.active_since:
+            skipped_inactive += 1
+            # Newest-first listing: once we hit older activity, remaining rows are older.
+            if order_by_activity:
+                log.info(
+                    "Stopping listing early: last_activity_at %s is older than cutoff %s",
+                    activity.isoformat(),
+                    config.active_since.isoformat(),
+                )
+                break
+            skipped += 1
+            continue
+
+        if not config.all_projects and not _is_arc_project_path(path):
+            skipped += 1
+            continue
+
+        targets.append((group_project.id, path_with_namespace))
+        if config.max_projects is not None and len(targets) >= config.max_projects:
+            log.info("Reached --max-projects=%d; stopping project listing", config.max_projects)
+            break
+
+        if scanned % LIST_PROGRESS_INTERVAL == 0:
+            elapsed = time.monotonic() - start
+            rate = scanned / elapsed if elapsed else 0.0
+            log.info(
+                "Scanned %d projects (%.0f/s, %d selected, %d skipped, %d inactive)...",
+                scanned,
+                rate,
+                len(targets),
+                skipped,
+                skipped_inactive,
+            )
+
+    log.info(
+        "Listing complete: scanned=%d selected=%d skipped=%d inactive=%d",
+        scanned,
+        len(targets),
+        skipped,
+        skipped_inactive,
+    )
+    return targets
+
+
+def _load_project_cache(path: Path, group_full_path: str, log: logging.Logger) -> list[tuple[int, str]] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        log.warning("Ignoring unreadable project cache %s (%s)", path, exc)
+        return None
+    if payload.get("group") != group_full_path:
+        log.warning(
+            "Ignoring project cache %s (group mismatch: cache=%r current=%r)",
+            path,
+            payload.get("group"),
+            group_full_path,
+        )
+        return None
+    projects = payload.get("projects")
+    if not isinstance(projects, list):
+        log.warning("Ignoring project cache %s (invalid projects payload)", path)
+        return None
+    targets: list[tuple[int, str]] = []
+    for entry in projects:
+        if (
+            isinstance(entry, list)
+            and len(entry) == CACHE_PROJECT_ENTRY_LEN
+            and isinstance(entry[0], int)
+            and isinstance(entry[1], str)
+        ):
+            targets.append((entry[0], entry[1]))
+    log.info(
+        "Loaded %d projects from cache %s (generated_at=%s)",
+        len(targets),
+        path,
+        payload.get("generated_at"),
+    )
+    return targets
+
+
+def _save_project_cache(
+    path: Path,
+    group_full_path: str,
+    targets: list[tuple[int, str]],
+    log: logging.Logger,
+) -> None:
+    payload = {
+        "group": group_full_path,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "projects": [[project_id, project_path] for project_id, project_path in targets],
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    log.info("Wrote project cache %s (%d projects)", path, len(targets))
+
+
+def _decode_trace(raw: bytes | str) -> str:
+    if isinstance(raw, bytes):
+        return raw.decode("utf-8", errors="replace")
+    return raw
+
+
+def _clean_log_line(line: str) -> str:
+    line = ANSI_ESCAPE_RE.sub("", line)
+    return line.replace("\r", "").strip()
+
+
+def _truncate_excerpt(text: str, *, max_chars: int = EXCERPT_MAX_CHARS) -> str:
+    text = " ".join(text.split())
+    if len(text) <= max_chars:
+        return text
+    return text[: max_chars - 1].rstrip() + "…"
+
+
+def _build_short_excerpt(lines: list[str]) -> str:
+    """Build a short concrete snippet from the last non-noise log lines."""
+    useful: list[str] = []
+    for line in reversed(lines):
+        if NOISE_LINE_RE.match(line) or SECONDARY_FAILURE_RE.match(line):
+            continue
+        useful.append(line)
+        if len(useful) >= EXCERPT_MAX_LINES:
+            break
+    if not useful:
+        return UNKNOWN_CAUSE
+    useful.reverse()
+    return _truncate_excerpt(" | ".join(useful))
+
+
+def _extract_after_internal_error(lines: list[str]) -> str | None:
+    """Prefer the message immediately following an ``Internal Error:`` header."""
+    for index, line in enumerate(lines):
+        if not INTERNAL_ERROR_HEADER_RE.fullmatch(line):
+            continue
+        collected: list[str] = []
+        for follower in lines[index + 1 :]:
+            if not follower or follower.startswith("$") or NOISE_LINE_RE.match(follower):
+                break
+            if SECONDARY_FAILURE_RE.match(follower):
+                break
+            collected.append(follower)
+            if len(collected) >= INTERNAL_ERROR_MAX_FOLLOW_LINES:
+                break
+        if collected:
+            return " | ".join(collected)
+    return None
+
+
+def _extract_error_cause(trace: str | None) -> ExtractedCause:
+    """Heuristically pick a classified cause or a remainder excerpt."""
+    if not trace:
+        return ExtractedCause(
+            cause=REMAINDER_BUCKET_LABEL,
+            classified=False,
+            excerpt=UNKNOWN_CAUSE,
+        )
+
+    lines = [_clean_log_line(line) for line in trace.splitlines()]
+    lines = [line for line in lines if line]
+
+    internal = _extract_after_internal_error(lines)
+    if internal:
+        message = _truncate_excerpt(internal)
+        return ExtractedCause(cause=message, classified=True, excerpt=message)
+
+    # Prefer substantive error-like lines; skip runner / curl / artifact noise.
+    candidates: list[str] = []
+    for line in lines:
+        if NOISE_LINE_RE.match(line) or SECONDARY_FAILURE_RE.match(line):
+            continue
+        if CAUSE_HINT_RE.search(line):
+            candidates.append(line)
+
+    if candidates:
+        message = _truncate_excerpt(candidates[-1])
+        return ExtractedCause(cause=message, classified=True, excerpt=message)
+
+    # Remainder: keep a short concrete snippet so the failure stays visible.
+    excerpt = _build_short_excerpt(lines)
+    return ExtractedCause(
+        cause=REMAINDER_BUCKET_LABEL,
+        classified=False,
+        excerpt=excerpt,
+    )
+
+
+@dataclass(frozen=True)
+class JobMatchFilter:
+    """Which failed jobs count as a match."""
+
+    stage: str | None
+    job_name: str | None
+    job_name_contains: str | None
+    failed_job_limit: int
+    keep_trace: bool
+    project_id: int
+    path_with_namespace: str
+
+
+def _job_trace(project: Project, job: Any) -> str:
+    """Fetch a job trace with as few API round-trips as possible."""
+    try:
+        return _decode_trace(job.trace())
+    except (GitlabError, AttributeError, TypeError):
+        return _decode_trace(project.jobs.get(job.id, lazy=True).trace())
+
+
+def _find_failed_job(project: Project, filters: JobMatchFilter) -> FailedJobMatch | None:
+    """Return the newest failed job matching stage/name filters."""
+    # Prefer the jobs API with scope=failed. Stage is typically ``arc_json``;
+    # the job *name* is often ``ARC RO-Crate`` (not ``arc_json``).
+    failed_jobs = project.jobs.list(
+        get_all=False,
+        per_page=filters.failed_job_limit,
+        scope=["failed"],
+        order_by="id",
+        sort="desc",
+    )
+    for job in failed_jobs[: filters.failed_job_limit]:
+        if not _job_matches(
+            job,
+            stage=filters.stage,
+            job_name=filters.job_name,
+            job_name_contains=filters.job_name_contains,
+        ):
+            continue
+        trace = _job_trace(project, job)
+        extracted = _extract_error_cause(trace)
+        pipeline_id = getattr(job, "pipeline", None)
+        pipeline_id_value: int | None
+        pipeline_url: str | None = None
+        if isinstance(pipeline_id, dict):
+            raw_id = pipeline_id.get("id")
+            pipeline_id_value = int(raw_id) if raw_id is not None else None
+            pipeline_url = pipeline_id.get("web_url")
+        elif pipeline_id is None:
+            pipeline_id_value = None
+        else:
+            pipeline_id_value = int(pipeline_id)
+        return FailedJobMatch(
+            project_id=filters.project_id,
+            path_with_namespace=filters.path_with_namespace,
+            pipeline_id=pipeline_id_value,
+            pipeline_web_url=pipeline_url,
+            job_id=int(job.id),
+            job_name=job.name,
+            job_web_url=getattr(job, "web_url", None),
+            finished_at=getattr(job, "finished_at", None),
+            stage=getattr(job, "stage", None),
+            trace=trace if filters.keep_trace else None,
+            cause=extracted.cause,
+            classified=extracted.classified,
+            excerpt=extracted.excerpt,
+        )
+    return None
+
+
+def _check_project(job: ProjectCheckJob, log: logging.Logger) -> FailedJobMatch | None:
+    """Inspect one project; return a match or None. Errors are logged and skipped."""
+    try:
+        gl = _thread_gitlab(job.gitlab_url, job.token)
+        # lazy=True avoids an extra GET /projects/:id before listing jobs.
+        project = gl.projects.get(job.project_id, lazy=True)
+        return _find_failed_job(
+            project,
+            JobMatchFilter(
+                stage=job.stage,
+                job_name=job.job_name,
+                job_name_contains=job.job_name_contains,
+                failed_job_limit=job.failed_job_limit,
+                keep_trace=job.keep_trace,
+                project_id=job.project_id,
+                path_with_namespace=job.path_with_namespace,
+            ),
+        )
+    except GitlabError as exc:
+        log.error("Project %s (id=%s): %s", job.path_with_namespace, job.project_id, exc)
+        return None
+
+
+def _print_match(match: FailedJobMatch, log: logging.Logger, *, show_logs: bool) -> None:
+    separator = "=" * 72
+    log.info(separator)
+    log.info("FAILED %s", match.path_with_namespace)
+    log.info("  project_id=%s", match.project_id)
+    log.info("  pipeline_id=%s", match.pipeline_id)
+    if match.pipeline_web_url:
+        log.info("  pipeline_url=%s", match.pipeline_web_url)
+    log.info(
+        "  job_id=%s name=%r stage=%s finished_at=%s",
+        match.job_id,
+        match.job_name,
+        match.stage,
+        match.finished_at,
+    )
+    if match.job_web_url:
+        log.info("  job_url=%s", match.job_web_url)
+    log.info("  cause=%s", match.cause)
+    if not match.classified:
+        log.info("  excerpt=%s", match.excerpt)
+    if show_logs and match.trace is not None:
+        log.info("  ----- job log begin -----")
+        for line in match.trace.splitlines():
+            log.info("  | %s", line)
+        log.info("  ----- job log end -----")
+    log.info(separator)
+
+
+def _share(count: int, total: int) -> str:
+    if total == 0:
+        return "0.0%"
+    return f"{(100.0 * count / total):.1f}%"
+
+
+def _match_to_json(item: FailedJobMatch, *, include_excerpt: bool = False) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "project_id": item.project_id,
+        "path_with_namespace": item.path_with_namespace,
+        "job_id": item.job_id,
+        "job_url": item.job_web_url,
+        "pipeline_id": item.pipeline_id,
+        "finished_at": item.finished_at,
+    }
+    if include_excerpt:
+        payload["excerpt"] = item.excerpt
+    return payload
+
+
+def _build_ranked_causes(
+    matches: list[FailedJobMatch],
+) -> tuple[list[tuple[str, list[FailedJobMatch]]], list[FailedJobMatch]]:
+    classified = [match for match in matches if match.classified]
+    remainder = [match for match in matches if not match.classified]
+    by_cause: dict[str, list[FailedJobMatch]] = defaultdict(list)
+    for match in classified:
+        by_cause[match.cause].append(match)
+    ranked = sorted(by_cause.items(), key=lambda item: (-len(item[1]), item[0].lower()))
+    return ranked, remainder
+
+
+def _render_markdown_report(
+    *,
+    generated_at: str,
+    total: int,
+    ranked: list[tuple[str, list[FailedJobMatch]]],
+    remainder: list[FailedJobMatch],
+) -> str:
+    lines: list[str] = [
+        "# Failed `arc_json` job report",
+        "",
+        f"Generated: `{generated_at}`",
+        "",
+        f"- Failed projects: **{total}**",
+        f"- Classified causes: **{len(ranked)}**",
+        f"- Remainder (unclassified): **{len(remainder)}**",
+        "",
+        "## Summary",
+        "",
+        "| # | Count | Share | Cause |",
+        "| --: | --: | --: | --- |",
+    ]
+    for rank, (cause, group) in enumerate(ranked, start=1):
+        safe_cause = cause.replace("|", "\\|")
+        lines.append(f"| {rank} | {len(group)} | {_share(len(group), total)} | `{safe_cause}` |")
+    lines.append(f"| remainder | {len(remainder)} | {_share(len(remainder), total)} | `{REMAINDER_BUCKET_LABEL}` |")
+    lines.extend(["", "## Cause details", ""])
+
+    for rank, (cause, group) in enumerate(ranked, start=1):
+        project_rows = sorted(group, key=lambda item: item.path_with_namespace)
+        lines.extend([
+            f"### {rank}. `{cause}`",
+            "",
+            f"Count: **{len(project_rows)}** ({_share(len(project_rows), total)})",
+            "",
+            "| Project | Job |",
+            "| --- | --- |",
+        ])
+        for item in project_rows:
+            lines.append(f"| `{item.path_with_namespace}` | {item.job_web_url or ''} |")
+        lines.append("")
+
+    lines.extend([
+        f"### remainder. `{REMAINDER_BUCKET_LABEL}`",
+        "",
+        f"Count: **{len(remainder)}** ({_share(len(remainder), total)})",
+        "",
+    ])
+    if not remainder:
+        lines.extend(["_No unclassified failures._", ""])
+    else:
+        lines.extend(["| Project | Excerpt | Job |", "| --- | --- | --- |"])
+        for item in sorted(remainder, key=lambda match: match.path_with_namespace):
+            excerpt = item.excerpt.replace("|", "\\|")
+            lines.append(f"| `{item.path_with_namespace}` | {excerpt} | {item.job_web_url or ''} |")
+        lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def _build_json_report(
+    *,
+    generated_at: str,
+    total: int,
+    ranked: list[tuple[str, list[FailedJobMatch]]],
+    remainder: list[FailedJobMatch],
+) -> dict[str, Any]:
+    causes = [
+        {
+            "rank": rank,
+            "cause": cause,
+            "count": len(group),
+            "projects": [_match_to_json(item) for item in sorted(group, key=lambda row: row.path_with_namespace)],
+        }
+        for rank, (cause, group) in enumerate(ranked, start=1)
+    ]
+    return {
+        "generated_at": generated_at,
+        "total_failed_projects": total,
+        "classified_cause_count": len(ranked),
+        "remainder_count": len(remainder),
+        "causes": causes,
+        "remainder": [
+            _match_to_json(item, include_excerpt=True)
+            for item in sorted(remainder, key=lambda row: row.path_with_namespace)
+        ],
+    }
+
+
+def _report_cause_statistics(
+    matches: list[FailedJobMatch],
+    *,
+    report_md: Path,
+    report_json: Path,
+    log: logging.Logger,
+) -> None:
+    """Write a readable markdown + JSON report; log only a short stdout summary."""
+    ranked, remainder = _build_ranked_causes(matches)
+    total = len(matches)
+    generated_at = datetime.now(UTC).isoformat()
+
+    report_md.write_text(
+        _render_markdown_report(
+            generated_at=generated_at,
+            total=total,
+            ranked=ranked,
+            remainder=remainder,
+        ),
+        encoding="utf-8",
+    )
+    report_json.write_text(
+        json.dumps(
+            _build_json_report(
+                generated_at=generated_at,
+                total=total,
+                ranked=ranked,
+                remainder=remainder,
+            ),
+            indent=2,
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    log.info(
+        "Report written: %s (%d failed, %d causes, %d remainder)",
+        report_md,
+        total,
+        len(ranked),
+        len(remainder),
+    )
+    log.info("JSON report written: %s", report_json)
+    if ranked:
+        top_cause, top_group = ranked[0]
+        log.info("Top cause (%d / %d): %s", len(top_group), total, top_cause)
+    elif remainder:
+        log.info("All failures are in the remainder bucket (%d)", len(remainder))
+
+
+def _filter_description(args: argparse.Namespace) -> str:
+    parts: list[str] = []
+    if args.stage:
+        parts.append(f"stage={args.stage!r}")
+    else:
+        parts.append("any stage")
+    if args.job_name:
+        parts.append(f"exact name {args.job_name!r}")
+    elif args.job_name_contains:
+        parts.append(f"name contains {args.job_name_contains!r}")
+    else:
+        parts.append("any job name")
+    return ", ".join(parts)
+
+
+def _check_projects(
+    targets: list[tuple[int, str]],
+    args: argparse.Namespace,
+    log: logging.Logger,
+) -> list[FailedJobMatch]:
+    if not targets:
+        log.info("No projects to inspect")
+        return []
+
+    log.info(
+        "Checking %d projects for %s (failed_job_limit=%d, workers=%d)...",
+        len(targets),
+        _filter_description(args),
+        args.failed_job_limit,
+        args.workers,
+    )
+    matches: list[FailedJobMatch] = []
+    errors = 0
+    checked = 0
+    start = time.monotonic()
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        futures: dict[Future[FailedJobMatch | None], str] = {
+            pool.submit(
+                _check_project,
+                ProjectCheckJob(
+                    gitlab_url=args.url,
+                    token=args.token,
+                    project_id=project_id,
+                    path_with_namespace=path,
+                    stage=args.stage,
+                    job_name=args.job_name,
+                    job_name_contains=args.job_name_contains,
+                    failed_job_limit=args.failed_job_limit,
+                    keep_trace=args.show_logs,
+                ),
+                log,
+            ): path
+            for project_id, path in targets
+        }
+        for future in as_completed(futures):
+            checked += 1
+            path = futures[future]
+            try:
+                match = future.result()
+            except Exception as exc:  # noqa: BLE001 — isolate worker failures
+                errors += 1
+                log.error("Unexpected error for %s: %s", path, exc)
+                match = None
+            if match is not None:
+                matches.append(match)
+                if args.show_logs or args.project:
+                    _print_match(match, log, show_logs=args.show_logs)
+            if checked % CHECK_PROGRESS_INTERVAL == 0:
+                elapsed = time.monotonic() - start
+                rate = checked / elapsed if elapsed else 0.0
+                log.info(
+                    "Progress: %d/%d (%.1f/s, matches=%d, errors=%d)",
+                    checked,
+                    len(targets),
+                    rate,
+                    len(matches),
+                    errors,
+                )
+
+    matches.sort(key=lambda item: (item.path_with_namespace, -(item.pipeline_id or 0)))
+    log.info(
+        "Done: checked=%d matches=%d errors=%d (log file: %s)",
+        checked,
+        len(matches),
+        errors,
+        LOG_FILE,
+    )
+    return matches
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Find failed CI jobs in a GitLab group, extract root-cause messages from "
+            f"logs, and print frequency statistics. Default stage: {DEFAULT_STAGE!r}."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="See the script docstring for examples.",
+    )
+    parser.add_argument(
+        "--url",
+        default=DEFAULT_GITLAB_URL,
+        help=f"GitLab base URL (default: {DEFAULT_GITLAB_URL})",
+    )
+    parser.add_argument(
+        "--group",
+        default=DEFAULT_GROUP,
+        help=f"Group path or ID (default: {DEFAULT_GROUP})",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("GITLAB_TOKEN"),
+        help="GitLab personal access token (default: $GITLAB_TOKEN)",
+    )
+    parser.add_argument(
+        "--stage",
+        default=DEFAULT_STAGE,
+        help=f"CI stage to match (default: {DEFAULT_STAGE}); use --any-stage to disable",
+    )
+    parser.add_argument(
+        "--any-stage",
+        action="store_true",
+        help="Match failed jobs in any stage (overrides --stage)",
+    )
+    parser.add_argument(
+        "--job-name",
+        default=None,
+        help="Exact CI job name to match (default: any name in the selected stage)",
+    )
+    parser.add_argument(
+        "--job-name-contains",
+        default=None,
+        help="Substring that must appear in the CI job name",
+    )
+    parser.add_argument(
+        "--failed-job-limit",
+        type=int,
+        default=DEFAULT_FAILED_JOB_LIMIT,
+        help=(f"How many newest failed jobs per project to inspect (default: {DEFAULT_FAILED_JOB_LIMIT})"),
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=DEFAULT_WORKERS,
+        help=f"Parallel project checkers (default: {DEFAULT_WORKERS})",
+    )
+    parser.add_argument(
+        "--active-since-days",
+        type=int,
+        default=None,
+        help=(
+            "Only inspect projects with last_activity_at within N days "
+            "(lists newest-first and stops early; major speedup)"
+        ),
+    )
+    parser.add_argument(
+        "--project-cache",
+        default=None,
+        help=(
+            "JSON file for project-id cache. If the file exists it is loaded "
+            f"(skips group listing). After a fresh listing it is written. "
+            f"Example: {DEFAULT_PROJECT_CACHE}"
+        ),
+    )
+    parser.add_argument(
+        "--refresh-project-cache",
+        action="store_true",
+        help="Ignore an existing --project-cache file and relist the group",
+    )
+    parser.add_argument(
+        "--include-subgroups",
+        action="store_true",
+        help="Include projects from subgroups (slower; default: group only)",
+    )
+    parser.add_argument(
+        "--all-projects",
+        action="store_true",
+        help="Inspect every project in the group, not only ARC-hash paths",
+    )
+    parser.add_argument(
+        "--project",
+        default=None,
+        help=(
+            "Only this project id, path, or path_with_namespace "
+            "(resolved directly via API; does not list the whole group)"
+        ),
+    )
+    parser.add_argument(
+        "--max-projects",
+        type=int,
+        default=None,
+        help="Stop after selecting this many projects (useful for smoke tests)",
+    )
+    parser.add_argument(
+        "--report-file",
+        default=DEFAULT_REPORT_FILE,
+        help=f"Markdown report output path (default: {DEFAULT_REPORT_FILE})",
+    )
+    parser.add_argument(
+        "--report-json",
+        default=DEFAULT_REPORT_JSON,
+        help=f"JSON report output path (default: {DEFAULT_REPORT_JSON})",
+    )
+    parser.add_argument(
+        "--show-logs",
+        action="store_true",
+        help="Print full job traces to the log (not recommended for large scans)",
+    )
+    parser.add_argument(
+        "--summary-only",
+        action="store_true",
+        help=argparse.SUPPRESS,  # deprecated: stats are the default; traces always fetched
+    )
+    args = parser.parse_args(argv)
+    if args.any_stage:
+        args.stage = None
+    return args
+
+
+def _validate_args(args: argparse.Namespace, log: logging.Logger) -> int | None:
+    checks: list[tuple[bool, str]] = [
+        (not args.token, "GitLab token required: pass --token or set GITLAB_TOKEN"),
+        (args.workers < 1, "--workers must be at least 1"),
+        (args.failed_job_limit < 1, "--failed-job-limit must be at least 1"),
+        (args.max_projects is not None and args.max_projects < 1, "--max-projects must be at least 1"),
+        (
+            args.active_since_days is not None and args.active_since_days < 1,
+            "--active-since-days must be at least 1",
+        ),
+        (bool(args.job_name and args.job_name_contains), "Use only one of --job-name or --job-name-contains"),
+        (
+            bool(args.refresh_project_cache and not args.project_cache),
+            "--refresh-project-cache requires --project-cache",
+        ),
+    ]
+    for failed, message in checks:
+        if failed:
+            log.error(message)
+            return 1
+    return None
+
+
+def _resolve_targets(
+    gl: gitlab.Gitlab,
+    group: Group,
+    args: argparse.Namespace,
+    log: logging.Logger,
+) -> list[tuple[int, str]] | None:
+    """Return targets, or None on fatal resolution error."""
+    if args.project:
+        targets = _resolve_single_project(gl, group, args.project, log)
+        return targets or None
+
+    cache_path = Path(args.project_cache) if args.project_cache else None
+    if cache_path is not None and not args.refresh_project_cache:
+        cached = _load_project_cache(cache_path, group.full_path, log)
+        if cached is not None:
+            if args.max_projects is not None:
+                return cached[: args.max_projects]
+            return cached
+
+    active_since = None
+    if args.active_since_days is not None:
+        active_since = datetime.now(UTC) - timedelta(days=args.active_since_days)
+        log.info("Activity cutoff: last_activity_at >= %s", active_since.isoformat())
+
+    targets = _collect_projects(
+        group,
+        log,
+        CollectConfig(
+            all_projects=args.all_projects,
+            include_subgroups=args.include_subgroups,
+            max_projects=args.max_projects,
+            active_since=active_since,
+        ),
+    )
+    if cache_path is not None:
+        _save_project_cache(cache_path, group.full_path, targets, log)
+    return targets
+
+
+def main(argv: list[str] | None = None) -> int:
+    """List projects with a failed job and print logs."""
+    args = _parse_args(argv)
+    log = _configure_logging()
+
+    validation_error = _validate_args(args, log)
+    if validation_error is not None:
+        return validation_error
+
+    gl = gitlab.Gitlab(args.url, private_token=args.token, per_page=100)
+    gl.auth()
+
+    group = gl.groups.get(args.group)
+    log.info("Group: %s (id=%s)", group.full_path, group.id)
+    log.info("Job filter: %s", _filter_description(args))
+
+    targets = _resolve_targets(gl, group, args, log)
+    if targets is None:
+        return 1
+
+    matches = _check_projects(targets, args, log)
+
+    if not matches:
+        log.info("No matching failed jobs found (%s)", _filter_description(args))
+        return 0
+
+    _report_cause_statistics(
+        matches,
+        report_md=Path(args.report_file),
+        report_json=Path(args.report_json),
+        log=log,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/quality-check.sh
+++ b/scripts/quality-check.sh
@@ -1,35 +1,84 @@
 #!/bin/bash
-
 # Code Quality Check Script
-# Führt alle Qualitätsprüfungen lokal aus
+# Mirrors GitHub Actions reusable-code-quality.yml (ruff / pylint / mypy / bandit).
+# Does not run pytest or pre-push hooks — those stay in pre-push / CI.
+
+set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
 if [ -d "${repo_root}/.venv/bin" ]; then
     export PATH="${repo_root}/.venv/bin:${PATH}"
 fi
 
-echo "🔍 Starting Code Quality Checks..."
-echo "=================================="
-
-# Farben für bessere Lesbarkeit
 GREEN='\033[0;32m'
 RED='\033[0;31m'
 YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+NC='\033[0m'
 
-# Function to print status
 print_status() {
-    if [ $? -eq 0 ]; then
-        echo -e "${GREEN}✅ $1 passed${NC}"
+    local label="$1"
+    local code="$2"
+    if [ "${code}" -eq 0 ]; then
+        echo -e "${GREEN}✅ ${label} passed${NC}"
     else
-        echo -e "${RED}❌ $1 failed${NC}"
-        exit 1
+        echo -e "${RED}❌ ${label} failed${NC}"
+        exit "${code}"
     fi
 }
 
-# Run all quality checks defined in pre-commit
-echo -e "${YELLOW}🔍 1. Running all pre-commit checks..."
-pre-commit run --hook-stage push --all-files
-print_status 'pre-commit checks'
+run_check() {
+    local label="$1"
+    shift
+    echo -e "${YELLOW}🔍 ${label}...${NC}"
+    set +e
+    "$@"
+    local code=$?
+    set -e
+    print_status "${label}" "${code}"
+}
+
+echo "🔍 Starting Code Quality Checks (CI-parity)..."
+echo "=================================="
+
+run_check "Ruff format" \
+    uv run ruff format --check --diff --config pyproject.toml middleware/
+run_check "Ruff lint" \
+    uv run ruff check --config pyproject.toml middleware/
+run_check "Pylint" \
+    uv run pylint --rcfile pyproject.toml middleware/
+run_check "MyPy" \
+    uv run mypy --config-file pyproject.toml middleware/
+
+echo -e "${YELLOW}🔍 Bandit...${NC}"
+bandit_report="$(mktemp)"
+set +e
+uv run bandit -r middleware/ -c .bandit -f json -o "${bandit_report}"
+BANDIT_REPORT="${bandit_report}" python3 - <<'PY'
+import json
+import os
+import sys
+
+with open(os.environ["BANDIT_REPORT"], encoding="utf-8") as f:
+    data = json.load(f)
+for r in data.get("results", []):
+    print(
+        f"  [{r['issue_severity']:6}] {r['filename']}:{r['line_number']}: {r['issue_text']}"
+    )
+totals = data.get("metrics", {}).get("_totals", {})
+low = int(totals.get("SEVERITY.LOW", 0) or 0)
+med = int(totals.get("SEVERITY.MEDIUM", 0) or 0)
+high = int(totals.get("SEVERITY.HIGH", 0) or 0)
+print(f"Bandit findings: LOW={low}, MEDIUM={med}, HIGH={high}")
+if med + high > 0:
+    print(f"Failing: {med + high} MEDIUM/HIGH finding(s) found.")
+    sys.exit(1)
+PY
+bandit_code=$?
+set -e
+rm -f "${bandit_report}"
+print_status "Bandit" "${bandit_code}"
+
 echo -e "${GREEN}🎉 All quality checks passed!${NC}"
 echo "================================="

--- a/scripts/quality-fix.sh
+++ b/scripts/quality-fix.sh
@@ -22,5 +22,5 @@ uv run ruff format --config pyproject.toml middleware/
 echo -e "${GREEN}✅ Ruff formatting applied${NC}"
 
 echo -e "${GREEN}🎉 Auto-fixes completed!${NC}"
-echo "Now run the quality checks to see remaining issues:"
+echo "Now run the CI-parity quality checks:"
 echo "./scripts/quality-check.sh"

--- a/scripts/quality-fix.sh
+++ b/scripts/quality-fix.sh
@@ -14,11 +14,11 @@ YELLOW='\033[1;33m'
 NC='\033[0m'
 
 echo -e "${YELLOW}🔧 1. Running Ruff (Auto-fixing linting issues)...${NC}"
-uv run ruff check --fix middleware/ || true
+uv run ruff check --config pyproject.toml --fix middleware/ || true
 echo -e "${GREEN}✅ Ruff auto-fixes applied${NC}"
 
 echo -e "${YELLOW}🔧 2. Running Ruff (Auto-formatting)...${NC}"
-uv run ruff format middleware/
+uv run ruff format --config pyproject.toml middleware/
 echo -e "${GREEN}✅ Ruff formatting applied${NC}"
 
 echo -e "${GREEN}🎉 Auto-fixes completed!${NC}"

--- a/uv.lock
+++ b/uv.lock
@@ -232,7 +232,7 @@ dev = [
 requires-dist = [
     { name = "aiocouch", specifier = ">=2.0.0" },
     { name = "aiocouch", specifier = ">=4.0.1" },
-    { name = "arctrl", specifier = ">=3.0.0b15" },
+    { name = "arctrl", specifier = ">=3.1.1" },
     { name = "asn1crypto", specifier = ">=1.5.1" },
     { name = "celery", specifier = ">=5.3.6" },
     { name = "celery-types", specifier = ">=0.24.0" },
@@ -253,16 +253,15 @@ dev = [{ name = "types-pyyaml", specifier = ">=6.0.12.20250915" }]
 
 [[package]]
 name = "arctrl"
-version = "3.2.0"
+version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "fable-library" },
     { name = "openpyxl" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/11/4e46998bbd96c31fbf28d242da430a548be56a5503e84f7898541087427b/arctrl-3.2.0.tar.gz", hash = "sha256:f75ddf0e36aea4328c78324db53b179837b81ab580b87ca4c55722d5a4f597df", size = 645478, upload-time = "2026-07-30T07:40:30.614Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/67/71166ceca5434b968adf448e2e8bd1c011f93cada850fdd26e6f6063464b/arctrl-3.1.1.tar.gz", hash = "sha256:f3cc0d483ef1d427b0cfb174b2388afe750de28a237de2df0d569cee27b50aa7", size = 672314, upload-time = "2026-07-22T12:12:23.14Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/d2/c15f223eb4bfafa2ba64c46268867d871a507de4118f67ac99bad5692814/arctrl-3.2.0-py3-none-any.whl", hash = "sha256:fa24e6dd5202829c31fdbf3ee00ad1194ef37334ae5f90f95b208a6b46c7dace", size = 934482, upload-time = "2026-07-30T07:40:28.235Z" },
+    { url = "https://files.pythonhosted.org/packages/22/0a/8425a499889b5866185e8b273076d61a8912ca6d6062007f252233c8df14/arctrl-3.1.1-py3-none-any.whl", hash = "sha256:f4351c8b06b3876fd337f512ccea2581a76208a51d86ff3edc35748ba0915c2d", size = 961864, upload-time = "2026-07-22T12:12:21.628Z" },
 ]
 
 [[package]]
@@ -778,68 +777,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
-]
-
-[[package]]
-name = "fable-library"
-version = "5.13.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6b/72/3252b8280c97568a5cbd62f206925cbb4b11cb65b07fe09d5494fd4ed992/fable_library-5.13.0.tar.gz", hash = "sha256:b43fb48ea4a471eed76ca7ae23254f33bf617ca0fb1e0754ef9f218ffb347200", size = 239380, upload-time = "2026-07-24T11:41:29.421Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/ad/57f6c40b7087875652527aff2dd55d205115290384a4d08d0e23670f07c4/fable_library-5.13.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:c550c527c33905f200183b197e0fed396969910bcaa02f67eed69bdf62384b21", size = 1398523, upload-time = "2026-07-24T11:39:50.318Z" },
-    { url = "https://files.pythonhosted.org/packages/53/66/a13069897bc78ea4ddb05845110cd4fc19b0fc445870c98e1d55146eb5e3/fable_library-5.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:37d095f9523ff889f5bdf0ec3336c7219362955e318b5785b6f20e008cb31154", size = 1305326, upload-time = "2026-07-24T11:39:51.738Z" },
-    { url = "https://files.pythonhosted.org/packages/76/32/9de3b2e616c3b91e4e87c486471eac8b3237e0c0cb70fff39f066ebd72a7/fable_library-5.13.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:86d506118c88c555265050be3ff4214c8f943511e307943b8736a1b297d39db9", size = 1353138, upload-time = "2026-07-24T11:39:53.079Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/a4/3b74004230b75c8bafff7b52c40bb1e32c47abb413c318e644ef72380d23/fable_library-5.13.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:334ce1470ad31de61d36fc7c83f16a6d461ae4d529c81660457a4d8c9da96743", size = 1335554, upload-time = "2026-07-24T11:39:54.465Z" },
-    { url = "https://files.pythonhosted.org/packages/16/0e/4608be04c0739ebfa12f00ad6359fff6a6176cf3fbf11ea5cbd14ecbc98e/fable_library-5.13.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2bbd44e853db3d38a1ff6bac22c8166f51a40e330b5986666cb261e213d5906f", size = 1477846, upload-time = "2026-07-24T11:39:55.902Z" },
-    { url = "https://files.pythonhosted.org/packages/06/c5/300b552bd6e185d6046110cc89b93a5bb506e7f492d446e9914cf34f4318/fable_library-5.13.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:98347918a4fad47b6d2af04c1842e7ce0eca4582dca985abffcc9fcc1299af6f", size = 1490415, upload-time = "2026-07-24T11:39:57.294Z" },
-    { url = "https://files.pythonhosted.org/packages/67/73/dcfa75febe1b2036e4c73b207e370d47b059bb85991f6e5720b805851ed1/fable_library-5.13.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db34175b37664548e6a96362bb3d0b767fb16dd87d24d4e9b4d1023d7d96df48", size = 1425542, upload-time = "2026-07-24T11:39:58.69Z" },
-    { url = "https://files.pythonhosted.org/packages/38/ea/4b9b5fca94ab55924facb3820b004e03e9bb4a4f407287c36e573997a7fc/fable_library-5.13.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:646bcfb1ee6d5aa31d600092a6afbe370551a0155ac5fe4e19378b85a1bd31e2", size = 1455217, upload-time = "2026-07-24T11:40:00.221Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/7f/0adf13037eb7e1f2d2231691110d439c4a84a74998f12e9a3a22fe983d57/fable_library-5.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:891e72c15b9f6d5fedd1138bbd83e3b57c77bde6cf7624dd9bfc69f1dfa85ce8", size = 1529822, upload-time = "2026-07-24T11:40:01.653Z" },
-    { url = "https://files.pythonhosted.org/packages/64/b9/d5143139badc706ecba83c157c87a1a98b7e0e5cb87fdab4b2877d24a4e8/fable_library-5.13.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b15a28cb6b01d98008e364a7d533b6959aa4f7e6c5900c7c5bd3983e92274632", size = 1612613, upload-time = "2026-07-24T11:40:03.184Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/b2/5d91fad6f4b66fb06286fe7e2b65d27f39c9c9a7a5b7998171541248b26e/fable_library-5.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:7458459cbb4734c316e5d516c6134643b34b4a651479db907826f40800a00cb0", size = 1637229, upload-time = "2026-07-24T11:40:04.558Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/23/17a9df3de001d5f463f892beb9751497eba515b574b6573f5674e7586329/fable_library-5.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9fc2e4074d845036f54c42951022c44b1b6a6754aa0e5af36112f33268a91702", size = 1653731, upload-time = "2026-07-24T11:40:05.974Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/3f/98f7eba82d8958d598630c4c047f054dd2b41cc969dc7d1c878e0531f9cd/fable_library-5.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:b685f9010fba63794c09c340b7f20fdc2dff373cd511f964cc32657b0e189bea", size = 1408569, upload-time = "2026-07-24T11:40:07.462Z" },
-    { url = "https://files.pythonhosted.org/packages/80/e0/fd95ed78f5cbc300206be7d2d6d05ba8cfb53c216eed5f93031315813ec6/fable_library-5.13.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:a663b4b5d04fa9bbdb88f3a2f9e21baa4f6d5ebf77c194b33f82be072046e085", size = 1399075, upload-time = "2026-07-24T11:40:08.918Z" },
-    { url = "https://files.pythonhosted.org/packages/84/88/fa438233d065dc2ca0bd087ebe9a6c4984bb26e9b27892e46d16ef71c8df/fable_library-5.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:32f39fb442ade883fa0cbfbbdc54935443bc9a521e9bc64a8b88d9d19bc58aa1", size = 1306243, upload-time = "2026-07-24T11:40:10.306Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/7f/9764b480d138c170eb3dfbe543d8a3cf5dbdfd5b2f56df23cce5dace42c2/fable_library-5.13.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:782b07b2e82314720bfbfe3468a108f6a801413c1302e2b12f7eed52a7750d23", size = 1353432, upload-time = "2026-07-24T11:40:11.73Z" },
-    { url = "https://files.pythonhosted.org/packages/13/d4/60098418cd9b549515b43a15a6636e370301f0a1fdf2e7289e7b57cacc64/fable_library-5.13.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2365c8cbba894a745049041f271e2a92693e02ae18a7af6363a1104148b26a4c", size = 1336432, upload-time = "2026-07-24T11:40:13.078Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/27/e67cf3812ffa443d045060f5a2de34932c0314754143f790cac1f243b9d6/fable_library-5.13.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ab695ae3c2347b91120a21a753fb0d25ab2fc8729979dc19c20478631ac3468b", size = 1477874, upload-time = "2026-07-24T11:40:14.563Z" },
-    { url = "https://files.pythonhosted.org/packages/47/0f/37bc5abe5a3cac8227912ea22fcf22c7da55bc0a61200d257fb962437849/fable_library-5.13.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:34785b5f1e2b78b958a13b80cd5431711a76d11de21fabbc3603bd7a07382e15", size = 1490011, upload-time = "2026-07-24T11:40:16.18Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/c8/878bf6773589e904f9f11b68407220ef6e9e2593f8f7ed121b0151bc66ac/fable_library-5.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:973f7c9ffaf3c1416c6573e43562d9da8852e3e59607eccabb2127cd626d67dc", size = 1426215, upload-time = "2026-07-24T11:40:17.561Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/da/5fd16fc7ab312646b05835cf821005ecef1d13394ce895b28ae6439e0b0a/fable_library-5.13.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:aa541b41602c01c77b0a0fc6ab5f8649998efdd2f7b2a4a2eb433100d2f5a820", size = 1455634, upload-time = "2026-07-24T11:40:19.255Z" },
-    { url = "https://files.pythonhosted.org/packages/30/76/8e067b4170ac2a8ebff1d2867b6cf0bf18908cc4dc33001dfa8f16575660/fable_library-5.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:84eccdc8b4e983166f5bbcd06b70e547de80947d02d08aaa9f6d7e0182513ad4", size = 1530150, upload-time = "2026-07-24T11:40:20.875Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/c4/04312dd29c1677b6ab9278c2faaeef3bd0d3d537b49e20c698fd2985e5e1/fable_library-5.13.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:c5660aa9146c49d2d42b00d4b612d08a1f3a82cc1c1056a6bc8f94cbc8890298", size = 1613322, upload-time = "2026-07-24T11:40:22.396Z" },
-    { url = "https://files.pythonhosted.org/packages/99/f3/a277f39713fe74cd41489aafdab4e0f9cce08123b5ade32f7272a96129ed/fable_library-5.13.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:9a3a4ba17ec177ae75f12fbe2ff244753839454507d67a7ca737f19c0e4c7e5f", size = 1637103, upload-time = "2026-07-24T11:40:23.884Z" },
-    { url = "https://files.pythonhosted.org/packages/97/c9/9da7bf5d36fd033d4af05f369b4f1610f4217a6deaec29241bf244ba1acf/fable_library-5.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c99ace7082feb254c65ac93f64006b9a07faec2ac85be3528458a6f05cf8f15a", size = 1654503, upload-time = "2026-07-24T11:40:25.374Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/8e/9fd13fc07795935fba7c523601c558541fec30c8b3e7faca4833b0940460/fable_library-5.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:fd2cb0753bad72e7673b60d796d9d8fc882012dceb1707e060312e318a4b262b", size = 1410516, upload-time = "2026-07-24T11:40:26.757Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/6a/0a636f5c87d1b1750a2ba3086a8a449952c8016e84b3eeb45fb7a9691f50/fable_library-5.13.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:52a4e43f82c91ba5d6da2739e69d1a86763cedf54425756946480aaae7e71dfb", size = 1399458, upload-time = "2026-07-24T11:40:28.575Z" },
-    { url = "https://files.pythonhosted.org/packages/36/1f/a4f5690366400fa70f00c6d3fe9341d1f190c1f6108e88f99e144fe5e714/fable_library-5.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:36c0d7065879c5b11d4840f0ad0cd6102b1c3ea745a006cb735b753555cd684c", size = 1304584, upload-time = "2026-07-24T11:40:29.922Z" },
-    { url = "https://files.pythonhosted.org/packages/93/55/df8be1939068ca6377392410cba1feaaad96f463fd4430f4be54d873533e/fable_library-5.13.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38d99de97e124364226518936d036eb84195a525f904f2b41c3b6181ba9dd928", size = 1352285, upload-time = "2026-07-24T11:40:32.207Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/65/0c49f5a9ac8d067d4973e6bb48dd5caeee22b3877ff7e0bffd932bc1dc93/fable_library-5.13.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:75185f9f819403d8223eaabc2d2ab0aa569f9479376caaf12d925ed6076219b1", size = 1338149, upload-time = "2026-07-24T11:40:33.627Z" },
-    { url = "https://files.pythonhosted.org/packages/70/6f/dfcdce9af2e1eb42506531bb385b2b4be40d0a790d983aabec9360b69ac0/fable_library-5.13.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:239d3698f5fe6843e6c4d8e979f6f084e1ae8be5bc285aa63d8b5b19cf1afdf7", size = 1478014, upload-time = "2026-07-24T11:40:35.089Z" },
-    { url = "https://files.pythonhosted.org/packages/52/07/0396f4996527bf9fe3bcc301b31bab00e6738e77b6ec62ea4e88f3b29329/fable_library-5.13.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d8960fa8a6fd8942d7f5b856df9892eb72ac47a5af54c4acab7edb5bc010c2eb", size = 1491536, upload-time = "2026-07-24T11:40:37.029Z" },
-    { url = "https://files.pythonhosted.org/packages/35/b6/c61486d7b3e74d73782af3848d858c033c09d3f8045526222f9422c6c563/fable_library-5.13.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:709e4f3cff1eaeb85ff83d3beca66a89ebbb0bf107188d91c2d6ca019ac4ebf0", size = 1426466, upload-time = "2026-07-24T11:40:38.441Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/37/620ec1d435351210515c5b1524805a0043c9deef0ba6d84948f4a4d6ab8f/fable_library-5.13.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1b8ec5d8d8e5234fa973b594028ce4b58c1810403cdb030fc651508916313fd3", size = 1456670, upload-time = "2026-07-24T11:40:39.96Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/bf/6c741373bf4e01995833a102a9a42f2c0553f28bfbbaca7d4ecdd31f660c/fable_library-5.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:75a513319f0eeb6d4d9ea538759b0727f34dd545207760bc3aa767c92ab70558", size = 1529769, upload-time = "2026-07-24T11:40:41.435Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/98/56ef690f1a8d7adce9c827429483ed6cc3d427de119f68a259750fb758b7/fable_library-5.13.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:4e25c5934cf285e0d1d50c76591478347276200398aa1e254c6f985b8f88549e", size = 1614640, upload-time = "2026-07-24T11:40:42.928Z" },
-    { url = "https://files.pythonhosted.org/packages/64/a2/e2630f606c3a67d825f87dd3b9c2aaa8e0ab4adf749b53f2f50b0b10fe13/fable_library-5.13.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f4c25880f4a8a38be14573364421f9b2661f90f454b9751a8d56bb7ebcb09aa6", size = 1637786, upload-time = "2026-07-24T11:40:44.416Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/57/e730d0bad916454b3b86460b5c032471cb950445687209576dc4466cbaff/fable_library-5.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ca4f221bdeca436e9c11abce595fc5a55922e388bedaac518767312c7fa8c87a", size = 1654714, upload-time = "2026-07-24T11:40:45.947Z" },
-    { url = "https://files.pythonhosted.org/packages/06/ba/1091cf45f9ddf8f4b5dc3b4f1b7df83ea08fee24849fd1f651646152714c/fable_library-5.13.0-cp314-cp314-win32.whl", hash = "sha256:1a9c8da9231ba81c868b1103b8d4898f33582d44cde884de59dd95e8f703e8e5", size = 1257557, upload-time = "2026-07-24T11:40:47.359Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/87/e08ab70a85215142e149a6bd562c0c5f5f50d5ccaa589db87cd00308c5e3/fable_library-5.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:0c07a7374c5f7e5c3b4a696f7e9624985b5688ed6aa267432fecf9cc2b6d35be", size = 1408938, upload-time = "2026-07-24T11:40:49.121Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/e3/0803c34cb8ff5ce36e22ec7bbcf12329faf3b3d279f530e398d1b1b9f34d/fable_library-5.13.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce0e43652d81f6d22595f8ccbcfc32cad39ef4ed643b032d65a8bf7d80cb5689", size = 1359287, upload-time = "2026-07-24T11:40:50.564Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/44/d2b6b20a590ea0004bc8fbbf949ae73fd35861d9ddeb020dd66d2d91b571/fable_library-5.13.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4d3165e8c92e954259033eed6a9a1e325aca0d81b0a0c66cc4b1569f17dd4719", size = 1335786, upload-time = "2026-07-24T11:40:52.189Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/2f/4c1f032c1a25974189c31e1768163829e410bad00cbf88dd7dd1a4600cf8/fable_library-5.13.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7ef2d2251b147d8bf7bd4b3ba042c73cba8d8e8899ae9054258c3e1257065d8d", size = 1484994, upload-time = "2026-07-24T11:40:53.733Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/a2/760e4dd1e658db44b372365adeb771029a5d24dbf292a20b0a2e3be850ad/fable_library-5.13.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40962f291f58c978d7e4c3fc12d3765a70d421989ff8f7234f9e65f089a8b3be", size = 1499217, upload-time = "2026-07-24T11:40:55.885Z" },
-    { url = "https://files.pythonhosted.org/packages/68/e8/d274118300335222b5a88b2ca6253731768458bb604557ca110a8d12bf68/fable_library-5.13.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5013e124dafc45da5ea617ca9c46f4c4544cf76b22251565e2e6712ecc5333d5", size = 1436477, upload-time = "2026-07-24T11:40:57.686Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/c1/c88614d7e4edce0b3497a827ef6f911e9848b63ec6eecf53b4b2bb80e719/fable_library-5.13.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0c7522f47404e2b0e64f7d47208f603f35e0c5897496951b4d62dcf051dedc37", size = 1460863, upload-time = "2026-07-24T11:40:59.117Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/64/cb16af5b93ee2bcae293ae084eab021eeff7a4669b0cbc2d814261f5443a/fable_library-5.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c2a5e380e80637f2c1ea25ca7ebc5cd165feee8a13b924699e1c995bcc5ee23c", size = 1536395, upload-time = "2026-07-24T11:41:00.948Z" },
-    { url = "https://files.pythonhosted.org/packages/54/c6/3d21973c8df547fe6beabb3b3db0c1e75a1f1f1f90bc9b05fedc9dd2faa8/fable_library-5.13.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:4557aa9920706242c824a0ce7a8c9c2e38baafaacbb4cfb09cb5c562cc14ad1f", size = 1613546, upload-time = "2026-07-24T11:41:02.825Z" },
-    { url = "https://files.pythonhosted.org/packages/38/eb/99b564447c261c53c93ac0ed7cd51ce6c8934ecb6ebaddc628931d4fb6c5/fable_library-5.13.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:4496f54b1b8a79066d1e7cac6081f113752dafb915cc4386de1744f1ea04d597", size = 1646913, upload-time = "2026-07-24T11:41:04.322Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/c2/b465ffe23114317e31f0b4e1fe8e90e0c1514243678dbca0997f307f98ad/fable_library-5.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c37a40e2dc9f5b3adaec5df57fb552b489bfecd393e8ac46af650bdd978e3adf", size = 1665943, upload-time = "2026-07-24T11:41:05.759Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/54/97ab29b2f16637225d71bae41bbe3bc8d2246d7b41002a5f665640e0285b/fable_library-5.13.0-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:12142c67134840a66dc4a0c78828112ac47c31e97d3517e12d83c52e9da319f8", size = 1426255, upload-time = "2026-07-24T11:41:07.223Z" },
-    { url = "https://files.pythonhosted.org/packages/41/5d/3f8c477790193397543dda2bb587e86a76f6c088fba4f60249c0b3701725/fable_library-5.13.0-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:62bcd15bd9276615876a605fff4f942d6ce31a3a63addcd4d745550559952359", size = 1456813, upload-time = "2026-07-24T11:41:08.814Z" },
-    { url = "https://files.pythonhosted.org/packages/75/32/a76037a00cf513bf2be35e7cec061c4c712f5d9a84e9dd406fae0730caec/fable_library-5.13.0-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:34c990dda0f05f1e7b9bd922acc475149a1f7d9376397ad6697772574f2e1d92", size = 1436333, upload-time = "2026-07-24T11:41:10.338Z" },
-    { url = "https://files.pythonhosted.org/packages/02/d8/d6190a9473a2f65f52e66b8a0cda979130ac203d20d3740cc7dd938b4770/fable_library-5.13.0-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f5abae35d4643585717eb28596ef1c15e5603e7eb4a324684ea2af49832c29f3", size = 1461061, upload-time = "2026-07-24T11:41:12.045Z" },
 ]
 
 [[package]]
@@ -3148,7 +3085,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "arctrl", specifier = ">=3.0.0b15" }]
+requires-dist = [{ name = "arctrl", specifier = ">=3.1.1" }]
 
 [[package]]
 name = "truststore"


### PR DESCRIPTION
- Replaced `FailedRecord` with `HarvestIssue` to represent both dataset and repository-level issues.
- Introduced `IssueKind` enum to classify issues as either `dataset` or `repository`.
- Updated relevant methods and serializers to accommodate the new structure, ensuring backward compatibility in JSON-LD outputs.
- Adjusted tests to reflect changes in the failure reporting mechanism and ensure accurate validation of harvest issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Intentional breaking change to harvest-report JSON-LD and public types (`FailedRecord` removed); downstream tools must adopt v2. The new GitLab script only needs a token and does not affect runtime middleware.
> 
> **Overview**
> **Harvest reporting** moves from `FailedRecord` / `failed_records` to **`HarvestIssue`** with **`IssueKind`** (`dataset` | `repository`), exported as **`failures`** on repository snapshots. **`record_failed`** still bumps **`failed_datasets`**; new **`record_repository_issue`** appends repository-scoped issues without touching that counter. **`HarvestIssue`** validates kinds and rejects **`record_id`** on repository issues.
> 
> **JSON-LD** now targets **`ns/harvest-report/v2`**: **`fairagro:failures`** (with **`fairagro:kind`**) replaces **`fairagro:failedRecords`**. v1 vocabulary is documented as frozen; **`ns/harvest-report/v2/`** adds context and docs. OpenSpec/AGENTS reflect the v2 wire shape (explicitly **not** backward-compatible with v1).
> 
> Also adds **`scripts/list_failed_arc_json_jobs.py`** — parallel GitLab group scan for failed **`arc_json`** jobs, log cause extraction, and markdown/JSON reports (orthogonal to the report library).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd98571387e1894da05155d3d6c4f41614e4c034. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->