### PR TITLE
Enhance content hashing by normalizing reference list order

### DIFF
--- a/middleware/api/src/middleware/api/document_store/content_hash.py
+++ b/middleware/api/src/middleware/api/document_store/content_hash.py
@@ -24,16 +24,17 @@ _VOLATILE_ROCRATE_FIELDS = frozenset({
 })
 
 # RO-Crate properties that behave like unordered reference sets for hashing.
+# Only applied when every list element is a dict with a string ``@id`` (safe heuristic).
+# Domain-specific payload noise (keyword join order, blank-node comment text, DE/EN
+# description choice) is intentionally NOT normalized here — fix those in harvesters.
 _ORDER_INSENSITIVE_REFERENCE_LIST_FIELDS = frozenset({
     "hasPart",
+    "creator",
+    "author",
+    "contributor",
+    # Investigation/root often links Comments via ``[{"@id": …}, …]``; order is not semantic.
+    "comment",
 })
-
-# Schema.org / OpenAgrar mappers join unordered keyword sets with this separator.
-# Permuting the join changes Comment/ParameterValue payloads and arctrl-derived ``@id``s.
-_KEYWORDS_JOIN_SEP = ", "
-_KEYWORDS_NAME = "Keywords"
-_KEYWORDS_ID_MARKER = "_Keywords_"
-_KEYWORDS_PAYLOAD_FIELDS = ("text", "value")
 
 
 def strip_volatile_rocrate_fields(value: RoCrateContent) -> RoCrateContent:
@@ -62,96 +63,28 @@ def _graph_sort_key(node: JsonValue) -> tuple[str, str]:
     return ("", json.dumps(node, sort_keys=True))
 
 
-def _join_keywords_sorted(payload: str) -> str:
-    """Return a lexicographically sorted ``", "``-joined keyword string."""
-    parts = [part.strip() for part in payload.split(_KEYWORDS_JOIN_SEP) if part.strip()]
-    return _KEYWORDS_JOIN_SEP.join(sorted(parts))
-
-
-def _encode_keywords_for_arc_id(joined: str) -> str:
-    """Match arctrl-style ``@id`` encoding for keyword joins (spaces → underscores)."""
-    return joined.replace(" ", "_")
-
-
-def _normalize_keywords_node(node: dict[str, JsonValue]) -> dict[str, str]:
-    """Sort Keywords payloads in *node*; return ``{old_@id: new_@id}`` remaps."""
-    if node.get("name") != _KEYWORDS_NAME:
-        return {}
-
-    payload_key: str | None = None
-    for key in _KEYWORDS_PAYLOAD_FIELDS:
-        value = node.get(key)
-        if isinstance(value, str) and value.strip():
-            payload_key = key
-            break
-    if payload_key is None:
-        return {}
-
-    old_payload = cast(str, node[payload_key])
-    new_payload = _join_keywords_sorted(old_payload)
-    node[payload_key] = new_payload
-
-    remaps: dict[str, str] = {}
-    old_id = node.get("@id")
-    if not isinstance(old_id, str) or _KEYWORDS_ID_MARKER not in old_id:
-        return remaps
-
-    prefix, _, _old_suffix = old_id.partition(_KEYWORDS_ID_MARKER)
-    new_id = f"{prefix}{_KEYWORDS_ID_MARKER}{_encode_keywords_for_arc_id(new_payload)}"
-    if new_id != old_id:
-        remaps[old_id] = new_id
-        node["@id"] = new_id
-    return remaps
-
-
-def _apply_id_remaps(node: JsonValue, remaps: dict[str, str]) -> JsonValue:
-    """Rewrite ``@id`` values that point at remapped Keywords nodes."""
-    if not remaps:
-        return node
-    if isinstance(node, dict):
-        rewritten: dict[str, JsonValue] = {}
-        for key, item in node.items():
-            if key == "@id" and isinstance(item, str) and item in remaps:
-                rewritten[key] = remaps[item]
-            else:
-                rewritten[key] = _apply_id_remaps(item, remaps)
-        return rewritten
-    if isinstance(node, list):
-        return [_apply_id_remaps(elem, remaps) for elem in node]
-    return node
-
-
-def _canonicalize_json_for_hash(
-    node: JsonValue,
-    *,
-    parent_key: str | None = None,
-    id_remaps: dict[str, str] | None = None,
-) -> JsonValue:
+def _canonicalize_json_for_hash(node: JsonValue, *, parent_key: str | None = None) -> JsonValue:
     """Canonicalize RO-Crate JSON for stable hashing.
 
     In addition to excluding volatile timestamp fields (done upstream),
     this normalizes deterministic ordering for certain RO-Crate structures:
 
     - ``@graph`` nodes remain handled by the caller (see ``canonicalize_rocrate_for_hash``).
-    - For allowlisted reference-list properties such as ``hasPart``: if every element is a
-      dict with a string ``@id``, sort deterministically by it.
-    - Nodes named ``Keywords`` get a sorted join string (and stable ``@id``) so RDF object
-      order from harvesters does not churn the content hash.
+    - For allowlisted reference-list properties (``hasPart``, ``creator``, …): if every
+      element is a dict with a string ``@id``, sort deterministically by it.
     """
     if isinstance(node, dict):
         canonical: dict[str, JsonValue] = {}
         for key, item in node.items():
             if key == "@graph" and isinstance(item, list):
                 # Keep graph ordering handling in the caller: we only canonicalize nodes.
