### PR TITLE
Feature/stop repeated committing

### DIFF
--- a/middleware/api/src/middleware/api/document_store/content_hash.py
+++ b/middleware/api/src/middleware/api/document_store/content_hash.py
@@ -49,13 +49,61 @@ def _graph_sort_key(node: JsonValue) -> tuple[str, str]:
     return ("", json.dumps(node, sort_keys=True))
 
 
+def _canonicalize_json_for_hash(node: JsonValue) -> JsonValue:
+    """Canonicalize RO-Crate JSON for stable hashing.
+
+    In addition to excluding volatile timestamp fields (done upstream),
+    this normalizes deterministic ordering for certain RO-Crate structures:
+
+    - ``@graph`` nodes remain handled by the caller (see ``canonicalize_rocrate_for_hash``).
+    - For other lists: if every element is a dict with a string ``@id``, sort deterministically by it.
+    """
+    if isinstance(node, dict):
+        canonical: dict[str, JsonValue] = {}
+        for key, item in node.items():
+            if key == "@graph" and isinstance(item, list):
+                # Keep graph ordering handling in the caller: we only canonicalize nodes.
+                canonical[key] = [_canonicalize_json_for_hash(n) for n in item]
+                continue
+            canonical[key] = _canonicalize_json_for_hash(item)
+        return canonical
+
+    if isinstance(node, list):
+        canonical_elems = [_canonicalize_json_for_hash(elem) for elem in node]
+
+        # Heuristic: sort lists of RO-Crate reference objects deterministically.
+        # This addresses non-semantic list permutations like ``hasPart`` ordering.
+        if all(isinstance(elem, dict) and isinstance(elem.get("@id"), str) for elem in canonical_elems):
+            return sorted(
+                canonical_elems,  # type: ignore[arg-type]
+                key=lambda elem: (
+                    elem["@id"],  # type: ignore[index]
+                    json.dumps(elem, sort_keys=True),
+                ),
+            )
+
+        return canonical_elems
+
+    return node
+
+
 def canonicalize_rocrate_for_hash(value: RoCrateContent) -> RoCrateContent:
-    """Strip volatile fields and order ``@graph`` for stable hashing."""
+    """Strip volatile fields and make RO-Crate JSON order-deterministic for hashing."""
     stripped = strip_volatile_rocrate_fields(value)
-    graph = stripped.get("@graph")
-    if isinstance(graph, list):
-        return {**stripped, "@graph": sorted(graph, key=_graph_sort_key)}
-    return stripped
+
+    # First normalize list ordering for all nested structures (except @graph, which we
+    # keep in its special handling path to avoid changing prior expectations).
+    def _canonicalize_root(node: RoCrateContent) -> RoCrateContent:
+        canonical: dict[str, JsonValue] = {}
+        for key, item in node.items():
+            if key == "@graph" and isinstance(item, list):
+                canonical_nodes = [_canonicalize_json_for_hash(n) for n in item]
+                canonical[key] = sorted(canonical_nodes, key=_graph_sort_key)
+            else:
+                canonical[key] = _canonicalize_json_for_hash(item)
+        return canonical  # type: ignore[return-value]
+
+    return _canonicalize_root(stripped)
 
 
 def calculate_arc_content_hash(arc_content: RoCrateContent) -> str:

--- a/middleware/api/src/middleware/api/document_store/content_hash.py
+++ b/middleware/api/src/middleware/api/document_store/content_hash.py
@@ -23,6 +23,11 @@ _VOLATILE_ROCRATE_FIELDS = frozenset({
     "dateModified",
 })
 
+# RO-Crate properties that behave like unordered reference sets for hashing.
+_ORDER_INSENSITIVE_REFERENCE_LIST_FIELDS = frozenset({
+    "hasPart",
+})
+
 
 def strip_volatile_rocrate_fields(value: RoCrateContent) -> RoCrateContent:
     """Return a copy of RO-Crate JSON with serialization timestamps removed."""
