### PR TITLE
Enhance rollback handling in CouchDB during idempotency commit failures

### DIFF
--- a/middleware/api/src/middleware/api/document_store/couchdb.py
+++ b/middleware/api/src/middleware/api/document_store/couchdb.py
@@ -395,14 +395,23 @@ class CouchDB(DocumentStore):
             )
         except Exception:
             # Best-effort rollback so the same key can safely retry create.
+            harvest_rollback_ok = False
             try:
                 await self._client.delete_document(harvest_id)
+                harvest_rollback_ok = True
             except Exception:
                 logger.exception("Failed to roll back harvest %s after idempotency commit failure", harvest_id)
-            try:
-                await self._client.delete_document(doc_id)
-            except Exception:
-                logger.exception("Failed to roll back idempotency claim %s after commit failure", doc_id)
+            if harvest_rollback_ok:
+                try:
+                    await self._client.delete_document(doc_id)
+                except Exception:
+                    logger.exception("Failed to roll back idempotency claim %s after commit failure", doc_id)
+            else:
+                logger.warning(
+                    "Leaving idempotency claim %s pending; harvest %s rollback failed",
+                    doc_id,
+                    harvest_id,
+                )
             raise
         return harvest_id, False
 

--- a/middleware/api/tests/unit/test_harvest_idempotency.py
+++ b/middleware/api/tests/unit/test_harvest_idempotency.py
@@ -192,6 +192,28 @@ async def test_create_harvest_idempotent_preserves_create_error_if_rollback_fail
 
 
 @pytest.mark.asyncio