-                canonical[key] = [_canonicalize_json_for_hash(n, id_remaps=id_remaps) for n in item]
+                canonical[key] = [_canonicalize_json_for_hash(n) for n in item]
                 continue
-            canonical[key] = _canonicalize_json_for_hash(item, parent_key=key, id_remaps=id_remaps)
-        if id_remaps is not None:
-            id_remaps.update(_normalize_keywords_node(canonical))
+            canonical[key] = _canonicalize_json_for_hash(item, parent_key=key)
         return canonical
 
     if isinstance(node, list):
-        canonical_elems = [_canonicalize_json_for_hash(elem, id_remaps=id_remaps) for elem in node]
+        canonical_elems = [_canonicalize_json_for_hash(elem) for elem in node]
 
         # Only canonicalize list order for explicitly allowlisted reference properties.
         if parent_key in _ORDER_INSENSITIVE_REFERENCE_LIST_FIELDS and all(
@@ -175,28 +108,15 @@ def _canonicalize_json_for_hash(
 def canonicalize_rocrate_for_hash(value: RoCrateContent) -> RoCrateContent:
     """Strip volatile fields and make RO-Crate JSON order-deterministic for hashing."""
     stripped = strip_volatile_rocrate_fields(value)
-    id_remaps: dict[str, str] = {}
 
     canonical: RoCrateContent = {}
     for key, item in stripped.items():
         if key == "@graph" and isinstance(item, list):
-            canonical_nodes = [_canonicalize_json_for_hash(n, id_remaps=id_remaps) for n in item]
+            canonical_nodes = [_canonicalize_json_for_hash(n) for n in item]
             canonical[key] = sorted(canonical_nodes, key=_graph_sort_key)
         else:
-            canonical[key] = _canonicalize_json_for_hash(item, id_remaps=id_remaps)
-
-    if not id_remaps:
-        return canonical
-
-    remapped = _apply_id_remaps(canonical, id_remaps)
-    if not isinstance(remapped, dict):
-        msg = "RO-Crate content must be a JSON object"
-        raise TypeError(msg)
-
-    graph = remapped.get("@graph")
-    if isinstance(graph, list):
-        remapped["@graph"] = sorted(graph, key=_graph_sort_key)
-    return cast(RoCrateContent, remapped)
+            canonical[key] = _canonicalize_json_for_hash(item)
+    return canonical
 
 
 def calculate_arc_content_hash(arc_content: RoCrateContent) -> str:

--- a/middleware/api/tests/unit/test_content_hash.py
+++ b/middleware/api/tests/unit/test_content_hash.py
@@ -144,6 +144,71 @@ def test_calculate_arc_content_hash_ignores_haspart_list_order() -> None:
     assert calculate_arc_content_hash(arc_a) == calculate_arc_content_hash(arc_b)
 
 
+def _arc_with_person_refs(field: str, person_ids: list[str]) -> RoCrateContent:
+    return {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {
+                "@id": "./",
+                "identifier": "arc-1",
+                field: [{"@id": pid} for pid in person_ids],
+            },
+            {"@id": "#person-a", "name": "Person A"},
+            {"@id": "#person-b", "name": "Person B"},
+        ],
+    }
+
+
+def test_calculate_arc_content_hash_ignores_creator_list_order() -> None:
+    """Permuting ``creator`` ``@id`` refs must not change the hash."""
+    arc_a = _arc_with_person_refs("creator", ["#person-a", "#person-b"])
+    arc_b = _arc_with_person_refs("creator", ["#person-b", "#person-a"])
+    assert calculate_arc_content_hash(arc_a) == calculate_arc_content_hash(arc_b)
+
+
+def test_calculate_arc_content_hash_ignores_author_list_order() -> None:
+    """Permuting ``author`` ``@id`` refs must not change the hash."""
+    arc_a = _arc_with_person_refs("author", ["#person-a", "#person-b"])
+    arc_b = _arc_with_person_refs("author", ["#person-b", "#person-a"])
+    assert calculate_arc_content_hash(arc_a) == calculate_arc_content_hash(arc_b)
+
+
+def test_calculate_arc_content_hash_ignores_contributor_list_order() -> None:
+    """Permuting ``contributor`` ``@id`` refs must not change the hash."""
+    arc_a = _arc_with_person_refs("contributor", ["#person-a", "#person-b"])
+    arc_b = _arc_with_person_refs("contributor", ["#person-b", "#person-a"])
+    assert calculate_arc_content_hash(arc_a) == calculate_arc_content_hash(arc_b)
+
+
+def test_calculate_arc_content_hash_ignores_comment_ref_list_order() -> None:
+    """Permuting ``comment`` ``@id`` refs must not change the hash."""
+    arc_a: RoCrateContent = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {
+                "@id": "./",
+                "identifier": "arc-1",
+                "comment": [{"@id": "#c-a"}, {"@id": "#c-b"}],
+            },
+            {"@id": "#c-a", "@type": "Comment", "name": "License", "text": "CC-BY"},
+            {"@id": "#c-b", "@type": "Comment", "name": "Publisher", "text": "Zenodo"},
+        ],
+    }
+    arc_b: RoCrateContent = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {
+                "@id": "./",
+                "identifier": "arc-1",
+                "comment": [{"@id": "#c-b"}, {"@id": "#c-a"}],
+            },
+            {"@id": "#c-a", "@type": "Comment", "name": "License", "text": "CC-BY"},
+            {"@id": "#c-b", "@type": "Comment", "name": "Publisher", "text": "Zenodo"},
+        ],
+    }
+    assert calculate_arc_content_hash(arc_a) == calculate_arc_content_hash(arc_b)
+
+
 def test_calculate_arc_content_hash_preserves_non_allowlisted_list_order() -> None:
     """Non-allowlisted reference-list properties must keep their original order semantics."""
     arc_a: RoCrateContent = {
@@ -152,7 +217,7 @@ def test_calculate_arc_content_hash_preserves_non_allowlisted_list_order() -> No
             {
                 "@id": "./",
                 "identifier": "arc-1",
-                "creator": [{"@id": "#person-a"}, {"@id": "#person-b"}],
+                "editor": [{"@id": "#person-a"}, {"@id": "#person-b"}],
             },
             {"@id": "#person-a", "name": "Person A"},
             {"@id": "#person-b", "name": "Person B"},
@@ -165,13 +230,38 @@ def test_calculate_arc_content_hash_preserves_non_allowlisted_list_order() -> No
             {
                 "@id": "./",
                 "identifier": "arc-1",
-                "creator": [{"@id": "#person-b"}, {"@id": "#person-a"}],
+                "editor": [{"@id": "#person-b"}, {"@id": "#person-a"}],
             },
             {"@id": "#person-a", "name": "Person A"},
             {"@id": "#person-b", "name": "Person B"},
         ],
     }
 