@@ -50,14 +55,15 @@ def _graph_sort_key(node: JsonValue) -> tuple[str, str]:
     return ("", json.dumps(node, sort_keys=True))
 
 
-def _canonicalize_json_for_hash(node: JsonValue) -> JsonValue:
+def _canonicalize_json_for_hash(node: JsonValue, *, parent_key: str | None = None) -> JsonValue:
     """Canonicalize RO-Crate JSON for stable hashing.
 
     In addition to excluding volatile timestamp fields (done upstream),
     this normalizes deterministic ordering for certain RO-Crate structures:
 
     - ``@graph`` nodes remain handled by the caller (see ``canonicalize_rocrate_for_hash``).
-    - For other lists: if every element is a dict with a string ``@id``, sort deterministically by it.
+    - For allowlisted reference-list properties such as ``hasPart``: if every element is a
+      dict with a string ``@id``, sort deterministically by it.
     """
     if isinstance(node, dict):
         canonical: dict[str, JsonValue] = {}
@@ -66,15 +72,16 @@ def _canonicalize_json_for_hash(node: JsonValue) -> JsonValue:
                 # Keep graph ordering handling in the caller: we only canonicalize nodes.
                 canonical[key] = [_canonicalize_json_for_hash(n) for n in item]
                 continue
-            canonical[key] = _canonicalize_json_for_hash(item)
+            canonical[key] = _canonicalize_json_for_hash(item, parent_key=key)
         return canonical
 
     if isinstance(node, list):
         canonical_elems = [_canonicalize_json_for_hash(elem) for elem in node]
 
-        # Heuristic: sort lists of RO-Crate reference objects deterministically.
-        # This addresses non-semantic list permutations like ``hasPart`` ordering.
-        if all(isinstance(elem, dict) and isinstance(elem.get("@id"), str) for elem in canonical_elems):
+        # Only canonicalize list order for explicitly allowlisted reference properties.
+        if parent_key in _ORDER_INSENSITIVE_REFERENCE_LIST_FIELDS and all(
+            isinstance(elem, dict) and isinstance(elem.get("@id"), str) for elem in canonical_elems
+        ):
 
             def _reference_sort_key(elem: JsonValue) -> tuple[str, str]:
                 elem_dict = cast(dict[str, JsonValue], elem)