+async def test_create_harvest_idempotent_keeps_claim_when_harvest_rollback_fails_on_commit(
+    couchdb: CouchDB, couchdb_client: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Failed harvest rollback on commit failure must not release the claim."""
+
+    async def _delete_side_effect(doc_to_delete: str) -> bool:
+        if doc_to_delete == "harvest-1":
+            raise RuntimeError("harvest delete failed")
+        return True
+
+    couchdb_client.create_document_exclusive = AsyncMock()
+    couchdb_client.delete_document = AsyncMock(side_effect=_delete_side_effect)
+    couchdb_client.save_document = AsyncMock(side_effect=RuntimeError("commit failed"))
+    monkeypatch.setattr(couchdb, "create_harvest", AsyncMock(return_value="harvest-1"))
+
+    with pytest.raises(RuntimeError, match="commit failed"):
+        await couchdb.create_harvest_idempotent("rdi-1", "client-a", "key-1")
+
+    couchdb_client.delete_document.assert_awaited_once_with("harvest-1")
+
+
+@pytest.mark.asyncio
 async def test_create_harvest_idempotent_rolls_back_on_commit_failure(
     couchdb: CouchDB, couchdb_client: MagicMock, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/middleware/api_client/src/middleware/api_client/api_client.py
+++ b/middleware/api_client/src/middleware/api_client/api_client.py
@@ -454,7 +454,11 @@ class ApiClient:
     # ------------------------------------------------------------------
 
     def _uses_client_certificates(self) -> bool:
-        """Return True when httpx will load and present client certificates."""
+        """Return True when this client loads a client certificate chain.
+
+        ``verify_ssl`` is server-certificate verification; this client only
+        loads the cert chain in that mode (see ``_get_client``).
+        """
         return (
             self._config.verify_ssl
             and self._config.client_cert_path is not None
@@ -681,11 +685,11 @@ class ApiClient:
     ) -> HarvestResult:
         """Start a new harvest run.
 
-        Uses ``POST /v3/harvests``. ``Idempotency-Key`` is optional: when client
-        certificates are configured and ``verify_ssl`` is enabled (so mTLS is
-        actually presented), the client may send a key so the request is safe to
-        retry after transport failures. Otherwise the create stays unkeyed and
-        MUST NOT be retried (server requires ``client_id`` for keyed creates).
+        Uses ``POST /v3/harvests``. ``Idempotency-Key`` is optional: when this
+        client loads a client certificate chain, it may send a key so the
+        request is safe to retry after transport failures. Otherwise the create
+        stays unkeyed and MUST NOT be retried (server requires ``client_id`` for
+        keyed creates).
 
         Args:
             rdi: RDI identifier.

--- a/middleware/api_client/src/middleware/api_client/api_client.py
+++ b/middleware/api_client/src/middleware/api_client/api_client.py
@@ -453,6 +453,14 @@ class ApiClient:
     # HTTP infrastructure
     # ------------------------------------------------------------------
 
+    def _uses_client_certificates(self) -> bool:
+        """Return True when httpx will load and present client certificates."""
+        return (
+            self._config.verify_ssl
+            and self._config.client_cert_path is not None
+            and self._config.client_key_path is not None
+        )
+
     def _get_client(self) -> httpx.AsyncClient:
         """Return the shared httpx.AsyncClient, creating it on first call."""
         if self._client is None:
@@ -674,10 +682,10 @@ class ApiClient:
         """Start a new harvest run.
 
         Uses ``POST /v3/harvests``. ``Idempotency-Key`` is optional: when client
-        mTLS certificates are configured the client may send a key so the
-        request is safe to retry after transport failures. Without certificates
-        the create stays unkeyed and MUST NOT be retried (server requires
-        ``client_id`` for keyed creates).
+        certificates are configured and ``verify_ssl`` is enabled (so mTLS is
+        actually presented), the client may send a key so the request is safe to
+        retry after transport failures. Otherwise the create stays unkeyed and
+        MUST NOT be retried (server requires ``client_id`` for keyed creates).
 
         Args:
             rdi: RDI identifier.
@@ -688,7 +696,7 @@ class ApiClient:
         """
         request = CreateHarvestRequest(rdi=rdi, expected_datasets=expected_datasets)
         headers: dict[str, str] = {"content-type": "application/json"}
-        if self._config.client_cert_path is not None and self._config.client_key_path is not None:
+        if self._uses_client_certificates():
             headers["Idempotency-Key"] = str(uuid.uuid4())
         data = await self._request_with_retries(
             "POST",

--- a/middleware/api_client/src/middleware/api_client/api_client.py
+++ b/middleware/api_client/src/middleware/api_client/api_client.py
@@ -685,11 +685,12 @@ class ApiClient:
     ) -> HarvestResult:
         """Start a new harvest run.
 
-        Uses ``POST /v3/harvests``. ``Idempotency-Key`` is optional: when this
-        client loads a client certificate chain, it may send a key so the
-        request is safe to retry after transport failures. Otherwise the create
-        stays unkeyed and MUST NOT be retried (server requires ``client_id`` for
-        keyed creates).
+        Uses ``POST /v3/harvests``. ``Idempotency-Key`` is optional: this client
+        may send a key when it loads a client certificate chain (cert+key paths
+        set and ``verify_ssl`` true). ``verify_ssl`` itself only verifies the
+        server; this client also skips ``load_cert_chain`` when it is false (see
+        ``_get_client``), so a key is omitted then. Unkeyed create MUST NOT be
+        retried (server requires ``client_id`` for keyed creates).
 
         Args:
             rdi: RDI identifier.

--- a/middleware/api_client/tests/unit/test_client.py
+++ b/middleware/api_client/tests/unit/test_client.py
@@ -301,6 +301,24 @@ async def test_create_harvest_without_mtls_not_retried() -> None:
 
 @pytest.mark.asyncio
 @respx.mock
+async def test_create_harvest_omits_key_when_verify_ssl_false_despite_cert_paths(
+    test_config_dict: dict,
+) -> None:
+    """Cert paths alone do not send Idempotency-Key when verify_ssl is false."""
+    test_config_dict["verify_ssl"] = "false"
+    config = Config.from_data(test_config_dict)
+    route = respx.post(f"{config.api_url}v3/harvests").mock(
+        return_value=httpx.Response(http.HTTPStatus.OK, json=HARVEST_RESPONSE)
+    )
+    async with ApiClient(config) as client:
+        await client.create_harvest(rdi="test-rdi")
+
+    assert route.called
+    assert route.calls.last.request.headers.get("idempotency-key") is None
+
+
+@pytest.mark.asyncio
+@respx.mock
 async def test_create_harvest_retries_on_connect_error(client_config: Config) -> None:
     """Keyed harvest create retries ConnectError then succeeds."""
     client_config.retry_backoff_factor = 0.01

--- a/middleware/api_client/tests/unit/test_client.py
+++ b/middleware/api_client/tests/unit/test_client.py
@@ -304,7 +304,7 @@ async def test_create_harvest_without_mtls_not_retried() -> None:
 async def test_create_harvest_omits_key_when_verify_ssl_false_despite_cert_paths(
     test_config_dict: dict,
 ) -> None:
-    """Cert paths alone do not send Idempotency-Key when verify_ssl is false."""
+    """Cert paths do not send Idempotency-Key when ApiClient skips cert loading."""
     test_config_dict["verify_ssl"] = "false"
     config = Config.from_data(test_config_dict)
     route = respx.post(f"{config.api_url}v3/harvests").mock(

--- a/openspec/changes/harvest-create-idempotency-key/design.md
+++ b/openspec/changes/harvest-create-idempotency-key/design.md
@@ -75,11 +75,12 @@ shared in-memory lock.
    would be a soft break for strict clients.
    Optional additive header `Idempotent-Replayed: true` on replay only.
 
-7. **ApiClient may send a UUID4 key only when mTLS cert+key are configured**
-   Reason: the wire header stays optional (backward compatible). Keyed create
-   needs authenticated `client_id`; without certificates the API returns `400`
-   for `Idempotency-Key`, so the client omits the header and MUST NOT retry
-   create. With mTLS the library sends a key so create becomes retry-safe.
+7. **ApiClient may send a UUID4 key only when mTLS is actually used**
+   Condition: `verify_ssl` enabled and client cert+key paths configured (same as
+   `_get_client` cert loading). Reason: the wire header stays optional; keyed
+   create needs authenticated `client_id`. With `verify_ssl: false` httpx does
+   not present client certs, so sending a key would yield `400`. With mTLS the
+   library sends a key so create becomes retry-safe.
    Retry classification: treat keyed `POST /v3/harvests` like idempotent ARC
    POSTs for ConnectError and 502/503/504; still never retry completion or
    unkeyed create.

--- a/openspec/changes/harvest-create-idempotency-key/design.md
+++ b/openspec/changes/harvest-create-idempotency-key/design.md
@@ -75,12 +75,13 @@ shared in-memory lock.
    would be a soft break for strict clients.
    Optional additive header `Idempotent-Replayed: true` on replay only.
 
-7. **ApiClient may send a UUID4 key only when mTLS is actually used**
-   Condition: `verify_ssl` enabled and client cert+key paths configured (same as
-   `_get_client` cert loading). Reason: the wire header stays optional; keyed
-   create needs authenticated `client_id`. With `verify_ssl: false` httpx does
-   not present client certs, so sending a key would yield `400`. With mTLS the
-   library sends a key so create becomes retry-safe.
+7. **ApiClient may send a UUID4 key only when it presents client certificates**
+   Condition: `verify_ssl` enabled and client cert+key paths configured, matching
+   `_get_client` which only loads the client cert chain when `verify_ssl` is
+   true (`verify_ssl` is server-certificate verification, not mTLS). Reason:
+   keyed create needs authenticated `client_id`; without a presented cert the
+   API returns `400` for `Idempotency-Key`. When a cert is presented the library
+   sends a key so create becomes retry-safe.
    Retry classification: treat keyed `POST /v3/harvests` like idempotent ARC
    POSTs for ConnectError and 502/503/504; still never retry completion or
    unkeyed create.

--- a/openspec/changes/harvest-create-idempotency-key/specs/harvest-client/spec.md
+++ b/openspec/changes/harvest-create-idempotency-key/specs/harvest-client/spec.md
@@ -5,13 +5,12 @@
 ### Requirement: Optional Idempotency-Key on harvest create
 
 `Idempotency-Key` on `POST /v3/harvests` remains optional for backward
-compatibility. The client MAY send a non-empty key when client certificate and
-key paths are configured and SSL verification is enabled so mTLS is actually
-presented (authenticated `client_id` available). When it sends a key, that key
-MUST be generated once per logical create attempt and MUST be reused for every
-transport retry of that same attempt. A later distinct `create_harvest` call
-MUST use a different key if it sends one. When client certificates are not used,
-the client MUST omit `Idempotency-Key`.
+compatibility. The client MAY send a non-empty key when it presents client
+certificates (authenticated `client_id` available). When it sends a key, that
+key MUST be generated once per logical create attempt and MUST be reused for
+every transport retry of that same attempt. A later distinct `create_harvest`
+call MUST use a different key if it sends one. When the client does not present
+client certificates, it MUST omit `Idempotency-Key`.
 
 #### Scenario: Omit key when certificates are not configured
 
@@ -19,10 +18,11 @@ the client MUST omit `Idempotency-Key`.
 - **WHEN** the client creates a harvest
 - **THEN** the request omits `Idempotency-Key`
 
-#### Scenario: Omit key when verify_ssl disables mTLS
+#### Scenario: Omit key when this client does not load the cert chain
 
 - **GIVEN** the client has certificate and key paths configured but
-  `verify_ssl` is false (httpx does not present client certificates)
+  `verify_ssl` is false (`ApiClient` only loads the client cert chain when
+  `verify_ssl` is true; that flag is server-certificate verification, not mTLS)
 - **WHEN** the client creates a harvest
 - **THEN** the request omits `Idempotency-Key`
 

--- a/openspec/changes/harvest-create-idempotency-key/specs/harvest-client/spec.md
+++ b/openspec/changes/harvest-create-idempotency-key/specs/harvest-client/spec.md
@@ -6,15 +6,23 @@
 
 `Idempotency-Key` on `POST /v3/harvests` remains optional for backward
 compatibility. The client MAY send a non-empty key when client certificate and
-key paths are configured (authenticated `client_id` available). When it sends a
-key, that key MUST be generated once per logical create attempt and MUST be
-reused for every transport retry of that same attempt. A later distinct
-`create_harvest` call MUST use a different key if it sends one. When client
-certificates are not configured, the client MUST omit `Idempotency-Key`.
+key paths are configured and SSL verification is enabled so mTLS is actually
+presented (authenticated `client_id` available). When it sends a key, that key
+MUST be generated once per logical create attempt and MUST be reused for every
+transport retry of that same attempt. A later distinct `create_harvest` call
+MUST use a different key if it sends one. When client certificates are not used,
+the client MUST omit `Idempotency-Key`.
 
 #### Scenario: Omit key when certificates are not configured
 
 - **GIVEN** the client has no client certificate and key configured
+- **WHEN** the client creates a harvest
+- **THEN** the request omits `Idempotency-Key`
+
+#### Scenario: Omit key when verify_ssl disables mTLS
+
+- **GIVEN** the client has certificate and key paths configured but
+  `verify_ssl` is false (httpx does not present client certificates)
 - **WHEN** the client creates a harvest
 - **THEN** the request omits `Idempotency-Key`
 


### PR DESCRIPTION
- Improved the rollback mechanism to ensure that if the harvest rollback fails, the idempotency claim remains pending instead of being deleted.
- Added logging to capture scenarios where the rollback of the harvest fails, providing better visibility into the state of idempotency claims.
- Introduced a new unit test to verify that the idempotency claim is preserved when the harvest rollback fails, enhancing the robustness of the error handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes harvest idempotency failure semantics (pending claims vs full rollback) and when the client treats create as retryable; incorrect alignment could cause duplicate harvests or stuck keys, but scope is bounded to keyed create and error paths.
> 
> **Overview**
> **Tightens keyed harvest create rollback** when committing the idempotency index fails after a harvest document already exists. The store only deletes the idempotency claim if harvest rollback succeeds; if harvest delete fails, it **leaves the claim pending**, logs a warning, and avoids dropping the claim while an orphan harvest may still exist. A unit test covers that path.
> 
> **Aligns `ApiClient` `Idempotency-Key` behavior with when the client actually loads a cert chain**: a new `_uses_client_certificates()` requires `verify_ssl` plus cert and key paths (same as `_get_client`). Harvest create sends a key only in that case, so cert paths with `verify_ssl=false` no longer get a key or retry-safe keyed creates. OpenSpec/design and harvest-client spec are updated accordingly, with a client unit test for the `verify_ssl=false` case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b69ad880ce15d308436747381b95041fd2cedfc9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->