+    assert calculate_arc_content_hash(arc_a) != calculate_arc_content_hash(arc_b)
+
+
+def test_calculate_arc_content_hash_preserves_order_when_list_lacks_uniform_id_refs() -> None:
+    """Allowlisted fields stay order-sensitive when elements are not all ``{@id}`` dicts."""
+    arc_a: RoCrateContent = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {
+                "@id": "./",
+                "identifier": "arc-1",
+                "creator": ["Alice", "Bob"],
+            },
+        ],
+    }
+    arc_b: RoCrateContent = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {
+                "@id": "./",
+                "identifier": "arc-1",
+                "creator": ["Bob", "Alice"],
+            },
+        ],
+    }
     assert calculate_arc_content_hash(arc_a) != calculate_arc_content_hash(arc_b)
 
 
@@ -221,79 +311,54 @@ def test_calculate_arc_content_hash_differs_from_legacy_full_json_hash() -> None
     assert calculate_arc_content_hash(arc) != legacy_hash
 
 
-def test_calculate_arc_content_hash_ignores_keywords_join_order() -> None:
-    """Permuting Schema.org keyword joins must not change the ARC content hash.
-
-    Harvesters may emit the same keyword *set* in different RDF object orders.
-    That changes Investigation Comment / Data-Collection ParameterValue strings and
-    the arctrl ``@id``s derived from them (``#LDComment_Keywords_…``,
-    ``#ParameterValue_Keywords_…``) without a semantic content change.
-    """
-    keywords_a = "DEPTH, water, Longitude of event, Trawling time, Event label"
-    keywords_b = "Longitude of event, Event label, DEPTH, water, Trawling time"
-    expected_sorted = "DEPTH, Event label, Longitude of event, Trawling time, water"
+def test_calculate_arc_content_hash_treats_keyword_join_permutation_as_change() -> None:
+    """Keyword join / derived ``@id`` differences remain hash changes (Harvester concern)."""
+    keywords_a = "DEPTH, water, Longitude of event"
+    keywords_b = "Longitude of event, DEPTH, water"
 
     def _arc_with_keywords(joined: str) -> RoCrateContent:
         comment_id = f"#LDComment_Keywords_{joined.replace(' ', '_')}"