--- a/middleware/api/src/middleware/api/document_store/content_hash.py
+++ b/middleware/api/src/middleware/api/document_store/content_hash.py
@@ -82,16 +82,15 @@ def _canonicalize_json_for_hash(node: JsonValue, *, parent_key: str | None = Non
         if parent_key in _ORDER_INSENSITIVE_REFERENCE_LIST_FIELDS and all(
             isinstance(elem, dict) and isinstance(elem.get("@id"), str) for elem in canonical_elems
         ):
+            reference_elems: list[dict[str, JsonValue]] = [cast(dict[str, JsonValue], elem) for elem in canonical_elems]
 
-            def _reference_sort_key(elem: JsonValue) -> tuple[str, str]:
-                elem_dict = cast(dict[str, JsonValue], elem)
-                id_part = cast(str, elem_dict["@id"])
-                return (id_part, json.dumps(elem_dict, sort_keys=True))
+            def _reference_sort_key(elem: dict[str, JsonValue]) -> tuple[str, str]:
+                id_part = cast(str, elem["@id"])
+                return (id_part, json.dumps(elem, sort_keys=True))
 
-            return sorted(
-                canonical_elems,  # type: ignore[arg-type]
-                key=_reference_sort_key,
-            )
+            decorated = [(_reference_sort_key(elem), elem) for elem in reference_elems]
+            decorated.sort(key=lambda pair: pair[0])
+            return [elem for _, elem in decorated]
 
         return canonical_elems
 

--- a/middleware/api/src/middleware/api/document_store/content_hash.py
+++ b/middleware/api/src/middleware/api/document_store/content_hash.py
@@ -105,14 +105,14 @@ def canonicalize_rocrate_for_hash(value: RoCrateContent) -> RoCrateContent:
     # First normalize list ordering for all nested structures (except @graph, which we
     # keep in its special handling path to avoid changing prior expectations).
     def _canonicalize_root(node: RoCrateContent) -> RoCrateContent:
-        canonical: dict[str, JsonValue] = {}
+        canonical: RoCrateContent = {}
         for key, item in node.items():
             if key == "@graph" and isinstance(item, list):
                 canonical_nodes = [_canonicalize_json_for_hash(n) for n in item]
                 canonical[key] = sorted(canonical_nodes, key=_graph_sort_key)
             else:
                 canonical[key] = _canonicalize_json_for_hash(item)
-        return canonical  # type: ignore[return-value]
+        return canonical
 
     return _canonicalize_root(stripped)
 

--- a/middleware/api/src/middleware/api/document_store/content_hash.py
+++ b/middleware/api/src/middleware/api/document_store/content_hash.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from typing import cast
 
 # JSON shapes produced by ``json.loads`` / consumed by ``json.dumps``.
 type JsonPrimitive = str | int | float | bool | None
@@ -74,12 +75,15 @@ def _canonicalize_json_for_hash(node: JsonValue) -> JsonValue:
         # Heuristic: sort lists of RO-Crate reference objects deterministically.
         # This addresses non-semantic list permutations like ``hasPart`` ordering.
         if all(isinstance(elem, dict) and isinstance(elem.get("@id"), str) for elem in canonical_elems):
+
+            def _reference_sort_key(elem: JsonValue) -> tuple[str, str]:
+                elem_dict = cast(dict[str, JsonValue], elem)
+                id_part = cast(str, elem_dict["@id"])
+                return (id_part, json.dumps(elem_dict, sort_keys=True))
+
             return sorted(
                 canonical_elems,  # type: ignore[arg-type]
-                key=lambda elem: (
-                    elem["@id"],  # type: ignore[index]
-                    json.dumps(elem, sort_keys=True),
-                ),
+                key=_reference_sort_key,
             )
 
         return canonical_elems

--- a/middleware/api/tests/unit/test_content_hash.py
+++ b/middleware/api/tests/unit/test_content_hash.py
@@ -144,6 +144,37 @@ def test_calculate_arc_content_hash_ignores_haspart_list_order() -> None:
     assert calculate_arc_content_hash(arc_a) == calculate_arc_content_hash(arc_b)
 
 
+def test_calculate_arc_content_hash_preserves_non_allowlisted_list_order() -> None:
+    """Non-allowlisted reference-list properties must keep their original order semantics."""
+    arc_a: RoCrateContent = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {
+                "@id": "./",
+                "identifier": "arc-1",
+                "creator": [{"@id": "#person-a"}, {"@id": "#person-b"}],
+            },
+            {"@id": "#person-a", "name": "Person A"},
+            {"@id": "#person-b", "name": "Person B"},
+        ],
+    }
+
+    arc_b: RoCrateContent = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {
+                "@id": "./",
+                "identifier": "arc-1",
+                "creator": [{"@id": "#person-b"}, {"@id": "#person-a"}],
+            },
+            {"@id": "#person-a", "name": "Person A"},
+            {"@id": "#person-b", "name": "Person B"},
+        ],
+    }
+
+    assert calculate_arc_content_hash(arc_a) != calculate_arc_content_hash(arc_b)
+
+
 def test_calculate_arc_content_hash_ignores_graph_order() -> None:
     """``@graph`` node order must not affect the content hash."""
     first: RoCrateContent = {

--- a/middleware/api/tests/unit/test_content_hash.py
+++ b/middleware/api/tests/unit/test_content_hash.py
@@ -79,6 +79,40 @@ def test_calculate_arc_content_hash_ignores_timestamp_only_differences() -> None
     assert calculate_arc_content_hash(base) == calculate_arc_content_hash(refreshed)
 
 
+def test_calculate_arc_content_hash_ignores_date_modified_only_differences() -> None:
+    """Only ``dateModified`` differences must not change the ARC content hash."""
+    base: RoCrateContent = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {
+                "@id": "./",
+                "identifier": "arc-1",
+                "dateCreated": "2024-01-15",
+                "datePublished": "2026-01-01T10:00:00.111",
+                "sdDatePublished": "2026-01-01T10:00:00.112",
+                "nested": {"dateModified": "2026-01-01T10:00:00.200"},
+            },
+            {"@id": "#study", "name": "Study", "dateModified": "2026-01-01T10:00:00.201"},
+        ],
+    }
+    changed: RoCrateContent = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {
+                "@id": "./",
+                "identifier": "arc-1",
+                "dateCreated": "2024-01-15",
+                "datePublished": "2026-01-01T10:00:00.111",
+                "sdDatePublished": "2026-01-01T10:00:00.112",
+                "nested": {"dateModified": "2026-01-02T11:11:11.222"},
+            },
+            {"@id": "#study", "name": "Study", "dateModified": "2026-01-02T11:11:11.333"},
+        ],
+    }
+
+    assert calculate_arc_content_hash(base) == calculate_arc_content_hash(changed)
+
+
 def test_calculate_arc_content_hash_ignores_graph_order() -> None:
     """``@graph`` node order must not affect the content hash."""
     first: RoCrateContent = {

--- a/middleware/api/tests/unit/test_content_hash.py
+++ b/middleware/api/tests/unit/test_content_hash.py
@@ -113,6 +113,37 @@ def test_calculate_arc_content_hash_ignores_date_modified_only_differences() -> 
     assert calculate_arc_content_hash(base) == calculate_arc_content_hash(changed)
 
 
+def test_calculate_arc_content_hash_ignores_haspart_list_order() -> None:
+    """Permuting RO-Crate reference lists (e.g. ``hasPart``) must not change the hash."""
+    arc_a: RoCrateContent = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {
+                "@id": "./",
+                "identifier": "arc-1",
+                "hasPart": [{"@id": "#assay-a"}, {"@id": "#assay-b"}],
+            },
+            {"@id": "#assay-a", "name": "Assay A"},
+            {"@id": "#assay-b", "name": "Assay B"},
+        ],
+    }
+
+    arc_b: RoCrateContent = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {
+                "@id": "./",
+                "identifier": "arc-1",
+                "hasPart": [{"@id": "#assay-b"}, {"@id": "#assay-a"}],
+            },
+            {"@id": "#assay-a", "name": "Assay A"},
+            {"@id": "#assay-b", "name": "Assay B"},
+        ],
+    }
+
+    assert calculate_arc_content_hash(arc_a) == calculate_arc_content_hash(arc_b)
+
+
 def test_calculate_arc_content_hash_ignores_graph_order() -> None:
     """``@graph`` node order must not affect the content hash."""
     first: RoCrateContent = {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changing hash canonicalization can alter when updates are skipped vs applied for existing stored ARCs; behavior is scoped to allowlisted fields and covered by new unit tests.
> 
> **Overview**
> Tightens **RO-Crate content hashing** so semantically identical ARCs are not treated as changed when only serialization noise differs—supporting the goal of **avoiding repeated commits** on unchanged content.
> 
> `canonicalize_rocrate_for_hash` now walks nested JSON via `_canonicalize_json_for_hash` and **sorts allowlisted reference lists** (starting with `hasPart`) by `@id` when every element is an `@id` reference. **`@graph`** handling is unchanged in spirit: nodes are canonicalized then sorted with the existing `_graph_sort_key`. Volatile timestamp stripping was already in place; new tests lock in **`dateModified`-only** equivalence, **`hasPart`** order invariance, and that **non-allowlisted** lists (e.g. `creator`) still differ when order changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e307c8e3f6bc733ecb0f81b374844142aba84ec7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->