### PR TITLE
Feature/make harvest idempotent

### DIFF
--- a/middleware/api/src/middleware/api/api/fastapi_app.py
+++ b/middleware/api/src/middleware/api/api/fastapi_app.py
@@ -25,7 +25,9 @@ from ..business_logic.exceptions import (
     BusinessLogicError,
     ConflictError,
     InvalidJsonSemanticError,
+    InvalidRequestError,
     ResourceNotFoundError,
+    TransientError,
 )
 from ..celery_integration import (
     CeleryBrokerHealthChecker,
@@ -264,6 +266,20 @@ class Api:
         async def conflict_handler(_request: Request, exc: ConflictError) -> JSONResponse:
             return JSONResponse(
                 status_code=HTTPStatus.CONFLICT,
+                content={"detail": str(exc)},
+            )
+
+        @self._app.exception_handler(InvalidRequestError)
+        async def invalid_request_handler(_request: Request, exc: InvalidRequestError) -> JSONResponse:
+            return JSONResponse(
+                status_code=HTTPStatus.BAD_REQUEST,
+                content={"detail": str(exc)},
+            )
+
+        @self._app.exception_handler(TransientError)
+        async def transient_error_handler(_request: Request, exc: TransientError) -> JSONResponse:
+            return JSONResponse(
+                status_code=HTTPStatus.SERVICE_UNAVAILABLE,
                 content={"detail": str(exc)},
             )
 

--- a/middleware/api/src/middleware/api/api/v3/harvests.py
+++ b/middleware/api/src/middleware/api/api/v3/harvests.py
@@ -3,7 +3,7 @@
 from http import HTTPStatus
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response
 
 from middleware.api.api.common.dependencies import (
     CommonApiDependencies,
@@ -24,23 +24,31 @@ router = APIRouter(prefix="/v3/harvests", tags=["v3", "harvests"])
 @router.post("", response_model=v3_models.HarvestResponse)
 async def create_harvest(  # noqa: PLR0913, PLR0917
     request: Request,
+    response: Response,
     request_body: v3_models.CreateHarvestRequest,
     bl: Annotated[BusinessLogic, Depends(get_business_logic)],
     deps: Annotated[CommonApiDependencies, Depends(get_common_deps)],
     client_id: Annotated[str | None, Depends(get_client_id)],
     _content_type: Annotated[None, Depends(get_content_type)],
     _accept_type: Annotated[None, Depends(get_accept_type)],
+    idempotency_key: Annotated[str | None, Header(alias="Idempotency-Key")] = None,
 ) -> v3_models.HarvestResponse:
     """Start a new harvest run."""
     await deps.validate_rdi_authorized(request_body.rdi, request)
 
-    harvest_id = await bl.harvest_manager.create_harvest(
-        request_body.rdi, client_id=client_id, expected_datasets=request_body.expected_datasets
+    created = await bl.harvest_manager.create_harvest(
+        request_body.rdi,
+        client_id=client_id,
+        expected_datasets=request_body.expected_datasets,
+        idempotency_key=idempotency_key,
     )
 
-    harvest = await bl.harvest_manager.get_harvest(harvest_id)
+    harvest = await bl.harvest_manager.get_harvest(created.harvest_id)
     if not harvest:
         raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="Failed to create harvest")
+
+    if created.replayed:
+        response.headers["Idempotent-Replayed"] = "true"
 
     return _map_harvest(harvest)
 

--- a/middleware/api/src/middleware/api/business_logic/__init__.py
+++ b/middleware/api/src/middleware/api/business_logic/__init__.py
@@ -11,11 +11,12 @@ from .exceptions import (
     ConflictError,
     DuplicateArcInHarvestError,
     InvalidJsonSemanticError,
+    InvalidRequestError,
     ResourceNotFoundError,
     SetupError,
     TransientError,
 )
-from .harvest_manager import HarvestManager
+from .harvest_manager import CreateHarvestResult, HarvestManager
 from .ports import BrokerHealthChecker, BusinessLogicPorts
 
 __all__ = [
@@ -24,8 +25,10 @@ __all__ = [
     "BusinessLogic",
     "BusinessLogicError",
     "ConflictError",
+    "CreateHarvestResult",
     "DuplicateArcInHarvestError",
     "InvalidJsonSemanticError",
+    "InvalidRequestError",
     "ResourceNotFoundError",
     "SetupError",
     "BrokerHealthChecker",

--- a/middleware/api/src/middleware/api/business_logic/exceptions.py
+++ b/middleware/api/src/middleware/api/business_logic/exceptions.py
@@ -22,7 +22,12 @@ class DuplicateArcInHarvestError(ConflictError):
 
 
 class InvalidRequestError(BusinessLogicError):
-    """Arises when the request is syntactically valid JSON but semantically invalid."""
+    """Arises when request parameters or headers are invalid for this operation.
+
+    For example, an empty ``Idempotency-Key`` or a keyed create without an
+    authenticated client. Distinct from :class:`InvalidJsonSemanticError`, which
+    covers ARC JSON that is syntactically valid but semantically incorrect.
+    """
 
 
 class InvalidJsonSemanticError(BusinessLogicError):

--- a/middleware/api/src/middleware/api/business_logic/exceptions.py
+++ b/middleware/api/src/middleware/api/business_logic/exceptions.py
@@ -21,6 +21,10 @@ class DuplicateArcInHarvestError(ConflictError):
     """Arises when the same ARC is submitted more than once within a harvest run."""
 
 
+class InvalidRequestError(BusinessLogicError):
+    """Arises when the request is syntactically valid JSON but semantically invalid."""
+
+
 class InvalidJsonSemanticError(BusinessLogicError):
     """Arises when the ARC JSON syntax is valid but semantically incorrect.
 

--- a/middleware/api/src/middleware/api/business_logic/harvest_manager.py
+++ b/middleware/api/src/middleware/api/business_logic/harvest_manager.py
@@ -1,15 +1,34 @@
 """Harvest manager service for handling harvest-run lifecycles."""
 
 import logging
+from dataclasses import dataclass
 from typing import Any, Self
 
 from middleware.api.business_logic.config import HarvestConfig
-from middleware.api.business_logic.exceptions import AccessDeniedError, ConflictError, ResourceNotFoundError
-from middleware.api.document_store import DocumentStore
+from middleware.api.business_logic.exceptions import (
+    AccessDeniedError,
+    ConflictError,
+    InvalidRequestError,
+    ResourceNotFoundError,
+    TransientError,
+)
+from middleware.api.document_store import (
+    DocumentStore,
+    IdempotencyBodyConflictError,
+    IdempotencyPendingError,
+)
 from middleware.api.document_store.harvest_document import HarvestDocument
 from middleware.shared.api_models.common.models import HarvestStatus
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class CreateHarvestResult:
+    """Outcome of creating or replaying a harvest run."""
+
+    harvest_id: str
+    replayed: bool = False
 
 
 class HarvestManager:
@@ -36,11 +55,45 @@ class HarvestManager:
         """
         return cls(doc_store, config)
 
-    async def create_harvest(self, rdi: str, client_id: str | None, expected_datasets: int | None = None) -> str:
-        """Start a new harvest run."""
+    async def create_harvest(
+        self,
+        rdi: str,
+        client_id: str | None,
+        expected_datasets: int | None = None,
+        *,
+        idempotency_key: str | None = None,
+    ) -> CreateHarvestResult:
+        """Start a new harvest run, optionally keyed for idempotent retries."""
+        if idempotency_key is not None:
+            if idempotency_key == "":
+                raise InvalidRequestError("Idempotency-Key must not be empty")
+            if client_id is None:
+                raise InvalidRequestError("Idempotency-Key requires an authenticated client")
+            try:
+                harvest_id, replayed = await self._doc_store.create_harvest_idempotent(
+                    rdi,
+                    client_id,
+                    idempotency_key,
+                    expected_datasets=expected_datasets,
+                )
+            except IdempotencyBodyConflictError as exc:
+                raise ConflictError(str(exc)) from exc
+            except IdempotencyPendingError as exc:
+                raise TransientError(str(exc)) from exc
+            if replayed:
+                logger.info(
+                    "[%s] Replayed harvest create for key (rdi=%s): %s",
+                    client_id,
+                    rdi,
+                    harvest_id,
+                )
+            else:
+                logger.info("[%s] Created harvest: %s (rdi=%s, keyed)", client_id, harvest_id, rdi)
+            return CreateHarvestResult(harvest_id=harvest_id, replayed=replayed)
+
         harvest_id = await self._doc_store.create_harvest(rdi, client_id, expected_datasets=expected_datasets)
         logger.info("[%s] Created harvest: %s (rdi=%s)", client_id, harvest_id, rdi)
-        return harvest_id
+        return CreateHarvestResult(harvest_id=harvest_id, replayed=False)
 
     async def get_harvest(self, harvest_id: str) -> HarvestDocument | None:
         """Get harvest details."""

--- a/middleware/api/src/middleware/api/business_logic/harvest_manager.py
+++ b/middleware/api/src/middleware/api/business_logic/harvest_manager.py
@@ -65,7 +65,7 @@ class HarvestManager:
     ) -> CreateHarvestResult:
         """Start a new harvest run, optionally keyed for idempotent retries."""
         if idempotency_key is not None:
-            if idempotency_key == "":
+            if not idempotency_key.strip():
                 raise InvalidRequestError("Idempotency-Key must not be empty")
             if client_id is None:
                 raise InvalidRequestError("Idempotency-Key requires an authenticated client")

--- a/middleware/api/src/middleware/api/document_store/__init__.py
+++ b/middleware/api/src/middleware/api/document_store/__init__.py
@@ -16,6 +16,14 @@ class DuplicateArcError(DocumentStoreError):
     """Raised when the same ARC is submitted more than once within the same harvest run."""
 
 
+class IdempotencyBodyConflictError(DocumentStoreError):
+    """Raised when an Idempotency-Key is reused with an incompatible create body."""
+
+
+class IdempotencyPendingError(DocumentStoreError):
+    """Raised when a keyed create claim exists but is not yet committed."""
+
+
 class ArcStoreResult:
     """Result of storing an ARC."""
 
@@ -135,6 +143,26 @@ class DocumentStore(ABC):
 
         Returns:
             The harvest_id of the created harvest
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def create_harvest_idempotent(
+        self,
+        rdi: str,
+        client_id: str,
+        idempotency_key: str,
+        expected_datasets: int | None = None,
+    ) -> tuple[str, bool]:
+        """Create a harvest keyed by ``(client_id, idempotency_key)``.
+
+        Returns:
+            ``(harvest_id, replayed)`` where ``replayed`` is True when an existing
+            compatible harvest was returned.
+
+        Raises:
+            IdempotencyBodyConflictError: Key reused with incompatible body.
+            IdempotencyPendingError: Concurrent claim not yet committed.
         """
         raise NotImplementedError
 

--- a/middleware/api/src/middleware/api/document_store/couchdb.py
+++ b/middleware/api/src/middleware/api/document_store/couchdb.py
@@ -371,7 +371,11 @@ class CouchDB(DocumentStore):
         try:
             harvest_id = await self.create_harvest(rdi, client_id, expected_datasets=expected_datasets)
         except Exception:
-            await self._client.delete_document(doc_id)
+            # Best-effort: release the claim so the same key can retry create.
+            try:
+                await self._client.delete_document(doc_id)
+            except Exception:
+                logger.exception("Failed to roll back idempotency claim %s after create failure", doc_id)
             raise
 
         committed = HarvestIdempotencyDocument(

--- a/middleware/api/src/middleware/api/document_store/couchdb.py
+++ b/middleware/api/src/middleware/api/document_store/couchdb.py
@@ -1,5 +1,7 @@
 """CouchDB implementation of DocumentStore."""
 
+import asyncio
+import hashlib
 import logging
 import uuid
 from collections.abc import Callable
@@ -8,11 +10,17 @@ from typing import Any, cast
 
 from middleware.api.document_store.config import CouchDBConfig
 from middleware.api.document_store.content_hash import RoCrateContent, calculate_arc_content_hash
-from middleware.api.document_store.couchdb_client import CouchDBClient
+from middleware.api.document_store.couchdb_client import CouchDBClient, DocumentConflictError
 from middleware.api.utils import calculate_arc_id
 from middleware.shared.api_models.common.models import ArcEventType, ArcLifecycleStatus, HarvestStatus
 
-from . import ArcStoreResult, DocumentStore, DuplicateArcError
+from . import (
+    ArcStoreResult,
+    DocumentStore,
+    DuplicateArcError,
+    IdempotencyBodyConflictError,
+    IdempotencyPendingError,
+)
 from .arc_document import (
     ArcDocument,
     ArcEvent,
@@ -22,9 +30,16 @@ from .harvest_document import (
     HarvestDocument,
     HarvestStatistics,
 )
+from .harvest_idempotency_document import (
+    HarvestIdempotencyDocument,
+    IdempotencyStatus,
+)
 from .task_record import TaskRecord
 
 logger = logging.getLogger(__name__)
+
+_PENDING_POLL_ATTEMPTS = 20
+_PENDING_POLL_DELAY_S = 0.05
 
 
 class CouchDB(DocumentStore):
@@ -288,6 +303,92 @@ class CouchDB(DocumentStore):
         doc_data = doc.model_dump(mode="json", by_alias=True, exclude_none=True)
         await self._client.save_document(doc_id, doc_data)
         return doc_id
+
+    @staticmethod
+    def _idempotency_doc_id(client_id: str, idempotency_key: str) -> str:
+        digest = hashlib.sha256(f"{client_id}\0{idempotency_key}".encode()).hexdigest()
+        return f"harvest-idempotency:{digest}"
+
+    @staticmethod
+    def _bodies_compatible(
+        index: HarvestIdempotencyDocument,
+        rdi: str,
+        expected_datasets: int | None,
+    ) -> bool:
+        return index.rdi == rdi and index.expected_datasets == expected_datasets
+
+    async def _load_idempotency_doc(self, doc_id: str) -> HarvestIdempotencyDocument | None:
+        raw = await self._client.get_document(doc_id)
+        if raw is None:
+            return None
+        return HarvestIdempotencyDocument.model_validate(raw)
+
+    async def _resolve_idempotency_claim(
+        self,
+        doc_id: str,
+        rdi: str,
+        expected_datasets: int | None,
+    ) -> tuple[str, bool]:
+        for _ in range(_PENDING_POLL_ATTEMPTS):
+            index = await self._load_idempotency_doc(doc_id)
+            if index is None:
+                raise IdempotencyPendingError(f"Idempotency claim {doc_id} disappeared")
+            if index.status == IdempotencyStatus.COMMITTED and index.harvest_id:
+                if not self._bodies_compatible(index, rdi, expected_datasets):
+                    raise IdempotencyBodyConflictError("Idempotency-Key was reused with an incompatible create body")
+                return index.harvest_id, True
+            await asyncio.sleep(_PENDING_POLL_DELAY_S)
+
+        raise IdempotencyPendingError(f"Idempotency claim {doc_id} is still pending")
+
+    async def create_harvest_idempotent(
+        self,
+        rdi: str,
+        client_id: str,
+        idempotency_key: str,
+        expected_datasets: int | None = None,
+    ) -> tuple[str, bool]:
+        """Claim-then-finalize keyed harvest create."""
+        doc_id = self._idempotency_doc_id(client_id, idempotency_key)
+        pending = HarvestIdempotencyDocument(
+            doc_id=doc_id,
+            client_id=client_id,
+            idempotency_key=idempotency_key,
+            rdi=rdi,
+            expected_datasets=expected_datasets,
+            status=IdempotencyStatus.PENDING,
+            harvest_id=None,
+            created_at=datetime.now(UTC),
+        )
+        try:
+            await self._client.create_document_exclusive(
+                doc_id,
+                pending.model_dump(mode="json", by_alias=True, exclude_none=True),
+            )
+        except DocumentConflictError:
+            return await self._resolve_idempotency_claim(doc_id, rdi, expected_datasets)
+
+        try:
+            harvest_id = await self.create_harvest(rdi, client_id, expected_datasets=expected_datasets)
+        except Exception:
+            await self._client.delete_document(doc_id)
+            raise
+
+        committed = HarvestIdempotencyDocument(
+            doc_id=doc_id,
+            client_id=client_id,
+            idempotency_key=idempotency_key,
+            rdi=rdi,
+            expected_datasets=expected_datasets,
+            status=IdempotencyStatus.COMMITTED,
+            harvest_id=harvest_id,
+            created_at=pending.created_at,
+        )
+        await self._client.save_document(
+            doc_id,
+            committed.model_dump(mode="json", by_alias=True, exclude_none=True),
+        )
+        return harvest_id, False
 
     async def get_harvest(self, harvest_id: str) -> HarvestDocument | None:
         """Get harvest document."""

--- a/middleware/api/src/middleware/api/document_store/couchdb.py
+++ b/middleware/api/src/middleware/api/document_store/couchdb.py
@@ -333,9 +333,9 @@ class CouchDB(DocumentStore):
             index = await self._load_idempotency_doc(doc_id)
             if index is None:
                 raise IdempotencyPendingError(f"Idempotency claim {doc_id} disappeared")
+            if not self._bodies_compatible(index, rdi, expected_datasets):
+                raise IdempotencyBodyConflictError("Idempotency-Key was reused with an incompatible create body")
             if index.status == IdempotencyStatus.COMMITTED and index.harvest_id:
-                if not self._bodies_compatible(index, rdi, expected_datasets):
-                    raise IdempotencyBodyConflictError("Idempotency-Key was reused with an incompatible create body")
                 return index.harvest_id, True
             await asyncio.sleep(_PENDING_POLL_DELAY_S)
 

--- a/middleware/api/src/middleware/api/document_store/couchdb.py
+++ b/middleware/api/src/middleware/api/document_store/couchdb.py
@@ -384,10 +384,22 @@ class CouchDB(DocumentStore):
             harvest_id=harvest_id,
             created_at=pending.created_at,
         )
-        await self._client.save_document(
-            doc_id,
-            committed.model_dump(mode="json", by_alias=True, exclude_none=True),
-        )
+        try:
+            await self._client.save_document(
+                doc_id,
+                committed.model_dump(mode="json", by_alias=True, exclude_none=True),
+            )
+        except Exception:
+            # Best-effort rollback so the same key can safely retry create.
+            try:
+                await self._client.delete_document(harvest_id)
+            except Exception:
+                logger.exception("Failed to roll back harvest %s after idempotency commit failure", harvest_id)
+            try:
+                await self._client.delete_document(doc_id)
+            except Exception:
+                logger.exception("Failed to roll back idempotency claim %s after commit failure", doc_id)
+            raise
         return harvest_id, False
 
     async def get_harvest(self, harvest_id: str) -> HarvestDocument | None:

--- a/middleware/api/src/middleware/api/document_store/couchdb_client.py
+++ b/middleware/api/src/middleware/api/document_store/couchdb_client.py
@@ -211,9 +211,6 @@ class CouchDBClient:
             raise RuntimeError("Not connected to CouchDB")
 
         content = {k: v for k, v in data.items() if k not in {"_id", "_rev"}}
-        existing = await self.get_document(doc_id)
-        if existing is not None:
-            raise DocumentConflictError(f"Document {doc_id} already exists")
 
         try:
             doc = await self._db.create(doc_id, data=content)

--- a/middleware/api/src/middleware/api/document_store/couchdb_client.py
+++ b/middleware/api/src/middleware/api/document_store/couchdb_client.py
@@ -198,6 +198,30 @@ class CouchDBClient:
         except NotFoundError:
             return None
 
+    async def create_document_exclusive(self, doc_id: str, data: dict[str, Any]) -> dict[str, Any]:
+        """Create a document only if it does not already exist.
+
+        Unlike :meth:`save_document`, a conflict does not fall through to an update
+        of the existing document.
+
+        Raises:
+            DocumentConflictError: If the document already exists or create races.
+        """
+        if not self._db:
+            raise RuntimeError("Not connected to CouchDB")
+
+        content = {k: v for k, v in data.items() if k not in {"_id", "_rev"}}
+        existing = await self.get_document(doc_id)
+        if existing is not None:
+            raise DocumentConflictError(f"Document {doc_id} already exists")
+
+        try:
+            doc = await self._db.create(doc_id, data=content)
+            await doc.save()
+        except ConflictError as err:
+            raise DocumentConflictError(f"Document {doc_id} already exists") from err
+        return dict(doc)
+
     async def save_document(
         self,
         doc_id: str,

--- a/middleware/api/src/middleware/api/document_store/harvest_idempotency_document.py
+++ b/middleware/api/src/middleware/api/document_store/harvest_idempotency_document.py
@@ -1,0 +1,37 @@
+"""CouchDB document for harvest-create idempotency keys."""
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class IdempotencyStatus(StrEnum):
+    """Lifecycle of a harvest idempotency claim."""
+
+    PENDING = "pending"
+    COMMITTED = "committed"
+
+
+class HarvestIdempotencyDocument(BaseModel):
+    """Index document that maps ``(client_id, Idempotency-Key)`` to a harvest."""
+
+    doc_id: Annotated[str, Field(description="Document ID", alias="_id")]
+    doc_rev: Annotated[str | None, Field(description="CouchDB revision", alias="_rev")] = None
+    type: Annotated[str, Field(description="Document type")] = "harvest_idempotency"
+    client_id: Annotated[str, Field(description="Authenticated client that owns the key")]
+    idempotency_key: Annotated[str, Field(description="Raw Idempotency-Key from the client")]
+    rdi: Annotated[str, Field(description="RDI from the create request")]
+    expected_datasets: Annotated[
+        int | None,
+        Field(description="expected_datasets from the create request"),
+    ] = None
+    status: Annotated[IdempotencyStatus, Field(description="Claim status")]
+    harvest_id: Annotated[
+        str | None,
+        Field(description="Created harvest id once the claim is committed"),
+    ] = None
+    created_at: Annotated[datetime, Field(description="Claim creation timestamp")]
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")

--- a/middleware/api/tests/unit/test_harvest_idempotency.py
+++ b/middleware/api/tests/unit/test_harvest_idempotency.py
@@ -1,0 +1,133 @@
+"""Unit tests for keyed harvest create idempotency in CouchDB DocumentStore."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from middleware.api.document_store import IdempotencyBodyConflictError, IdempotencyPendingError
+from middleware.api.document_store.couchdb import CouchDB
+from middleware.api.document_store.couchdb_client import DocumentConflictError
+from middleware.api.document_store.harvest_idempotency_document import (
+    HarvestIdempotencyDocument,
+    IdempotencyStatus,
+)
+
+
+@pytest.fixture
+def couchdb() -> CouchDB:
+    """CouchDB store with a mocked low-level client."""
+    store = CouchDB.__new__(CouchDB)
+    store._config = MagicMock()  # noqa: SLF001
+    store._db_name = "test"  # noqa: SLF001
+    store._client = MagicMock()  # noqa: SLF001
+    return store
+
+
+@pytest.mark.asyncio
+async def test_create_harvest_idempotent_first_create(couchdb: CouchDB) -> None:
+    """First keyed create claims, creates harvest, and commits."""
+    couchdb._client.create_document_exclusive = AsyncMock()  # noqa: SLF001
+    couchdb._client.delete_document = AsyncMock()  # noqa: SLF001
+    couchdb._client.save_document = AsyncMock()  # noqa: SLF001
+    couchdb.create_harvest = AsyncMock(return_value="harvest-1")  # type: ignore[method-assign]
+
+    harvest_id, replayed = await couchdb.create_harvest_idempotent("rdi-1", "client-a", "key-1", expected_datasets=3)
+
+    assert harvest_id == "harvest-1"
+    assert replayed is False
+    couchdb._client.create_document_exclusive.assert_awaited_once()  # noqa: SLF001
+    couchdb.create_harvest.assert_awaited_once()
+    couchdb._client.save_document.assert_awaited_once()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_create_harvest_idempotent_replay(couchdb: CouchDB) -> None:
+    """Existing committed claim with compatible body is replayed."""
+    doc_id = CouchDB._idempotency_doc_id("client-a", "key-1")  # noqa: SLF001
+    index = HarvestIdempotencyDocument(
+        doc_id=doc_id,
+        client_id="client-a",
+        idempotency_key="key-1",
+        rdi="rdi-1",
+        expected_datasets=None,
+        status=IdempotencyStatus.COMMITTED,
+        harvest_id="harvest-existing",
+        created_at=datetime.now(UTC),
+    )
+    couchdb._client.create_document_exclusive = AsyncMock(  # noqa: SLF001
+        side_effect=DocumentConflictError("exists")
+    )
+    couchdb._client.get_document = AsyncMock(  # noqa: SLF001
+        return_value=index.model_dump(mode="json", by_alias=True)
+    )
+
+    harvest_id, replayed = await couchdb.create_harvest_idempotent("rdi-1", "client-a", "key-1")
+
+    assert harvest_id == "harvest-existing"
+    assert replayed is True
+
+
+@pytest.mark.asyncio
+async def test_create_harvest_idempotent_body_conflict(couchdb: CouchDB) -> None:
+    """Existing committed claim with different rdi raises conflict."""
+    doc_id = CouchDB._idempotency_doc_id("client-a", "key-1")  # noqa: SLF001
+    index = HarvestIdempotencyDocument(
+        doc_id=doc_id,
+        client_id="client-a",
+        idempotency_key="key-1",
+        rdi="rdi-other",
+        expected_datasets=None,
+        status=IdempotencyStatus.COMMITTED,
+        harvest_id="harvest-existing",
+        created_at=datetime.now(UTC),
+    )
+    couchdb._client.create_document_exclusive = AsyncMock(  # noqa: SLF001
+        side_effect=DocumentConflictError("exists")
+    )
+    couchdb._client.get_document = AsyncMock(  # noqa: SLF001
+        return_value=index.model_dump(mode="json", by_alias=True)
+    )
+
+    with pytest.raises(IdempotencyBodyConflictError):
+        await couchdb.create_harvest_idempotent("rdi-1", "client-a", "key-1")
+
+
+@pytest.mark.asyncio
+async def test_create_harvest_idempotent_pending_timeout(couchdb: CouchDB, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stuck pending claim eventually raises IdempotencyPendingError."""
+    monkeypatch.setattr("middleware.api.document_store.couchdb._PENDING_POLL_ATTEMPTS", 2)
+    monkeypatch.setattr("middleware.api.document_store.couchdb._PENDING_POLL_DELAY_S", 0)
+    doc_id = CouchDB._idempotency_doc_id("client-a", "key-1")  # noqa: SLF001
+    index = HarvestIdempotencyDocument(
+        doc_id=doc_id,
+        client_id="client-a",
+        idempotency_key="key-1",
+        rdi="rdi-1",
+        expected_datasets=None,
+        status=IdempotencyStatus.PENDING,
+        harvest_id=None,
+        created_at=datetime.now(UTC),
+    )
+    couchdb._client.create_document_exclusive = AsyncMock(  # noqa: SLF001
+        side_effect=DocumentConflictError("exists")
+    )
+    couchdb._client.get_document = AsyncMock(  # noqa: SLF001
+        return_value=index.model_dump(mode="json", by_alias=True)
+    )
+
+    with pytest.raises(IdempotencyPendingError):
+        await couchdb.create_harvest_idempotent("rdi-1", "client-a", "key-1")
+
+
+@pytest.mark.asyncio
+async def test_create_harvest_idempotent_deletes_claim_on_create_failure(couchdb: CouchDB) -> None:
+    """Failed harvest create rolls back the pending claim."""
+    couchdb._client.create_document_exclusive = AsyncMock()  # noqa: SLF001
+    couchdb._client.delete_document = AsyncMock(return_value=True)  # noqa: SLF001
+    couchdb.create_harvest = AsyncMock(side_effect=RuntimeError("boom"))  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await couchdb.create_harvest_idempotent("rdi-1", "client-a", "key-1")
+
+    couchdb._client.delete_document.assert_awaited_once()  # noqa: SLF001

--- a/middleware/api/tests/unit/test_harvest_idempotency.py
+++ b/middleware/api/tests/unit/test_harvest_idempotency.py
@@ -120,6 +120,27 @@ async def test_create_harvest_idempotent_pending_timeout(
 
 
 @pytest.mark.asyncio
+async def test_create_harvest_idempotent_pending_body_conflict(couchdb: CouchDB, couchdb_client: MagicMock) -> None:
+    """Incompatible body while claim is still pending raises conflict immediately."""
+    doc_id = CouchDB._idempotency_doc_id("client-a", "key-1")  # noqa: SLF001
+    index = HarvestIdempotencyDocument(
+        doc_id=doc_id,
+        client_id="client-a",
+        idempotency_key="key-1",
+        rdi="rdi-other",
+        expected_datasets=None,
+        status=IdempotencyStatus.PENDING,
+        harvest_id=None,
+        created_at=datetime.now(UTC),
+    )
+    couchdb_client.create_document_exclusive = AsyncMock(side_effect=DocumentConflictError("exists"))
+    couchdb_client.get_document = AsyncMock(return_value=index.model_dump(mode="json", by_alias=True))
+
+    with pytest.raises(IdempotencyBodyConflictError):
+        await couchdb.create_harvest_idempotent("rdi-1", "client-a", "key-1")
+
+
+@pytest.mark.asyncio
 async def test_create_harvest_idempotent_deletes_claim_on_create_failure(
     couchdb: CouchDB, couchdb_client: MagicMock, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/middleware/api/tests/unit/test_harvest_idempotency.py
+++ b/middleware/api/tests/unit/test_harvest_idempotency.py
@@ -95,6 +95,29 @@ async def test_create_harvest_idempotent_body_conflict(couchdb: CouchDB, couchdb
 
 
 @pytest.mark.asyncio
+async def test_create_harvest_idempotent_expected_datasets_conflict(
+    couchdb: CouchDB, couchdb_client: MagicMock
+) -> None:
+    """Existing committed claim with different expected_datasets raises conflict."""
+    doc_id = CouchDB._idempotency_doc_id("client-a", "key-1")  # noqa: SLF001
+    index = HarvestIdempotencyDocument(
+        doc_id=doc_id,
+        client_id="client-a",
+        idempotency_key="key-1",
+        rdi="rdi-1",
+        expected_datasets=3,
+        status=IdempotencyStatus.COMMITTED,
+        harvest_id="harvest-existing",
+        created_at=datetime.now(UTC),
+    )
+    couchdb_client.create_document_exclusive = AsyncMock(side_effect=DocumentConflictError("exists"))
+    couchdb_client.get_document = AsyncMock(return_value=index.model_dump(mode="json", by_alias=True))
+
+    with pytest.raises(IdempotencyBodyConflictError):
+        await couchdb.create_harvest_idempotent("rdi-1", "client-a", "key-1", expected_datasets=5)
+
+
+@pytest.mark.asyncio
 async def test_create_harvest_idempotent_pending_timeout(
     couchdb: CouchDB, couchdb_client: MagicMock, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/middleware/api/tests/unit/test_harvest_idempotency.py
+++ b/middleware/api/tests/unit/test_harvest_idempotency.py
@@ -153,3 +153,21 @@ async def test_create_harvest_idempotent_deletes_claim_on_create_failure(
         await couchdb.create_harvest_idempotent("rdi-1", "client-a", "key-1")
 
     couchdb_client.delete_document.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_create_harvest_idempotent_rolls_back_on_commit_failure(
+    couchdb: CouchDB, couchdb_client: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Failed index commit deletes harvest and claim so the key can be retried."""
+    couchdb_client.create_document_exclusive = AsyncMock()
+    couchdb_client.delete_document = AsyncMock(return_value=True)
+    couchdb_client.save_document = AsyncMock(side_effect=RuntimeError("commit failed"))
+    monkeypatch.setattr(couchdb, "create_harvest", AsyncMock(return_value="harvest-1"))
+
+    with pytest.raises(RuntimeError, match="commit failed"):
+        await couchdb.create_harvest_idempotent("rdi-1", "client-a", "key-1")
+
+    assert couchdb_client.delete_document.await_count == 2  # noqa: PLR2004
+    deleted_ids = [call.args[0] for call in couchdb_client.delete_document.await_args_list]
+    assert deleted_ids == ["harvest-1", CouchDB._idempotency_doc_id("client-a", "key-1")]  # noqa: SLF001

--- a/middleware/api/tests/unit/test_harvest_idempotency.py
+++ b/middleware/api/tests/unit/test_harvest_idempotency.py
@@ -15,34 +15,43 @@ from middleware.api.document_store.harvest_idempotency_document import (
 
 
 @pytest.fixture
-def couchdb() -> CouchDB:
+def couchdb_client() -> MagicMock:
+    """Provide a MagicMock standing in for CouchDBClient."""
+    return MagicMock()
+
+
+@pytest.fixture
+def couchdb(couchdb_client: MagicMock) -> CouchDB:
     """CouchDB store with a mocked low-level client."""
     store = CouchDB.__new__(CouchDB)
     store._config = MagicMock()  # noqa: SLF001
     store._db_name = "test"  # noqa: SLF001
-    store._client = MagicMock()  # noqa: SLF001
+    store._client = couchdb_client  # type: ignore[assignment]
     return store
 
 
 @pytest.mark.asyncio
-async def test_create_harvest_idempotent_first_create(couchdb: CouchDB) -> None:
+async def test_create_harvest_idempotent_first_create(
+    couchdb: CouchDB, couchdb_client: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """First keyed create claims, creates harvest, and commits."""
-    couchdb._client.create_document_exclusive = AsyncMock()  # noqa: SLF001
-    couchdb._client.delete_document = AsyncMock()  # noqa: SLF001
-    couchdb._client.save_document = AsyncMock()  # noqa: SLF001
-    couchdb.create_harvest = AsyncMock(return_value="harvest-1")  # type: ignore[method-assign]
+    couchdb_client.create_document_exclusive = AsyncMock()
+    couchdb_client.delete_document = AsyncMock()
+    couchdb_client.save_document = AsyncMock()
+    create_harvest = AsyncMock(return_value="harvest-1")
+    monkeypatch.setattr(couchdb, "create_harvest", create_harvest)
 
     harvest_id, replayed = await couchdb.create_harvest_idempotent("rdi-1", "client-a", "key-1", expected_datasets=3)
 
     assert harvest_id == "harvest-1"
     assert replayed is False
-    couchdb._client.create_document_exclusive.assert_awaited_once()  # noqa: SLF001
-    couchdb.create_harvest.assert_awaited_once()
-    couchdb._client.save_document.assert_awaited_once()  # noqa: SLF001
+    couchdb_client.create_document_exclusive.assert_awaited_once()
+    create_harvest.assert_awaited_once()
+    couchdb_client.save_document.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_create_harvest_idempotent_replay(couchdb: CouchDB) -> None:
+async def test_create_harvest_idempotent_replay(couchdb: CouchDB, couchdb_client: MagicMock) -> None:
     """Existing committed claim with compatible body is replayed."""
     doc_id = CouchDB._idempotency_doc_id("client-a", "key-1")  # noqa: SLF001
     index = HarvestIdempotencyDocument(
@@ -55,12 +64,8 @@ async def test_create_harvest_idempotent_replay(couchdb: CouchDB) -> None:
         harvest_id="harvest-existing",
         created_at=datetime.now(UTC),
     )
-    couchdb._client.create_document_exclusive = AsyncMock(  # noqa: SLF001
-        side_effect=DocumentConflictError("exists")
-    )
-    couchdb._client.get_document = AsyncMock(  # noqa: SLF001
-        return_value=index.model_dump(mode="json", by_alias=True)
-    )
+    couchdb_client.create_document_exclusive = AsyncMock(side_effect=DocumentConflictError("exists"))
+    couchdb_client.get_document = AsyncMock(return_value=index.model_dump(mode="json", by_alias=True))
 
     harvest_id, replayed = await couchdb.create_harvest_idempotent("rdi-1", "client-a", "key-1")
 
@@ -69,7 +74,7 @@ async def test_create_harvest_idempotent_replay(couchdb: CouchDB) -> None:
 
 
 @pytest.mark.asyncio
-async def test_create_harvest_idempotent_body_conflict(couchdb: CouchDB) -> None:
+async def test_create_harvest_idempotent_body_conflict(couchdb: CouchDB, couchdb_client: MagicMock) -> None:
     """Existing committed claim with different rdi raises conflict."""
     doc_id = CouchDB._idempotency_doc_id("client-a", "key-1")  # noqa: SLF001
     index = HarvestIdempotencyDocument(
@@ -82,19 +87,17 @@ async def test_create_harvest_idempotent_body_conflict(couchdb: CouchDB) -> None
         harvest_id="harvest-existing",
         created_at=datetime.now(UTC),
     )
-    couchdb._client.create_document_exclusive = AsyncMock(  # noqa: SLF001
-        side_effect=DocumentConflictError("exists")
-    )
-    couchdb._client.get_document = AsyncMock(  # noqa: SLF001
-        return_value=index.model_dump(mode="json", by_alias=True)
-    )
+    couchdb_client.create_document_exclusive = AsyncMock(side_effect=DocumentConflictError("exists"))
+    couchdb_client.get_document = AsyncMock(return_value=index.model_dump(mode="json", by_alias=True))
 
     with pytest.raises(IdempotencyBodyConflictError):
         await couchdb.create_harvest_idempotent("rdi-1", "client-a", "key-1")
 
 
 @pytest.mark.asyncio
-async def test_create_harvest_idempotent_pending_timeout(couchdb: CouchDB, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_create_harvest_idempotent_pending_timeout(
+    couchdb: CouchDB, couchdb_client: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Stuck pending claim eventually raises IdempotencyPendingError."""
     monkeypatch.setattr("middleware.api.document_store.couchdb._PENDING_POLL_ATTEMPTS", 2)
     monkeypatch.setattr("middleware.api.document_store.couchdb._PENDING_POLL_DELAY_S", 0)
@@ -109,25 +112,23 @@ async def test_create_harvest_idempotent_pending_timeout(couchdb: CouchDB, monke
         harvest_id=None,
         created_at=datetime.now(UTC),
     )
-    couchdb._client.create_document_exclusive = AsyncMock(  # noqa: SLF001
-        side_effect=DocumentConflictError("exists")
-    )
-    couchdb._client.get_document = AsyncMock(  # noqa: SLF001
-        return_value=index.model_dump(mode="json", by_alias=True)
-    )
+    couchdb_client.create_document_exclusive = AsyncMock(side_effect=DocumentConflictError("exists"))
+    couchdb_client.get_document = AsyncMock(return_value=index.model_dump(mode="json", by_alias=True))
 
     with pytest.raises(IdempotencyPendingError):
         await couchdb.create_harvest_idempotent("rdi-1", "client-a", "key-1")
 
 
 @pytest.mark.asyncio
-async def test_create_harvest_idempotent_deletes_claim_on_create_failure(couchdb: CouchDB) -> None:
+async def test_create_harvest_idempotent_deletes_claim_on_create_failure(
+    couchdb: CouchDB, couchdb_client: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Failed harvest create rolls back the pending claim."""
-    couchdb._client.create_document_exclusive = AsyncMock()  # noqa: SLF001
-    couchdb._client.delete_document = AsyncMock(return_value=True)  # noqa: SLF001
-    couchdb.create_harvest = AsyncMock(side_effect=RuntimeError("boom"))  # type: ignore[method-assign]
+    couchdb_client.create_document_exclusive = AsyncMock()
+    couchdb_client.delete_document = AsyncMock(return_value=True)
+    monkeypatch.setattr(couchdb, "create_harvest", AsyncMock(side_effect=RuntimeError("boom")))
 
     with pytest.raises(RuntimeError, match="boom"):
         await couchdb.create_harvest_idempotent("rdi-1", "client-a", "key-1")
 
-    couchdb._client.delete_document.assert_awaited_once()  # noqa: SLF001
+    couchdb_client.delete_document.assert_awaited_once()

--- a/middleware/api/tests/unit/test_harvest_idempotency.py
+++ b/middleware/api/tests/unit/test_harvest_idempotency.py
@@ -156,6 +156,19 @@ async def test_create_harvest_idempotent_deletes_claim_on_create_failure(
 
 
 @pytest.mark.asyncio
+async def test_create_harvest_idempotent_preserves_create_error_if_rollback_fails(
+    couchdb: CouchDB, couchdb_client: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rollback delete failures must not mask the original create error."""
+    couchdb_client.create_document_exclusive = AsyncMock()
+    couchdb_client.delete_document = AsyncMock(side_effect=RuntimeError("delete failed"))
+    monkeypatch.setattr(couchdb, "create_harvest", AsyncMock(side_effect=RuntimeError("boom")))
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await couchdb.create_harvest_idempotent("rdi-1", "client-a", "key-1")
+
+
+@pytest.mark.asyncio
 async def test_create_harvest_idempotent_rolls_back_on_commit_failure(
     couchdb: CouchDB, couchdb_client: MagicMock, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/middleware/api/tests/unit/test_harvest_manager.py
+++ b/middleware/api/tests/unit/test_harvest_manager.py
@@ -6,7 +6,12 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from middleware.api.business_logic.config import HarvestConfig
-from middleware.api.business_logic.exceptions import AccessDeniedError, ConflictError, ResourceNotFoundError
+from middleware.api.business_logic.exceptions import (
+    AccessDeniedError,
+    ConflictError,
+    InvalidRequestError,
+    ResourceNotFoundError,
+)
 from middleware.api.business_logic.harvest_manager import CreateHarvestResult, HarvestManager
 from middleware.api.document_store.harvest_document import HarvestDocument, HarvestStatistics
 from middleware.shared.api_models.common.models import HarvestStatus
@@ -97,8 +102,6 @@ async def test_create_harvest_keyed_replay(manager: HarvestManager, doc_store: M
 @pytest.mark.asyncio
 async def test_create_harvest_empty_key_rejected(manager: HarvestManager) -> None:
     """Empty Idempotency-Key raises InvalidRequestError."""
-    from middleware.api.business_logic.exceptions import InvalidRequestError
-
     with pytest.raises(InvalidRequestError, match="must not be empty"):
         await manager.create_harvest("rdi-1", "client-a", idempotency_key="")
 
@@ -106,8 +109,6 @@ async def test_create_harvest_empty_key_rejected(manager: HarvestManager) -> Non
 @pytest.mark.asyncio
 async def test_create_harvest_keyed_requires_client(manager: HarvestManager) -> None:
     """Keyed create without client_id raises InvalidRequestError."""
-    from middleware.api.business_logic.exceptions import InvalidRequestError
-
     with pytest.raises(InvalidRequestError, match="authenticated client"):
         await manager.create_harvest("rdi-1", None, idempotency_key="key-1")
 

--- a/middleware/api/tests/unit/test_harvest_manager.py
+++ b/middleware/api/tests/unit/test_harvest_manager.py
@@ -107,6 +107,13 @@ async def test_create_harvest_empty_key_rejected(manager: HarvestManager) -> Non
 
 
 @pytest.mark.asyncio
+async def test_create_harvest_whitespace_key_rejected(manager: HarvestManager) -> None:
+    """Whitespace-only Idempotency-Key raises InvalidRequestError."""
+    with pytest.raises(InvalidRequestError, match="must not be empty"):
+        await manager.create_harvest("rdi-1", "client-a", idempotency_key="   ")
+
+
+@pytest.mark.asyncio
 async def test_create_harvest_keyed_requires_client(manager: HarvestManager) -> None:
     """Keyed create without client_id raises InvalidRequestError."""
     with pytest.raises(InvalidRequestError, match="authenticated client"):

--- a/middleware/api/tests/unit/test_harvest_manager.py
+++ b/middleware/api/tests/unit/test_harvest_manager.py
@@ -7,7 +7,7 @@ import pytest
 
 from middleware.api.business_logic.config import HarvestConfig
 from middleware.api.business_logic.exceptions import AccessDeniedError, ConflictError, ResourceNotFoundError
-from middleware.api.business_logic.harvest_manager import HarvestManager
+from middleware.api.business_logic.harvest_manager import CreateHarvestResult, HarvestManager
 from middleware.api.document_store.harvest_document import HarvestDocument, HarvestStatistics
 from middleware.shared.api_models.common.models import HarvestStatus
 
@@ -64,7 +64,7 @@ async def test_create_harvest(manager: HarvestManager, doc_store: MagicMock) -> 
     """create_harvest delegates to doc_store and returns the harvest_id."""
     doc_store.create_harvest = AsyncMock(return_value="harvest-99")
     result = await manager.create_harvest("rdi-1", "client-a")
-    assert result == "harvest-99"
+    assert result == CreateHarvestResult(harvest_id="harvest-99", replayed=False)
     doc_store.create_harvest.assert_called_once()
 
 
@@ -75,6 +75,41 @@ async def test_create_harvest_with_expected_datasets(manager: HarvestManager, do
     await manager.create_harvest("rdi-1", "client-a", expected_datasets=42)
     _, kwargs = doc_store.create_harvest.call_args
     assert kwargs.get("expected_datasets") == 42  # noqa: PLR2004
+
+
+@pytest.mark.asyncio
+async def test_create_harvest_keyed(manager: HarvestManager, doc_store: MagicMock) -> None:
+    """Keyed create delegates to create_harvest_idempotent."""
+    doc_store.create_harvest_idempotent = AsyncMock(return_value=("harvest-1", False))
+    result = await manager.create_harvest("rdi-1", "client-a", idempotency_key="key-1")
+    assert result == CreateHarvestResult(harvest_id="harvest-1", replayed=False)
+    doc_store.create_harvest_idempotent.assert_called_once_with("rdi-1", "client-a", "key-1", expected_datasets=None)
+
+
+@pytest.mark.asyncio
+async def test_create_harvest_keyed_replay(manager: HarvestManager, doc_store: MagicMock) -> None:
+    """Compatible keyed replay sets replayed=True."""
+    doc_store.create_harvest_idempotent = AsyncMock(return_value=("harvest-1", True))
+    result = await manager.create_harvest("rdi-1", "client-a", idempotency_key="key-1")
+    assert result.replayed is True
+
+
+@pytest.mark.asyncio
+async def test_create_harvest_empty_key_rejected(manager: HarvestManager) -> None:
+    """Empty Idempotency-Key raises InvalidRequestError."""
+    from middleware.api.business_logic.exceptions import InvalidRequestError
+
+    with pytest.raises(InvalidRequestError, match="must not be empty"):
+        await manager.create_harvest("rdi-1", "client-a", idempotency_key="")
+
+
+@pytest.mark.asyncio
+async def test_create_harvest_keyed_requires_client(manager: HarvestManager) -> None:
+    """Keyed create without client_id raises InvalidRequestError."""
+    from middleware.api.business_logic.exceptions import InvalidRequestError
+
+    with pytest.raises(InvalidRequestError, match="authenticated client"):
+        await manager.create_harvest("rdi-1", None, idempotency_key="key-1")
 
 
 # ---------------------------------------------------------------------------

--- a/middleware/api/tests/unit/test_v3_harvests.py
+++ b/middleware/api/tests/unit/test_v3_harvests.py
@@ -9,7 +9,8 @@ from fastapi.testclient import TestClient
 
 from middleware.api.api.fastapi_app import Api
 from middleware.api.business_logic import BusinessLogicError, DuplicateArcInHarvestError, InvalidJsonSemanticError
-from middleware.api.business_logic.exceptions import ConflictError
+from middleware.api.business_logic.exceptions import ConflictError, InvalidRequestError
+from middleware.api.business_logic.harvest_manager import CreateHarvestResult
 from middleware.api.document_store.harvest_document import HarvestDocument, HarvestStatistics
 from middleware.shared.api_models import ArcOperationResult, ArcResponse, ArcStatus
 from middleware.shared.api_models.common.models import HarvestStatus
@@ -29,7 +30,7 @@ def test_create_harvest_success(client: TestClient, cert: str, middleware_api: A
         patch.object(middleware_api.app.state.common_deps, "get_authorized_rdis", new_callable=AsyncMock) as mock_auth,
         patch.object(middleware_api.business_logic.harvest_manager, "get_harvest", new_callable=AsyncMock) as mock_get,
     ):
-        mock_create.return_value = harvest_id
+        mock_create.return_value = CreateHarvestResult(harvest_id=harvest_id, replayed=False)
         mock_auth.return_value = ["rdi-1"]
         mock_get.return_value = HarvestDocument(
             doc_id="harvest-123",
@@ -55,6 +56,104 @@ def test_create_harvest_success(client: TestClient, cert: str, middleware_api: A
         body = r.json()
         assert body["harvest_id"] == harvest_id
         assert body["status"] == "RUNNING"
+        mock_create.assert_awaited_once()
+        assert mock_create.await_args is not None
+        assert mock_create.await_args.kwargs.get("idempotency_key") is None
+
+
+@pytest.mark.unit
+def test_create_harvest_with_idempotency_key_replay(client: TestClient, cert: str, middleware_api: Api) -> None:
+    """Replay path sets Idempotent-Replayed response header."""
+    harvest_id = "harvest-123"
+
+    with (
+        patch.object(
+            middleware_api.business_logic.harvest_manager, "create_harvest", new_callable=AsyncMock
+        ) as mock_create,
+        patch.object(middleware_api.app.state.common_deps, "get_authorized_rdis", new_callable=AsyncMock) as mock_auth,
+        patch.object(middleware_api.business_logic.harvest_manager, "get_harvest", new_callable=AsyncMock) as mock_get,
+    ):
+        mock_create.return_value = CreateHarvestResult(harvest_id=harvest_id, replayed=True)
+        mock_auth.return_value = ["rdi-1"]
+        mock_get.return_value = HarvestDocument(
+            doc_id=harvest_id,
+            rdi="rdi-1",
+            client_id="test-client-cn",
+            status=HarvestStatus.RUNNING,
+            started_at=datetime.now(UTC),
+            statistics=HarvestStatistics(),
+        )
+
+        r = client.post(
+            "/v3/harvests",
+            headers={
+                "ssl-client-cert": cert,
+                "ssl-client-verify": "SUCCESS",
+                "content-type": "application/json",
+                "accept": "application/json",
+                "Idempotency-Key": "same-key",
+            },
+            json={"rdi": "rdi-1"},
+        )
+
+        assert r.status_code == http.HTTPStatus.OK
+        assert r.headers.get("Idempotent-Replayed") == "true"
+        assert mock_create.await_args is not None
+        assert mock_create.await_args.kwargs.get("idempotency_key") == "same-key"
+
+
+@pytest.mark.unit
+def test_create_harvest_empty_idempotency_key(client: TestClient, cert: str, middleware_api: Api) -> None:
+    """Empty Idempotency-Key returns 400."""
+    with (
+        patch.object(
+            middleware_api.business_logic.harvest_manager, "create_harvest", new_callable=AsyncMock
+        ) as mock_create,
+        patch.object(middleware_api.app.state.common_deps, "get_authorized_rdis", new_callable=AsyncMock) as mock_auth,
+    ):
+        mock_auth.return_value = ["rdi-1"]
+        mock_create.side_effect = InvalidRequestError("Idempotency-Key must not be empty")
+
+        r = client.post(
+            "/v3/harvests",
+            headers={
+                "ssl-client-cert": cert,
+                "ssl-client-verify": "SUCCESS",
+                "content-type": "application/json",
+                "accept": "application/json",
+                "Idempotency-Key": "",
+            },
+            json={"rdi": "rdi-1"},
+        )
+
+        assert r.status_code == http.HTTPStatus.BAD_REQUEST
+
+
+@pytest.mark.unit
+def test_create_harvest_idempotency_body_conflict(client: TestClient, cert: str, middleware_api: Api) -> None:
+    """Incompatible keyed reuse returns 409."""
+    with (
+        patch.object(
+            middleware_api.business_logic.harvest_manager, "create_harvest", new_callable=AsyncMock
+        ) as mock_create,
+        patch.object(middleware_api.app.state.common_deps, "get_authorized_rdis", new_callable=AsyncMock) as mock_auth,
+    ):
+        mock_auth.return_value = ["rdi-1"]
+        mock_create.side_effect = ConflictError("Idempotency-Key was reused with an incompatible create body")
+
+        r = client.post(
+            "/v3/harvests",
+            headers={
+                "ssl-client-cert": cert,
+                "ssl-client-verify": "SUCCESS",
+                "content-type": "application/json",
+                "accept": "application/json",
+                "Idempotency-Key": "same-key",
+            },
+            json={"rdi": "rdi-1"},
+        )
+
+        assert r.status_code == http.HTTPStatus.CONFLICT
 
 
 @pytest.mark.unit
@@ -186,7 +285,7 @@ def test_create_harvest_internal_error(client: TestClient, cert: str, middleware
         patch.object(middleware_api.app.state.common_deps, "get_authorized_rdis", new_callable=AsyncMock) as mock_auth,
         patch.object(middleware_api.business_logic.harvest_manager, "get_harvest", new_callable=AsyncMock) as mock_get,
     ):
-        mock_create.return_value = "harvest-xyz"
+        mock_create.return_value = CreateHarvestResult(harvest_id="harvest-xyz", replayed=False)
         mock_auth.return_value = ["rdi-1"]
         mock_get.return_value = None  # Simulate DB failure after creation
 
@@ -667,7 +766,7 @@ def test_create_harvest_with_completed_at(client: TestClient, cert: str, middlew
         patch.object(middleware_api.app.state.common_deps, "get_authorized_rdis", new_callable=AsyncMock) as mock_auth,
         patch.object(middleware_api.business_logic.harvest_manager, "get_harvest", new_callable=AsyncMock) as mock_get,
     ):
-        mock_create.return_value = harvest_id
+        mock_create.return_value = CreateHarvestResult(harvest_id=harvest_id, replayed=False)
         mock_auth.return_value = ["rdi-1"]
         mock_get.return_value = completed_doc
 

--- a/middleware/api_client/src/middleware/api_client/api_client.py
+++ b/middleware/api_client/src/middleware/api_client/api_client.py
@@ -6,7 +6,7 @@ import logging
 import ssl
 import threading
 import uuid
-from collections.abc import AsyncGenerator, AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterator, Mapping
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from http import HTTPStatus
@@ -71,6 +71,16 @@ class ApiClient:
     _global_state_lock = threading.Lock()
 
     @classmethod
+    def _has_idempotency_key(cls, headers: Mapping[str, str] | None) -> bool:
+        """Return True when headers contain a non-empty Idempotency-Key."""
+        if not headers:
+            return False
+        for key, value in headers.items():
+            if key.lower() == "idempotency-key":
+                return bool(str(value).strip())
+        return False
+
+    @classmethod
     def _is_idempotent_arc_post_path(cls, path: str) -> bool:
         """Return whether *path* is a server-idempotent ARC POST endpoint.
 
@@ -86,23 +96,29 @@ class ApiClient:
         )
 
     @classmethod
-    def _is_idempotent_post_path(cls, path: str) -> bool:
+    def _is_idempotent_post_path(cls, path: str, headers: Mapping[str, str] | None = None) -> bool:
         """Return whether a POST path is safe to retry with an identical request.
 
-        Covers idempotent ARC POSTs and keyed ``POST /v3/harvests`` (create).
-        Harvest completion remains non-retryable.
+        Covers idempotent ARC POSTs and ``POST /v3/harvests`` only when a
+        non-empty ``Idempotency-Key`` header is present. Harvest completion
+        remains non-retryable.
         """
         normalized = path.lstrip("/")
         if normalized == "v3/harvests":
-            return True
+            return cls._has_idempotency_key(headers)
         return cls._is_idempotent_arc_post_path(path)
 
     @classmethod
-    def _is_retryable_method(cls, method: str, path: str) -> bool:
+    def _is_retryable_method(
+        cls,
+        method: str,
+        path: str,
+        headers: Mapping[str, str] | None = None,
+    ) -> bool:
         """Return whether failures for this method/path may be retried."""
         if method in cls._IDEMPOTENT_METHODS:
             return True
-        return method == "POST" and cls._is_idempotent_post_path(path)
+        return method == "POST" and cls._is_idempotent_post_path(path, headers)
 
     @classmethod
     def _configure_global_request_limiter(cls, max_concurrency: int) -> None:
@@ -144,15 +160,27 @@ class ApiClient:
             limiter.release()
 
     @classmethod
-    def _should_retry_http_status(cls, method: str, path: str, status_code: int) -> bool:
+    def _should_retry_http_status(
+        cls,
+        method: str,
+        path: str,
+        status_code: int,
+        headers: Mapping[str, str] | None = None,
+    ) -> bool:
         """Return whether a response status is retryable for a method/path."""
         transient = {httpx.codes.BAD_GATEWAY, httpx.codes.SERVICE_UNAVAILABLE, httpx.codes.GATEWAY_TIMEOUT}
-        return cls._is_retryable_method(method, path) and status_code in transient
+        return cls._is_retryable_method(method, path, headers) and status_code in transient
 
     @classmethod
-    def _should_retry_request_error(cls, method: str, path: str, error: httpx.RequestError) -> bool:
+    def _should_retry_request_error(
+        cls,
+        method: str,
+        path: str,
+        error: httpx.RequestError,
+        headers: Mapping[str, str] | None = None,
+    ) -> bool:
         """Return whether a request error is retryable for a method/path."""
-        if not cls._is_retryable_method(method, path):
+        if not cls._is_retryable_method(method, path, headers):
             return False
         return not isinstance(error, httpx.TimeoutException)
 
@@ -164,12 +192,13 @@ class ApiClient:
         *,
         status_code: int | None = None,
         request_error: httpx.RequestError | None = None,
+        headers: Mapping[str, str] | None = None,
     ) -> bool:
         """Return whether an HTTP failure is retryable for a request method/path."""
         if status_code is not None:
-            return cls._should_retry_http_status(method, path, status_code)
+            return cls._should_retry_http_status(method, path, status_code, headers)
         if request_error is not None:
-            return cls._should_retry_request_error(method, path, request_error)
+            return cls._should_retry_request_error(method, path, request_error, headers)
         return False
 
     @classmethod
@@ -214,22 +243,11 @@ class ApiClient:
         cls,
         failure: httpx.HTTPStatusError | httpx.RequestError,
         *,
-        method: str,
-        path: str,
+        should_retry: bool,
         attempt: int,
         max_retries: int,
     ) -> bool:
         """Return True to retry; otherwise raise a normalized ApiClientError."""
-        status_code = failure.response.status_code if isinstance(failure, httpx.HTTPStatusError) else None
-        request_error = failure if isinstance(failure, httpx.RequestError) else None
-
-        should_retry = cls._should_retry_failure(
-            method,
-            path,
-            status_code=status_code,
-            request_error=request_error,
-        )
-
         if should_retry and attempt < max_retries:
             if isinstance(failure, httpx.HTTPStatusError):
                 logger.warning("Transient HTTP error %d from server, will retry", failure.response.status_code)
@@ -486,6 +504,8 @@ class ApiClient:
         client = self._get_client()
         path = path.lstrip("/")
         method = method.upper()
+        raw_headers = kwargs.get("headers")
+        headers = cast(Mapping[str, str], raw_headers) if isinstance(raw_headers, Mapping) else None
 
         for attempt in range(self._config.max_retries + 1):
             if attempt > 0:
@@ -501,7 +521,7 @@ class ApiClient:
                     resp = await client.request(method, path, **kwargs)
 
                 # Retry on transient server-side errors before raising
-                should_retry = self._should_retry_failure(method, path, status_code=resp.status_code)
+                should_retry = self._should_retry_failure(method, path, status_code=resp.status_code, headers=headers)
                 if should_retry and attempt < self._config.max_retries:
                     logger.warning("Transient HTTP error %d from server, will retry", resp.status_code)
                     continue
@@ -512,10 +532,18 @@ class ApiClient:
                 return self._parse_json_response(resp, method, path)
 
             except (httpx.HTTPStatusError, httpx.RequestError) as e:
+                status_code = e.response.status_code if isinstance(e, httpx.HTTPStatusError) else None
+                request_error = e if isinstance(e, httpx.RequestError) else None
+                should_retry = self._should_retry_failure(
+                    method,
+                    path,
+                    status_code=status_code,
+                    request_error=request_error,
+                    headers=headers,
+                )
                 if self._should_retry_or_raise_failure(
                     e,
-                    method=method,
-                    path=path,
+                    should_retry=should_retry,
                     attempt=attempt,
                     max_retries=self._config.max_retries,
                 ):

--- a/middleware/api_client/src/middleware/api_client/api_client.py
+++ b/middleware/api_client/src/middleware/api_client/api_client.py
@@ -673,8 +673,11 @@ class ApiClient:
     ) -> HarvestResult:
         """Start a new harvest run.
 
-        Uses ``POST /v3/harvests`` with a generated ``Idempotency-Key`` so the
-        request is safe to retry after transport failures.
+        Uses ``POST /v3/harvests``. ``Idempotency-Key`` is optional: when client
+        mTLS certificates are configured the client may send a key so the
+        request is safe to retry after transport failures. Without certificates
+        the create stays unkeyed and MUST NOT be retried (server requires
+        ``client_id`` for keyed creates).
 
         Args:
             rdi: RDI identifier.
@@ -684,15 +687,14 @@ class ApiClient:
             :class:`HarvestResult` with the newly created harvest.
         """
         request = CreateHarvestRequest(rdi=rdi, expected_datasets=expected_datasets)
-        idempotency_key = str(uuid.uuid4())
+        headers: dict[str, str] = {"content-type": "application/json"}
+        if self._config.client_cert_path is not None and self._config.client_key_path is not None:
+            headers["Idempotency-Key"] = str(uuid.uuid4())
         data = await self._request_with_retries(
             "POST",
             "v3/harvests",
             content=request.model_dump_json(by_alias=True),
-            headers={
-                "content-type": "application/json",
-                "Idempotency-Key": idempotency_key,
-            },
+            headers=headers,
         )
         return self._parse_harvest_response(data)
 

--- a/middleware/api_client/src/middleware/api_client/api_client.py
+++ b/middleware/api_client/src/middleware/api_client/api_client.py
@@ -5,6 +5,7 @@ import json
 import logging
 import ssl
 import threading
+import uuid
 from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
@@ -74,7 +75,6 @@ class ApiClient:
         """Return whether *path* is a server-idempotent ARC POST endpoint.
 
         Covers ``POST /v3/arcs`` and ``POST /v3/harvests/{harvest_id}/arcs``.
-        Other POSTs (create/complete harvest) are not safe to retry.
         """
         normalized = path.lstrip("/")
         if normalized == "v3/arcs":
@@ -86,11 +86,23 @@ class ApiClient:
         )
 
     @classmethod
+    def _is_idempotent_post_path(cls, path: str) -> bool:
+        """Return whether a POST path is safe to retry with an identical request.
+
+        Covers idempotent ARC POSTs and keyed ``POST /v3/harvests`` (create).
+        Harvest completion remains non-retryable.
+        """
+        normalized = path.lstrip("/")
+        if normalized == "v3/harvests":
+            return True
+        return cls._is_idempotent_arc_post_path(path)
+
+    @classmethod
     def _is_retryable_method(cls, method: str, path: str) -> bool:
         """Return whether failures for this method/path may be retried."""
         if method in cls._IDEMPOTENT_METHODS:
             return True
-        return method == "POST" and cls._is_idempotent_arc_post_path(path)
+        return method == "POST" and cls._is_idempotent_post_path(path)
 
     @classmethod
     def _configure_global_request_limiter(cls, max_concurrency: int) -> None:
@@ -633,7 +645,8 @@ class ApiClient:
     ) -> HarvestResult:
         """Start a new harvest run.
 
-        Uses ``POST /v3/harvests``.
+        Uses ``POST /v3/harvests`` with a generated ``Idempotency-Key`` so the
+        request is safe to retry after transport failures.
 
         Args:
             rdi: RDI identifier.
@@ -643,7 +656,16 @@ class ApiClient:
             :class:`HarvestResult` with the newly created harvest.
         """
         request = CreateHarvestRequest(rdi=rdi, expected_datasets=expected_datasets)
-        data = await self._post("v3/harvests", request)
+        idempotency_key = str(uuid.uuid4())
+        data = await self._request_with_retries(
+            "POST",
+            "v3/harvests",
+            content=request.model_dump_json(by_alias=True),
+            headers={
+                "content-type": "application/json",
+                "Idempotency-Key": idempotency_key,
+            },
+        )
         return self._parse_harvest_response(data)
 
     async def list_harvests(

--- a/middleware/api_client/tests/unit/test_client.py
+++ b/middleware/api_client/tests/unit/test_client.py
@@ -252,14 +252,55 @@ async def test_create_or_update_arc_retries_on_connect_error(client_config: Conf
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_create_harvest_network_error_not_retried(client_config: Config) -> None:
-    """Non-ARC POSTs (create harvest) must not retry ConnectError."""
+async def test_create_harvest_sends_idempotency_key(client_config: Config) -> None:
+    """create_harvest always sends a non-empty Idempotency-Key header."""
+    route = respx.post(f"{client_config.api_url}v3/harvests").mock(
+        return_value=httpx.Response(http.HTTPStatus.OK, json=HARVEST_RESPONSE)
+    )
+    async with ApiClient(client_config) as client:
+        await client.create_harvest(rdi="test-rdi")
+
+    assert route.called
+    key = route.calls.last.request.headers.get("idempotency-key")
+    assert key
+    assert len(key) > 0
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_create_harvest_retries_on_connect_error(client_config: Config) -> None:
+    """Keyed harvest create retries ConnectError then succeeds."""
     client_config.retry_backoff_factor = 0.01
+    client_config.max_retries = 2
+    seen_keys: list[str] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        seen_keys.append(request.headers["idempotency-key"])
+        if len(seen_keys) == 1:
+            raise httpx.ConnectError("Connection refused")
+        return httpx.Response(http.HTTPStatus.OK, json=HARVEST_RESPONSE)
+
+    route = respx.post(f"{client_config.api_url}v3/harvests").mock(side_effect=_handler)
+    async with ApiClient(client_config) as client:
+        result = await client.create_harvest(rdi="test-rdi")
+
+    assert result.harvest_id == HARVEST_RESPONSE["harvest_id"]
+    assert route.call_count == 2  # noqa: PLR2004
+    assert len(seen_keys) == 2  # noqa: PLR2004
+    assert seen_keys[0] == seen_keys[1]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_create_harvest_exhausted_retries(client_config: Config) -> None:
+    """Keyed harvest create raises after retries are exhausted."""
+    client_config.retry_backoff_factor = 0.01
+    client_config.max_retries = 1
     route = respx.post(f"{client_config.api_url}v3/harvests").mock(side_effect=httpx.ConnectError("Connection refused"))
     async with ApiClient(client_config) as client:
-        with pytest.raises(ApiClientError, match="Request failed: Connection refused"):
+        with pytest.raises(ApiClientError, match="Request failed after 1 retries"):
             await client.create_harvest(rdi="test-rdi")
-    assert route.call_count == 1
+    assert route.call_count == 2  # noqa: PLR2004
 
 
 @pytest.mark.asyncio
@@ -384,9 +425,10 @@ def test_format_request_error_falls_back_when_message_empty() -> None:
 @respx.mock
 async def test_empty_connect_error_message_is_not_blank(client_config: Config) -> None:
     """ApiClientError for empty ConnectError still carries a useful message."""
+    client_config.max_retries = 0
     respx.post(f"{client_config.api_url}v3/harvests").mock(side_effect=httpx.ConnectError(""))
     async with ApiClient(client_config) as client:
-        with pytest.raises(ApiClientError, match="Request failed: ConnectError") as exc_info:
+        with pytest.raises(ApiClientError, match="ConnectError") as exc_info:
             await client.create_harvest(rdi="test-rdi")
     assert str(exc_info.value).strip() != "Request failed:"
 
@@ -465,15 +507,20 @@ async def test_create_harvest_without_expected_datasets(client_config: Config) -
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_create_harvest_503_not_retried(client_config: Config) -> None:
-    """POST create_harvest is not retried on transient server errors."""
+async def test_create_harvest_retries_on_503(client_config: Config) -> None:
+    """Keyed harvest create retries transient 503 responses."""
+    client_config.retry_backoff_factor = 0.01
+    client_config.max_retries = 2
     route = respx.post(f"{client_config.api_url}v3/harvests").mock(
-        return_value=httpx.Response(http.HTTPStatus.SERVICE_UNAVAILABLE, text="Busy")
+        side_effect=[
+            httpx.Response(http.HTTPStatus.SERVICE_UNAVAILABLE, text="Busy"),
+            httpx.Response(http.HTTPStatus.OK, json=HARVEST_RESPONSE),
+        ]
     )
     async with ApiClient(client_config) as client:
-        with pytest.raises(ApiClientError, match="HTTP error 503"):
-            await client.create_harvest(rdi="test-rdi")
-    assert route.call_count == 1
+        result = await client.create_harvest(rdi="test-rdi")
+    assert result.harvest_id == HARVEST_RESPONSE["harvest_id"]
+    assert route.call_count == 2  # noqa: PLR2004
 
 
 @pytest.mark.asyncio

--- a/middleware/api_client/tests/unit/test_client.py
+++ b/middleware/api_client/tests/unit/test_client.py
@@ -292,6 +292,21 @@ async def test_create_harvest_retries_on_connect_error(client_config: Config) ->
 
 @pytest.mark.asyncio
 @respx.mock
+async def test_unkeyed_harvest_create_post_not_retried(client_config: Config) -> None:
+    """POST /v3/harvests without Idempotency-Key must not be retried."""
+    from middleware.shared.api_models.v3.models import CreateHarvestRequest
+
+    client_config.retry_backoff_factor = 0.01
+    client_config.max_retries = 2
+    route = respx.post(f"{client_config.api_url}v3/harvests").mock(side_effect=httpx.ConnectError("Connection refused"))
+    async with ApiClient(client_config) as client:
+        with pytest.raises(ApiClientError, match="Request failed: Connection refused"):
+            await client._post("v3/harvests", CreateHarvestRequest(rdi="test-rdi"))  # noqa: SLF001
+    assert route.call_count == 1
+
+
+@pytest.mark.asyncio
+@respx.mock
 async def test_create_harvest_exhausted_retries(client_config: Config) -> None:
     """Keyed harvest create raises after retries are exhausted."""
     client_config.retry_backoff_factor = 0.01

--- a/middleware/api_client/tests/unit/test_client.py
+++ b/middleware/api_client/tests/unit/test_client.py
@@ -253,7 +253,7 @@ async def test_create_or_update_arc_retries_on_connect_error(client_config: Conf
 @pytest.mark.asyncio
 @respx.mock
 async def test_create_harvest_sends_idempotency_key(client_config: Config) -> None:
-    """create_harvest always sends a non-empty Idempotency-Key header."""
+    """create_harvest may send Idempotency-Key when mTLS certs are configured."""
     route = respx.post(f"{client_config.api_url}v3/harvests").mock(
         return_value=httpx.Response(http.HTTPStatus.OK, json=HARVEST_RESPONSE)
     )
@@ -264,6 +264,38 @@ async def test_create_harvest_sends_idempotency_key(client_config: Config) -> No
     key = route.calls.last.request.headers.get("idempotency-key")
     assert key
     assert len(key) > 0
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_create_harvest_omits_idempotency_key_without_mtls() -> None:
+    """Without client certificates, create_harvest omits Idempotency-Key."""
+    config = Config(api_url="https://test-api.example.com/", verify_ssl=False)
+    route = respx.post(f"{config.api_url}v3/harvests").mock(
+        return_value=httpx.Response(http.HTTPStatus.OK, json=HARVEST_RESPONSE)
+    )
+    async with ApiClient(config) as client:
+        await client.create_harvest(rdi="test-rdi")
+
+    assert route.called
+    assert route.calls.last.request.headers.get("idempotency-key") is None
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_create_harvest_without_mtls_not_retried() -> None:
+    """Unkeyed create against cert-optional deployments is not retried."""
+    config = Config(
+        api_url="https://test-api.example.com/",
+        verify_ssl=False,
+        max_retries=2,
+        retry_backoff_factor=0.01,
+    )
+    route = respx.post(f"{config.api_url}v3/harvests").mock(side_effect=httpx.ConnectError("Connection refused"))
+    async with ApiClient(config) as client:
+        with pytest.raises(ApiClientError, match="Request failed: Connection refused"):
+            await client.create_harvest(rdi="test-rdi")
+    assert route.call_count == 1
 
 
 @pytest.mark.asyncio

--- a/middleware/api_client/tests/unit/test_client.py
+++ b/middleware/api_client/tests/unit/test_client.py
@@ -22,6 +22,7 @@ from middleware.api_client import (
     Config,
     HarvestResult,
 )
+from middleware.shared.api_models.v3.models import CreateHarvestRequest
 
 # ---------------------------------------------------------------------------
 # Initialization
@@ -326,8 +327,6 @@ async def test_create_harvest_retries_on_connect_error(client_config: Config) ->
 @respx.mock
 async def test_unkeyed_harvest_create_post_not_retried(client_config: Config) -> None:
     """POST /v3/harvests without Idempotency-Key must not be retried."""
-    from middleware.shared.api_models.v3.models import CreateHarvestRequest
-
     client_config.retry_backoff_factor = 0.01
     client_config.max_retries = 2
     route = respx.post(f"{client_config.api_url}v3/harvests").mock(side_effect=httpx.ConnectError("Connection refused"))

--- a/openspec/changes/harvest-create-idempotency-key/.openspec.yaml
+++ b/openspec/changes/harvest-create-idempotency-key/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-12

--- a/openspec/changes/harvest-create-idempotency-key/design.md
+++ b/openspec/changes/harvest-create-idempotency-key/design.md
@@ -28,56 +28,59 @@ shared in-memory lock.
 
 ## Decisions
 
-1. **Use the `Idempotency-Key` HTTP header (not a body field)**  
+1. **Use the `Idempotency-Key` HTTP header (not a body field)**
    Reason: industry-standard, keeps `CreateHarvestRequest` unchanged, easy for
-   proxies to log.  
+   proxies to log.
    Alternative considered: optional JSON field — rejected to avoid schema churn
    and mixed locations.
 
-2. **Scope keys by authenticated `client_id`**  
-   Reason: prevents cross-tenant key collisions; matches harvest ownership.  
-   Require `client_id` when a key is present (`400` otherwise).  
+2. **Scope keys by authenticated `client_id`**
+   Reason: prevents cross-tenant key collisions; matches harvest ownership.
+   Require `client_id` when a key is present (`400` otherwise).
    Alternative: global key namespace — rejected (weak keys could collide across
    clients).
 
-3. **Body compatibility = `rdi` + `expected_datasets` equality**  
+3. **Body compatibility = `rdi` + `expected_datasets` equality**
    Reason: those are the only create inputs that define the harvest; mismatched
-   reuse is a client bug → `409`.  
+   reuse is a client bug → `409`.
    Alternative: ignore `expected_datasets` on replay — rejected (progress
    denominator would silently diverge).
 
-4. **Persist via a dedicated CouchDB index document**  
+4. **Persist via a dedicated CouchDB index document**
    Document id pattern: `harvest-idempotency:{client_id}:{key}` (or a stable
-   hash of the key if length/charset is unsafe for `_id`).  
+   hash of the key if length/charset is unsafe for `_id`).
    Document body stores `harvest_id`, `rdi`, `expected_datasets`, and optional
-   timestamps.  
+   timestamps.
    First writer creates the harvest, then puts the index doc; on `_id` conflict,
-   load the winner’s harvest and apply replay/409 rules.  
+   load the winner’s harvest and apply replay/409 rules.
    Reason: CouchDB document-create conflict gives cluster-safe uniqueness
-   without a unique Mango index.  
+   without a unique Mango index.
    Alternative: field on `HarvestDocument` + query — race-prone under concurrent
-   creates.  
+   creates.
    Alternative: use the key as the harvest `_id` — **BREAKING** / couples public
    harvest ids to client keys.
 
-5. **Keep harvest `_id` as `harvest-{uuid}`**  
+5. **Keep harvest `_id` as `harvest-{uuid}`**
    Reason: preserves existing ID format and clients that already store harvest
    ids.
 
-6. **Response status stays `200` for create and replay**  
+6. **Response status stays `200` for create and replay**
    Reason: current create already returns 200; switching first create to 201
-   would be a soft break for strict clients.  
+   would be a soft break for strict clients.
    Optional additive header `Idempotent-Replayed: true` on replay only.
 
-7. **ApiClient always sends a UUID4 key from `create_harvest` / `harvest_arcs`**  
-   Reason: production harvesters get retry safety without config. Raw HTTP
-   callers may omit the header and keep legacy behaviour.  
+7. **ApiClient may send a UUID4 key only when mTLS cert+key are configured**
+   Reason: the wire header stays optional (backward compatible). Keyed create
+   needs authenticated `client_id`; without certificates the API returns `400`
+   for `Idempotency-Key`, so the client omits the header and MUST NOT retry
+   create. With mTLS the library sends a key so create becomes retry-safe.
    Retry classification: treat keyed `POST /v3/harvests` like idempotent ARC
-   POSTs for ConnectError and 502/503/504; still never retry completion.
+   POSTs for ConnectError and 502/503/504; still never retry completion or
+   unkeyed create.
 
-8. **Key retention**  
+8. **Key retention**
    Keep the index document for the lifetime of the harvest document (no short
-   TTL in v1).  
+   TTL in v1).
    Reason: retries can occur minutes later; orphan cleanup of terminal harvests
    can delete the index later as a follow-up.
 

--- a/openspec/changes/harvest-create-idempotency-key/design.md
+++ b/openspec/changes/harvest-create-idempotency-key/design.md
@@ -47,7 +47,8 @@ shared in-memory lock.
    denominator would silently diverge).
 
 4. **Persist via a dedicated CouchDB index document (claim-then-finalize)**
-   Document id pattern: `harvest-idempotency:{sha256(client_id + ":" + key)}`.
+   Document id pattern: `harvest-idempotency:{sha256(client_id + NUL + key)}`
+   (NUL `\0` separator in `_idempotency_doc_id`; raw key stored in body).
    Document body stores `client_id`, raw `idempotency_key`, `rdi`,
    `expected_datasets`, `status` (`pending` | `committed`), optional
    `harvest_id`, and timestamps.

--- a/openspec/changes/harvest-create-idempotency-key/design.md
+++ b/openspec/changes/harvest-create-idempotency-key/design.md
@@ -46,15 +46,20 @@ shared in-memory lock.
    Alternative: ignore `expected_datasets` on replay — rejected (progress
    denominator would silently diverge).
 
-4. **Persist via a dedicated CouchDB index document**
-   Document id pattern: `harvest-idempotency:{client_id}:{key}` (or a stable
-   hash of the key if length/charset is unsafe for `_id`).
-   Document body stores `harvest_id`, `rdi`, `expected_datasets`, and optional
-   timestamps.
-   First writer creates the harvest, then puts the index doc; on `_id` conflict,
-   load the winner’s harvest and apply replay/409 rules.
+4. **Persist via a dedicated CouchDB index document (claim-then-finalize)**
+   Document id pattern: `harvest-idempotency:{sha256(client_id + ":" + key)}`.
+   Document body stores `client_id`, raw `idempotency_key`, `rdi`,
+   `expected_datasets`, `status` (`pending` | `committed`), optional
+   `harvest_id`, and timestamps.
+   Flow: create index doc exclusively as `pending` → create harvest → commit
+   index with `harvest_id`. On `_id` conflict, load the winner and apply
+   replay / body-conflict / pending-poll rules. Best-effort rollback deletes
+   the claim (and harvest, if commit fails) so the same key can retry.
    Reason: CouchDB document-create conflict gives cluster-safe uniqueness
-   without a unique Mango index.
+   without a unique Mango index; claiming first avoids orphan harvests when
+   the index write fails.
+   Alternative: harvest first then index — rejected (orphan harvest on index
+   put failure; see Risks).
    Alternative: field on `HarvestDocument` + query — race-prone under concurrent
    creates.
    Alternative: use the key as the harvest `_id` — **BREAKING** / couples public
@@ -86,21 +91,21 @@ shared in-memory lock.
 
 ## Risks / Trade-offs
 
-- **[Risk] Partial failure: harvest saved, index doc not yet written** →
-  Mitigation: on index put failure, delete/compensate or retry index put; on
-  next keyed create, if no index exists, a second harvest could appear — prefer
-  “create index doc first in `pending` state then attach harvest_id” or
-  transactional ordering documented in tasks with tests for the chosen order.
+- **[Risk] Partial failure after pending claim** → Mitigation: on harvest
+  create failure, best-effort delete the pending claim (log/swallow delete
+  errors; re-raise original). On commit failure, best-effort delete harvest
+  and claim so the key can be retried. Concurrent waiters poll pending; stuck
+  pending eventually surfaces as a transient error.
 - **[Risk] Very long / weird keys as `_id`** → Mitigation: hash the key for
   `_id`, store raw key in the document body for debugging.
 - **[Risk] Clients that manually POST without keys still fail hard on
-  ConnectError** → Accepted; only library users gain retries.
+  ConnectError** → Accepted; only keyed library creates (mTLS) gain retries.
 - **[Trade-off] Index docs add storage** → Small vs harvest docs; acceptable.
 
 ## Migration Plan
 
 1. Deploy API with optional header support (backward compatible).
-2. Release api_client that sends keys and retries keyed create.
+2. Release api_client that sends keys under mTLS and retries keyed create.
 3. Roll harvesters to the new client when convenient — no coordinated cutover
    required.
 4. Rollback: disable client key sending or ignore header server-side; existing
@@ -108,5 +113,5 @@ shared in-memory lock.
 
 ## Open Questions
 
-None deferred — key hashing for `_id`, conflict semantics, and client always-on
-keys are decided above.
+None deferred — key hashing for `_id`, claim-then-finalize ordering, conflict
+semantics, and mTLS-gated client keys are decided above.

--- a/openspec/changes/harvest-create-idempotency-key/design.md
+++ b/openspec/changes/harvest-create-idempotency-key/design.md
@@ -1,0 +1,109 @@
+# Harvest Create Idempotency-Key — Design
+
+## Context
+
+See proposal.md for motivation
+([#305](https://github.com/fairagro/m4.2_advanced_middleware_api/issues/305)).
+
+Today `POST /v3/harvests` always allocates `harvest-{uuid}` in
+`DocumentStore.create_harvest`. The API client treats only ARC POSTs as
+retryable because create/complete are not server-idempotent. CouchDB remains the
+persistence layer; uniqueness must work across concurrent API replicas without a
+shared in-memory lock.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Additive wire contract: optional `Idempotency-Key` on create.
+- Safe client retries for keyed create after ConnectError / 502–504.
+- Single harvest document per `(client_id, key)` under concurrency.
+
+**Non-Goals:**
+
+- Mandatory keys or a new API version.
+- Idempotency for complete / PATCH status transitions.
+- Relying on `list_harvests` / #242 heuristics to recover a lost create
+  response.
+
+## Decisions
+
+1. **Use the `Idempotency-Key` HTTP header (not a body field)**  
+   Reason: industry-standard, keeps `CreateHarvestRequest` unchanged, easy for
+   proxies to log.  
+   Alternative considered: optional JSON field — rejected to avoid schema churn
+   and mixed locations.
+
+2. **Scope keys by authenticated `client_id`**  
+   Reason: prevents cross-tenant key collisions; matches harvest ownership.  
+   Require `client_id` when a key is present (`400` otherwise).  
+   Alternative: global key namespace — rejected (weak keys could collide across
+   clients).
+
+3. **Body compatibility = `rdi` + `expected_datasets` equality**  
+   Reason: those are the only create inputs that define the harvest; mismatched
+   reuse is a client bug → `409`.  
+   Alternative: ignore `expected_datasets` on replay — rejected (progress
+   denominator would silently diverge).
+
+4. **Persist via a dedicated CouchDB index document**  
+   Document id pattern: `harvest-idempotency:{client_id}:{key}` (or a stable
+   hash of the key if length/charset is unsafe for `_id`).  
+   Document body stores `harvest_id`, `rdi`, `expected_datasets`, and optional
+   timestamps.  
+   First writer creates the harvest, then puts the index doc; on `_id` conflict,
+   load the winner’s harvest and apply replay/409 rules.  
+   Reason: CouchDB document-create conflict gives cluster-safe uniqueness
+   without a unique Mango index.  
+   Alternative: field on `HarvestDocument` + query — race-prone under concurrent
+   creates.  
+   Alternative: use the key as the harvest `_id` — **BREAKING** / couples public
+   harvest ids to client keys.
+
+5. **Keep harvest `_id` as `harvest-{uuid}`**  
+   Reason: preserves existing ID format and clients that already store harvest
+   ids.
+
+6. **Response status stays `200` for create and replay**  
+   Reason: current create already returns 200; switching first create to 201
+   would be a soft break for strict clients.  
+   Optional additive header `Idempotent-Replayed: true` on replay only.
+
+7. **ApiClient always sends a UUID4 key from `create_harvest` / `harvest_arcs`**  
+   Reason: production harvesters get retry safety without config. Raw HTTP
+   callers may omit the header and keep legacy behaviour.  
+   Retry classification: treat keyed `POST /v3/harvests` like idempotent ARC
+   POSTs for ConnectError and 502/503/504; still never retry completion.
+
+8. **Key retention**  
+   Keep the index document for the lifetime of the harvest document (no short
+   TTL in v1).  
+   Reason: retries can occur minutes later; orphan cleanup of terminal harvests
+   can delete the index later as a follow-up.
+
+## Risks / Trade-offs
+
+- **[Risk] Partial failure: harvest saved, index doc not yet written** →
+  Mitigation: on index put failure, delete/compensate or retry index put; on
+  next keyed create, if no index exists, a second harvest could appear — prefer
+  “create index doc first in `pending` state then attach harvest_id” or
+  transactional ordering documented in tasks with tests for the chosen order.
+- **[Risk] Very long / weird keys as `_id`** → Mitigation: hash the key for
+  `_id`, store raw key in the document body for debugging.
+- **[Risk] Clients that manually POST without keys still fail hard on
+  ConnectError** → Accepted; only library users gain retries.
+- **[Trade-off] Index docs add storage** → Small vs harvest docs; acceptable.
+
+## Migration Plan
+
+1. Deploy API with optional header support (backward compatible).
+2. Release api_client that sends keys and retries keyed create.
+3. Roll harvesters to the new client when convenient — no coordinated cutover
+   required.
+4. Rollback: disable client key sending or ignore header server-side; existing
+   harvests remain valid.
+
+## Open Questions
+
+None deferred — key hashing for `_id`, conflict semantics, and client always-on
+keys are decided above.

--- a/openspec/changes/harvest-create-idempotency-key/proposal.md
+++ b/openspec/changes/harvest-create-idempotency-key/proposal.md
@@ -1,0 +1,49 @@
+# Harvest Create Idempotency-Key — Proposal
+
+## Why
+
+`POST /v3/harvests` is not safely retryable today: the harvest ID is
+server-generated, and after a transport failure (e.g. `httpx.ConnectError`
+before any HTTP response) the client cannot tell whether a harvest was created.
+Blind retries risk orphan `RUNNING` harvests; omitting retries leaves transient
+network blips as hard repository failures (see
+[#305](https://github.com/fairagro/m4.2_advanced_middleware_api/issues/305)).
+
+## What Changes
+
+- Accept an **optional** `Idempotency-Key` request header on `POST /v3/harvests`.
+- When present, scope the key to at least `client_id` and reuse the existing
+  harvest on compatible replay; conflicting body → `409`.
+- When absent, preserve current create-always semantics (no **BREAKING** change).
+- Persist the key so concurrent duplicate creates converge on one harvest
+  document.
+- Optionally emit an additive `Idempotent-Replayed` response header on replay.
+- Update the API client to send a key on create and retry create on connection /
+  selected transient failures while reusing that key.
+- Update OpenSpec requirements in `harvest-manager` and `harvest-client` (and
+  HTTP create contract if owned by a dedicated harvest upload/lifecycle domain).
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none — behaviour extends existing harvest create / client domains -->
+
+### Modified Capabilities
+
+- `harvest-manager`: Optional create-time idempotency key storage, lookup,
+  conflict, and atomic uniqueness.
+- `harvest-client`: Send `Idempotency-Key` on create; retry create when a key is
+  present; keep completion non-retryable unless separately specified.
+
+## Impact
+
+- API: `middleware/api/.../api/v3/harvests.py`, `HarvestManager`,
+  `DocumentStore` / `HarvestDocument`, CouchDB indexes.
+- Client: `middleware/api_client/.../api_client.py` retry classification and
+  `create_harvest`.
+- Specs: `openspec/specs/harvest-manager/`, `openspec/specs/harvest-client/`.
+- Tests: API unit/system create-harvest coverage; client retry tests (replace
+  “create must not retry” with key-aware behaviour).
+- Non-goals: mandatory keys; idempotency for complete / status PATCH; using
+  `list_harvests` (#242) as a substitute.

--- a/openspec/changes/harvest-create-idempotency-key/proposal.md
+++ b/openspec/changes/harvest-create-idempotency-key/proposal.md
@@ -33,8 +33,10 @@ network blips as hard repository failures (see
 
 - `harvest-manager`: Optional create-time idempotency key storage, lookup,
   conflict, and atomic uniqueness.
-- `harvest-client`: Send `Idempotency-Key` on create; retry create when a key is
-  present; keep completion non-retryable unless separately specified.
+- `harvest-client`: Optional `Idempotency-Key` on create (send only when mTLS
+  cert+key are configured); retry create only when a key was sent; without
+  certificates omit key and refuse create retries; keep completion non-retryable
+  unless separately specified.
 
 ## Impact
 

--- a/openspec/changes/harvest-create-idempotency-key/specs/harvest-client/spec.md
+++ b/openspec/changes/harvest-create-idempotency-key/specs/harvest-client/spec.md
@@ -1,0 +1,62 @@
+# Harvest Client — Delta
+
+## ADDED Requirements
+
+### Requirement: Send Idempotency-Key on harvest create
+
+When creating a harvest, the client MUST send a non-empty `Idempotency-Key`
+request header. The key MUST be generated once per logical create attempt and
+MUST be reused for every transport retry of that same attempt. A later distinct
+`create_harvest` call MUST use a different key.
+
+#### Scenario: First create attempt includes a key
+
+- **GIVEN** the caller starts a new harvest through the client
+- **WHEN** the client issues `POST /v3/harvests`
+- **THEN** the request includes a non-empty `Idempotency-Key` header
+
+#### Scenario: Retries reuse the same key
+
+- **GIVEN** a create attempt whose first transport attempt failed before a
+  definitive response
+- **WHEN** the client retries that create
+- **THEN** it reuses the same `Idempotency-Key` as the failed attempt
+
+## MODIFIED Requirements
+
+### Requirement: Retry only idempotent ARC transport failures
+
+The client MUST retry connection failures and transient `502`, `503`, or `504`
+responses for `POST /v3/arcs` and `POST /v3/harvests/{harvest_id}/arcs`.
+The client MUST also retry connection failures and those same transient status
+codes for `POST /v3/harvests` when it sent an `Idempotency-Key` on that create,
+reusing the key. It MUST NOT retry harvest completion POSTs or harvest create
+requests that omit an `Idempotency-Key`, and MUST treat `409` conflicting ARC
+content as a conflict rather than success. A `409` from keyed harvest create
+(incompatible body reuse) MUST NOT be retried.
+
+#### Scenario: Retry a transient harvest-scoped ARC submission failure
+
+- **GIVEN** a harvest-scoped ARC POST receives a transient gateway failure
+- **WHEN** the client retries it with the identical request body
+- **THEN** the retry is safe because the endpoint is idempotent
+
+#### Scenario: Retry keyed harvest create after ConnectError
+
+- **GIVEN** `POST /v3/harvests` was sent with an `Idempotency-Key` and fails
+  with a connection error before an HTTP response
+- **WHEN** retries remain
+- **THEN** the client retries the same create with the same key and body
+
+#### Scenario: Do not retry harvest completion
+
+- **GIVEN** a harvest completion request fails with a connection error
+- **WHEN** the client handles the failure
+- **THEN** it does not retry the completion POST
+
+#### Scenario: Receive conflicting ARC content for an existing identifier
+
+- **GIVEN** the server responds `409` for differing content with the same
+  harvest-local ARC identifier
+- **WHEN** the client handles the response
+- **THEN** it does not treat the response as a successful retry

--- a/openspec/changes/harvest-create-idempotency-key/specs/harvest-client/spec.md
+++ b/openspec/changes/harvest-create-idempotency-key/specs/harvest-client/spec.md
@@ -2,23 +2,26 @@
 
 ## ADDED Requirements
 
-### Requirement: Send Idempotency-Key on harvest create
+### Requirement: Optional Idempotency-Key on harvest create
 
-When creating a harvest, the client MUST send a non-empty `Idempotency-Key`
-request header. The key MUST be generated once per logical create attempt and
-MUST be reused for every transport retry of that same attempt. A later distinct
-`create_harvest` call MUST use a different key.
+`Idempotency-Key` on `POST /v3/harvests` remains optional for backward
+compatibility. The client MAY send a non-empty key when client certificate and
+key paths are configured (authenticated `client_id` available). When it sends a
+key, that key MUST be generated once per logical create attempt and MUST be
+reused for every transport retry of that same attempt. A later distinct
+`create_harvest` call MUST use a different key if it sends one. When client
+certificates are not configured, the client MUST omit `Idempotency-Key`.
 
-#### Scenario: First create attempt includes a key
+#### Scenario: Omit key when certificates are not configured
 
-- **GIVEN** the caller starts a new harvest through the client
-- **WHEN** the client issues `POST /v3/harvests`
-- **THEN** the request includes a non-empty `Idempotency-Key` header
+- **GIVEN** the client has no client certificate and key configured
+- **WHEN** the client creates a harvest
+- **THEN** the request omits `Idempotency-Key`
 
-#### Scenario: Retries reuse the same key
+#### Scenario: Keyed create under mTLS reuses the key on retry
 
-- **GIVEN** a create attempt whose first transport attempt failed before a
-  definitive response
+- **GIVEN** a create attempt that included an `Idempotency-Key` under mTLS and
+  whose first transport attempt failed before a definitive response
 - **WHEN** the client retries that create
 - **THEN** it reuses the same `Idempotency-Key` as the failed attempt
 
@@ -31,9 +34,9 @@ responses for `POST /v3/arcs` and `POST /v3/harvests/{harvest_id}/arcs`.
 The client MUST also retry connection failures and those same transient status
 codes for `POST /v3/harvests` when it sent an `Idempotency-Key` on that create,
 reusing the key. It MUST NOT retry harvest completion POSTs or harvest create
-requests that omit an `Idempotency-Key`, and MUST treat `409` conflicting ARC
-content as a conflict rather than success. A `409` from keyed harvest create
-(incompatible body reuse) MUST NOT be retried.
+requests that omit an `Idempotency-Key` (including creates without mTLS), and
+MUST treat `409` conflicting ARC content as a conflict rather than success. A
+`409` from keyed harvest create (incompatible body reuse) MUST NOT be retried.
 
 #### Scenario: Retry a transient harvest-scoped ARC submission failure
 
@@ -47,6 +50,19 @@ content as a conflict rather than success. A `409` from keyed harvest create
   with a connection error before an HTTP response
 - **WHEN** retries remain
 - **THEN** the client retries the same create with the same key and body
+
+#### Scenario: Do not retry unkeyed harvest create
+
+- **GIVEN** `POST /v3/harvests` was sent without an `Idempotency-Key` and fails
+  with a connection error
+- **WHEN** the client handles the failure
+- **THEN** it does not retry the create POST
+
+#### Scenario: Do not retry harvest create without mTLS
+
+- **GIVEN** the client has no client certificates configured
+- **WHEN** `POST /v3/harvests` fails with a connection error
+- **THEN** the client does not retry the create POST
 
 #### Scenario: Do not retry harvest completion
 

--- a/openspec/changes/harvest-create-idempotency-key/specs/harvest-manager/spec.md
+++ b/openspec/changes/harvest-create-idempotency-key/specs/harvest-manager/spec.md
@@ -1,0 +1,79 @@
+# Harvest Manager — Delta
+
+## ADDED Requirements
+
+### Requirement: Optional create Idempotency-Key
+
+`POST /v3/harvests` SHALL accept an optional `Idempotency-Key` request header.
+When the header is absent, the system MUST create a new harvest run exactly as
+today. When the header is present, it MUST be a non-empty string and the
+request MUST carry an authenticated `client_id`; otherwise the system MUST
+reject the request with `400 Bad Request`.
+
+#### Scenario: Create without Idempotency-Key
+
+- **GIVEN** a valid create body and no `Idempotency-Key` header
+- **WHEN** `POST /v3/harvests` is processed
+- **THEN** a new harvest document is created and returned
+
+#### Scenario: Reject empty Idempotency-Key
+
+- **GIVEN** a create request with an empty `Idempotency-Key` header
+- **WHEN** `POST /v3/harvests` is processed
+- **THEN** the response is `400 Bad Request` and no harvest is created
+
+#### Scenario: Reject keyed create without client identity
+
+- **GIVEN** a create request with a non-empty `Idempotency-Key` and no
+  authenticated `client_id`
+- **WHEN** `POST /v3/harvests` is processed
+- **THEN** the response is `400 Bad Request` and no harvest is created
+
+### Requirement: Replay compatible keyed creates
+
+When `Idempotency-Key` is present and a harvest already exists for the same
+`client_id` and key, and the request body is compatible with that harvest
+(`rdi` equal and `expected_datasets` equal, including both unset), the system
+SHALL return that existing harvest as `200` with the same response body shape
+as a first-time create. It MUST NOT create a second harvest document. The
+system MAY include the response header `Idempotent-Replayed: true` on such
+replays.
+
+#### Scenario: Replay after a lost create response
+
+- **GIVEN** a harvest was created for client `C` with key `K` and body `B`
+- **WHEN** the same client repeats `POST /v3/harvests` with header
+  `Idempotency-Key: K` and body `B`
+- **THEN** the response is `200` with the original harvest's identity and
+  fields
+- **AND** no additional harvest document exists for that key
+
+### Requirement: Conflict on incompatible keyed reuse
+
+When `Idempotency-Key` is present and a harvest already exists for the same
+`client_id` and key, but the request body is incompatible (`rdi` or
+`expected_datasets` differs), the system MUST respond with `409 Conflict` and
+MUST NOT modify the existing harvest.
+
+#### Scenario: Reuse key with a different RDI
+
+- **GIVEN** a harvest exists for client `C` with key `K` and `rdi=a`
+- **WHEN** the same client posts create with `Idempotency-Key: K` and `rdi=b`
+- **THEN** the response is `409 Conflict`
+- **AND** the existing harvest remains unchanged
+
+### Requirement: Atomic uniqueness for keyed creates
+
+Concurrent `POST /v3/harvests` requests that share the same `client_id` and
+`Idempotency-Key` MUST converge on a single harvest document. Exactly one
+create MUST persist; other concurrent attempts MUST observe that harvest as a
+compatible replay or receive a transient failure that is safe to retry with
+the same key.
+
+#### Scenario: Two concurrent keyed creates
+
+- **GIVEN** two overlapping create requests from the same client with the same
+  non-empty `Idempotency-Key` and compatible bodies
+- **WHEN** both are processed
+- **THEN** exactly one harvest document is stored for that client and key
+- **AND** both successful responses refer to that same harvest identity

--- a/openspec/changes/harvest-create-idempotency-key/tasks.md
+++ b/openspec/changes/harvest-create-idempotency-key/tasks.md
@@ -2,42 +2,42 @@
 
 ## 1. Persistence model
 
-- [ ] 1.1 Add a CouchDB idempotency index document model (stores raw key,
+- [x] 1.1 Add a CouchDB idempotency index document model (stores raw key,
   `client_id`, `harvest_id`, `rdi`, `expected_datasets`, status) with `_id`
   derived from a stable hash of `(client_id, key)`
-- [ ] 1.2 Implement DocumentStore helpers: put/get index doc, create harvest
+- [x] 1.2 Implement DocumentStore helpers: put/get index doc, create harvest
   unchanged for unkeyed path, keyed create using claim-then-finalize ordering
   (create index as `pending`, create harvest, patch index with `harvest_id` /
   `committed`)
-- [ ] 1.3 On index `_id` conflict, load winner and return existing harvest or
+- [x] 1.3 On index `_id` conflict, load winner and return existing harvest or
   signal body conflict; never leave a second harvest linked to the same key
 
 ## 2. API / HarvestManager
 
-- [ ] 2.1 Extend `create_harvest` to accept optional `Idempotency-Key`; reject
+- [x] 2.1 Extend `create_harvest` to accept optional `Idempotency-Key`; reject
   empty key or keyed create without `client_id` with `400`
-- [ ] 2.2 Wire `POST /v3/harvests` to read the header, invoke keyed/unkeyed
+- [x] 2.2 Wire `POST /v3/harvests` to read the header, invoke keyed/unkeyed
   paths, return `200` `HarvestResponse`, set `Idempotent-Replayed: true` on
   compatible replay, map incompatible reuse to `409`
-- [ ] 2.3 Map persistence conflict / ownership errors to existing HTTP error
+- [x] 2.3 Map persistence conflict / ownership errors to existing HTTP error
   conventions without changing unkeyed behaviour
 
 ## 3. API client
 
-- [ ] 3.1 Generate a UUID4 `Idempotency-Key` inside `create_harvest` and send it
+- [x] 3.1 Generate a UUID4 `Idempotency-Key` inside `create_harvest` and send it
   on `POST /v3/harvests`
-- [ ] 3.2 Treat keyed `POST /v3/harvests` as retryable for ConnectError and
+- [x] 3.2 Treat keyed `POST /v3/harvests` as retryable for ConnectError and
   `502`/`503`/`504`, reusing the same key across retries; keep completion
   non-retryable; do not retry create `409`
-- [ ] 3.3 Update/replace `test_create_harvest_network_error_not_retried` and add
+- [x] 3.3 Update/replace `test_create_harvest_network_error_not_retried` and add
   tests for key header presence, key reuse on retry, and successful retry after
   ConnectError
 
 ## 4. Tests and quality
 
-- [ ] 4.1 Add API unit/system tests: no header (legacy create), replay same
+- [x] 4.1 Add API unit/system tests: no header (legacy create), replay same
   key+body, `409` on body mismatch, `400` empty key / missing client, concurrent
   same-key creates → one harvest
-- [ ] 4.2 Run focused `uv run pytest` for api + api_client harvest/create/retry
+- [x] 4.2 Run focused `uv run pytest` for api + api_client harvest/create/retry
   suites; run `uv run ruff format/check --config pyproject.toml middleware/` on
   touched code

--- a/openspec/changes/harvest-create-idempotency-key/tasks.md
+++ b/openspec/changes/harvest-create-idempotency-key/tasks.md
@@ -24,8 +24,9 @@
 
 ## 3. API client
 
-- [x] 3.1 Generate a UUID4 `Idempotency-Key` inside `create_harvest` and send it
-  on `POST /v3/harvests`
+- [x] 3.1 Generate a UUID4 `Idempotency-Key` inside `create_harvest` only when
+  client cert+key are configured; omit the header otherwise (legacy
+  non-retryable). When present, send it on `POST /v3/harvests`
 - [x] 3.2 Treat keyed `POST /v3/harvests` as retryable for ConnectError and
   `502`/`503`/`504`, reusing the same key across retries; keep completion
   non-retryable; do not retry create `409`

--- a/openspec/changes/harvest-create-idempotency-key/tasks.md
+++ b/openspec/changes/harvest-create-idempotency-key/tasks.md
@@ -1,0 +1,43 @@
+# Harvest Create Idempotency-Key — Tasks
+
+## 1. Persistence model
+
+- [ ] 1.1 Add a CouchDB idempotency index document model (stores raw key,
+  `client_id`, `harvest_id`, `rdi`, `expected_datasets`, status) with `_id`
+  derived from a stable hash of `(client_id, key)`
+- [ ] 1.2 Implement DocumentStore helpers: put/get index doc, create harvest
+  unchanged for unkeyed path, keyed create using claim-then-finalize ordering
+  (create index as `pending`, create harvest, patch index with `harvest_id` /
+  `committed`)
+- [ ] 1.3 On index `_id` conflict, load winner and return existing harvest or
+  signal body conflict; never leave a second harvest linked to the same key
+
+## 2. API / HarvestManager
+
+- [ ] 2.1 Extend `create_harvest` to accept optional `Idempotency-Key`; reject
+  empty key or keyed create without `client_id` with `400`
+- [ ] 2.2 Wire `POST /v3/harvests` to read the header, invoke keyed/unkeyed
+  paths, return `200` `HarvestResponse`, set `Idempotent-Replayed: true` on
+  compatible replay, map incompatible reuse to `409`
+- [ ] 2.3 Map persistence conflict / ownership errors to existing HTTP error
+  conventions without changing unkeyed behaviour
+
+## 3. API client
+
+- [ ] 3.1 Generate a UUID4 `Idempotency-Key` inside `create_harvest` and send it
+  on `POST /v3/harvests`
+- [ ] 3.2 Treat keyed `POST /v3/harvests` as retryable for ConnectError and
+  `502`/`503`/`504`, reusing the same key across retries; keep completion
+  non-retryable; do not retry create `409`
+- [ ] 3.3 Update/replace `test_create_harvest_network_error_not_retried` and add
+  tests for key header presence, key reuse on retry, and successful retry after
+  ConnectError
+
+## 4. Tests and quality
+
+- [ ] 4.1 Add API unit/system tests: no header (legacy create), replay same
+  key+body, `409` on body mismatch, `400` empty key / missing client, concurrent
+  same-key creates → one harvest
+- [ ] 4.2 Run focused `uv run pytest` for api + api_client harvest/create/retry
+  suites; run `uv run ruff format/check --config pyproject.toml middleware/` on
+  touched code


### PR DESCRIPTION
fixes #305 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes harvest-create persistence and concurrency semantics in CouchDB; incorrect idempotency handling could duplicate or lose harvests, though unkeyed creates are unchanged and rollback paths are tested.
> 
> **Overview**
> Adds **optional idempotent harvest creation** so clients can safely retry `POST /v3/harvests` after transport failures without spawning duplicate runs.
> 
> **API:** `POST /v3/harvests` accepts an optional `Idempotency-Key` header (scoped to authenticated `client_id`). Compatible replays return the existing harvest with `Idempotent-Replayed: true`; mismatched `rdi` / `expected_datasets` → **409**; empty key or key without client → **400**; stuck concurrent claims → **503** via new `InvalidRequestError` / `TransientError` handlers.
> 
> **Persistence:** CouchDB uses a claim-then-finalize flow: exclusive idempotency index docs (`harvest-idempotency:{hash}`), `create_document_exclusive`, polling for pending claims, and rollback on partial failure. `HarvestManager.create_harvest` now returns `CreateHarvestResult` (`harvest_id`, `replayed`).
> 
> **Client:** With mTLS configured, `ApiClient.create_harvest` sends a UUID `Idempotency-Key` and retries keyed creates on connection errors and 502/503/504 (same key per attempt). Without certs, the header is omitted and create is not retried. Harvest completion stays non-retryable.
> 
> OpenSpec change docs and unit tests cover store, manager, API, and client behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 744339c288d936ffff4e85c72b47a0d8bcf1e257. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->