-        param_id = f"#ParameterValue_Keywords_{joined.replace(' ', '_')}"
         return {
             "@context": "https://w3id.org/ro/crate/1.1/context",
             "@graph": [
-                {
-                    "@id": "./",
-                    "identifier": "10.1594/PANGAEA.874745",
-                    "comment": {"@id": comment_id},
-                },
+                {"@id": "./", "identifier": "arc-1", "comment": {"@id": comment_id}},
                 {
                     "@id": comment_id,
                     "@type": "Comment",
                     "name": "Keywords",
                     "text": joined,
                 },
-                {
-                    "@id": param_id,
-                    "@type": "PropertyValue",
-                    "additionalType": "ParameterValue",
-                    "name": "Keywords",
-                    "value": joined,
-                },
-                {
-                    "@id": "#Process_Data_Collection",
-                    "parameterValue": {"@id": param_id},
-                },
             ],
         }
 
-    arc_a = _arc_with_keywords(keywords_a)
-    arc_b = _arc_with_keywords(keywords_b)
-
-    assert calculate_arc_content_hash(arc_a) == calculate_arc_content_hash(arc_b)
-
-    canonical = canonicalize_rocrate_for_hash(arc_a)
-    graph = canonical.get("@graph")
-    assert isinstance(graph, list)
-    by_id = {item["@id"]: item for item in graph if isinstance(item, dict) and isinstance(item.get("@id"), str)}
-    comment = by_id[f"#LDComment_Keywords_{expected_sorted.replace(' ', '_')}"]
-    param = by_id[f"#ParameterValue_Keywords_{expected_sorted.replace(' ', '_')}"]
-    assert isinstance(comment, dict)
-    assert isinstance(param, dict)
-    assert comment["text"] == expected_sorted
-    assert param["value"] == expected_sorted
-    root = by_id["./"]
-    assert isinstance(root, dict)
-    assert root["comment"] == {"@id": comment["@id"]}
+    assert calculate_arc_content_hash(_arc_with_keywords(keywords_a)) != calculate_arc_content_hash(
+        _arc_with_keywords(keywords_b)
+    )
 
 
-def test_calculate_arc_content_hash_detects_different_keyword_sets() -> None:
-    """Different keyword membership must still change the hash."""
+def test_calculate_arc_content_hash_treats_description_language_swap_as_change() -> None:
+    """Different description literals must change the hash (not normalized away)."""
+    arc_de: RoCrateContent = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [{"@id": "./", "identifier": "arc-1", "description": "Deutscher Text"}],
+    }
+    arc_en: RoCrateContent = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [{"@id": "./", "identifier": "arc-1", "description": "English text"}],
+    }
+    assert calculate_arc_content_hash(arc_de) != calculate_arc_content_hash(arc_en)
+
+
+def test_calculate_arc_content_hash_treats_blank_node_comment_text_as_change() -> None:
+    """Blank-node label comment text remains a hash change (Harvester must not persist it)."""
     arc_a: RoCrateContent = {
         "@context": "https://w3id.org/ro/crate/1.1/context",
         "@graph": [
             {
-                "@id": "#LDComment_Keywords_DEPTH,_water",
+                "@id": "#LDComment_contributorOrder_Nad019e26cbb748fc8af372d30f5d9946",
                 "@type": "Comment",
-                "name": "Keywords",
-                "text": "DEPTH, water",
+                "name": "contributorOrder",
+                "text": "Nad019e26cbb748fc8af372d30f5d9946",
             },
         ],
     }
@@ -301,12 +366,11 @@ def test_calculate_arc_content_hash_detects_different_keyword_sets() -> None:
         "@context": "https://w3id.org/ro/crate/1.1/context",
         "@graph": [
             {
-                "@id": "#LDComment_Keywords_DEPTH,_salinity",
+                "@id": "#LDComment_contributorOrder_N47faa23a0594409ea973e49159e269a7",
                 "@type": "Comment",
-                "name": "Keywords",
-                "text": "DEPTH, salinity",
+                "name": "contributorOrder",
+                "text": "N47faa23a0594409ea973e49159e269a7",
             },
         ],
     }
-
     assert calculate_arc_content_hash(arc_a) != calculate_arc_content_hash(arc_b)


### PR DESCRIPTION
- Updated `_canonicalize_json_for_hash` to include `creator`, `author`, `contributor`, and `comment` fields in the order-insensitive reference list handling, ensuring consistent content hashing regardless of list order.
- Removed outdated keyword normalization functions and streamlined the canonicalization process for better performance and clarity.
- Added tests to verify that permutations of `creator`, `author`, `contributor`, and `comment` references do not affect the content hash, while maintaining order sensitivity for non-allowlisted fields.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `calculate_arc_content_hash`, which drives ARC change detection and harvest duplicate checks. Existing docs may flip between “changed” and “unchanged” (more person/comment reorder stability; keyword-order churn now counts as a change).
> 
> **Overview**
> RO-Crate content hashing now treats `creator`, `author`, `contributor`, and `comment` `@id` lists as unordered (same as `hasPart`), so harvest reordering of those refs no longer looks like a content change.
> 
> Keyword-join sorting and `@id` remapping are **removed**. Permuted keyword strings, language-swapped descriptions, and blank-node comment text stay hash-different; that noise is left for harvesters to fix. Canonicalization is simpler (no remap pass).
> 
> Tests cover the new allowlist, keep order for non-`@id` lists and non-allowlisted fields (`editor`), and assert keyword/description/blank-node differences still change the hash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4518c38d7a974d7207370165e12244c2eb5126b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->