### PR TITLE
Work around arctrl 3.2 Int32/divmod failure in ARC.Write.

### DIFF
--- a/middleware/api/src/middleware/api/arc_store/__init__.py
+++ b/middleware/api/src/middleware/api/arc_store/__init__.py
@@ -8,7 +8,10 @@ from abc import ABC, abstractmethod
 from arctrl import ARC  # type: ignore[import-untyped]
 from opentelemetry import trace
 
+from middleware.api.arc_store.arctrl_compat import patch_fable_int32_for_openpyxl
 from middleware.api.utils import calculate_arc_id
+
+patch_fable_int32_for_openpyxl()
 
 logger = logging.getLogger(__name__)
 

--- a/middleware/api/src/middleware/api/arc_store/arctrl_compat.py
+++ b/middleware/api/src/middleware/api/arc_store/arctrl_compat.py
@@ -23,7 +23,8 @@ def patch_fable_int32_for_openpyxl() -> None:
     indices from arctrl 3.2 / fable-library 5.13 are ``fable.Int32``, which
     implements ``//`` and ``%`` but not ``__divmod__``, so builtins ``divmod``
     raises ``TypeError``. Adding ``__divmod__`` / ``__rdivmod__`` restores Write
-    for study/assay ISA files (see ARCtrl#631 and related Int32 issues).
+    for study/assay ISA files (see ARCtrl#638). Duplicated in ``middleware/tools/rocrate2arc.py``
+    (no api dependency); remove both when fixed (fairagro/m4.2_advanced_middleware_api#339).
     """
     if _state["patched"]:
         return

--- a/middleware/api/src/middleware/api/arc_store/arctrl_compat.py
+++ b/middleware/api/src/middleware/api/arc_store/arctrl_compat.py
@@ -1,0 +1,51 @@
+"""Compatibility shims for arctrl / fable-library Python packaging quirks."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_state: dict[str, bool] = {"patched": False}
+
+_FableInt32: Any | None
+try:
+    from fable_library.core import Int32 as _FableInt32  # type: ignore[import-untyped, no-redef]
+except ImportError:
+    _FableInt32 = None
+
+
+def patch_fable_int32_for_openpyxl() -> None:
+    """Teach ``fable.Int32`` ``divmod`` so openpyxl can write XLSX under arctrl 3.2+.
+
+    ``openpyxl.utils.cell.get_column_letter`` calls ``divmod(col_idx, 26)``. Column
+    indices from arctrl 3.2 / fable-library 5.13 are ``fable.Int32``, which
+    implements ``//`` and ``%`` but not ``__divmod__``, so builtins ``divmod``
+    raises ``TypeError``. Adding ``__divmod__`` / ``__rdivmod__`` restores Write
+    for study/assay ISA files (see ARCtrl#631 and related Int32 issues).
+    """
+    if _state["patched"]:
+        return
+    if _FableInt32 is None:
+        logger.debug("fable_library.core.Int32 unavailable; skipping openpyxl divmod patch")
+        _state["patched"] = True
+        return
+
+    def divmod_method(self: object, other: object) -> tuple[int, int]:
+        result = divmod(int(self), int(other))  # type: ignore[call-overload]
+        return int(result[0]), int(result[1])
+
+    def rdivmod_method(self: object, other: object) -> tuple[int, int]:
+        result = divmod(int(other), int(self))  # type: ignore[call-overload]
+        return int(result[0]), int(result[1])
+
+    _FableInt32.__divmod__ = divmod_method
+    _FableInt32.__rdivmod__ = rdivmod_method
+    _state["patched"] = True
+    logger.debug("Patched fable.Int32.__divmod__ for openpyxl column letters")
+
+
+def reset_fable_int32_patch_for_tests() -> None:
+    """Allow unit tests to re-apply the patch after import-order side effects."""
+    _state["patched"] = False

--- a/middleware/api/src/middleware/api/arc_store/arctrl_compat.py
+++ b/middleware/api/src/middleware/api/arc_store/arctrl_compat.py
@@ -40,8 +40,10 @@ def patch_fable_int32_for_openpyxl() -> None:
         result = divmod(int(other), int(self))  # type: ignore[call-overload]
         return int(result[0]), int(result[1])
 
-    _FableInt32.__divmod__ = divmod_method
-    _FableInt32.__rdivmod__ = rdivmod_method
+    if "__divmod__" not in _FableInt32.__dict__:
+        _FableInt32.__divmod__ = divmod_method
+    if "__rdivmod__" not in _FableInt32.__dict__:
+        _FableInt32.__rdivmod__ = rdivmod_method
     _state["patched"] = True
     logger.debug("Patched fable.Int32.__divmod__ for openpyxl column letters")
 

--- a/middleware/api/src/middleware/api/arc_store/arctrl_compat.py
+++ b/middleware/api/src/middleware/api/arc_store/arctrl_compat.py
@@ -40,12 +40,16 @@ def patch_fable_int32_for_openpyxl() -> None:
         result = divmod(int(other), int(self))  # type: ignore[call-overload]
         return int(result[0]), int(result[1])
 
+    changed = False
     if "__divmod__" not in _FableInt32.__dict__:
         _FableInt32.__divmod__ = divmod_method
+        changed = True
     if "__rdivmod__" not in _FableInt32.__dict__:
         _FableInt32.__rdivmod__ = rdivmod_method
+        changed = True
     _state["patched"] = True
-    logger.debug("Patched fable.Int32.__divmod__ for openpyxl column letters")
+    if changed:
+        logger.debug("Patched fable.Int32.__divmod__ for openpyxl column letters")
 
 
 def reset_fable_int32_patch_for_tests() -> None:

--- a/middleware/api/tests/unit/test_arctrl_compat.py
+++ b/middleware/api/tests/unit/test_arctrl_compat.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import pytest
 from arctrl import ARC  # type: ignore[import-untyped]
-from fable_library.core import int32  # type: ignore[import-untyped]
 
 from middleware.api.arc_store.arctrl_compat import (
     patch_fable_int32_for_openpyxl,
@@ -25,7 +24,8 @@ def test_patch_fable_int32_divmod_is_idempotent() -> None:
 
 def test_patch_fable_int32_enables_divmod_with_python_int() -> None:
     """Openpyxl column-letter path needs builtins.divmod(Int32, int)."""
-    pytest.importorskip("fable_library.core")
+    fable_core = pytest.importorskip("fable_library.core")
+    int32 = fable_core.int32
 
     reset_fable_int32_patch_for_tests()
     patch_fable_int32_for_openpyxl()

--- a/middleware/api/tests/unit/test_arctrl_compat.py
+++ b/middleware/api/tests/unit/test_arctrl_compat.py
@@ -1,0 +1,52 @@
+"""Tests for arctrl / fable-library compatibility shims."""
+
+from __future__ import annotations
+
+import importlib.metadata
+from pathlib import Path
+
+import pytest
+from arctrl import ARC  # type: ignore[import-untyped]
+from fable_library.core import int32  # type: ignore[import-untyped]
+
+from middleware.api.arc_store.arctrl_compat import (
+    patch_fable_int32_for_openpyxl,
+    reset_fable_int32_patch_for_tests,
+)
+
+_ARCTRL_VERSION = importlib.metadata.version("arctrl")
+
+
+def test_patch_fable_int32_divmod_is_idempotent() -> None:
+    """Patch may run repeatedly (package import + tools) without error."""
+    patch_fable_int32_for_openpyxl()
+    patch_fable_int32_for_openpyxl()
+
+
+def test_patch_fable_int32_enables_divmod_with_python_int() -> None:
+    """Openpyxl column-letter path needs builtins.divmod(Int32, int)."""
+    pytest.importorskip("fable_library.core")
+
+    reset_fable_int32_patch_for_tests()
+    patch_fable_int32_for_openpyxl()
+    quotient, remainder = divmod(int32(44), 26)
+    assert int(quotient) == 1  # noqa: PLR2004
+    assert int(remainder) == 18  # noqa: PLR2004
+
+
+@pytest.mark.skipif(
+    _ARCTRL_VERSION.startswith("3.1."),
+    reason="arctrl 3.1.x Write does not hit the Int32/divmod openpyxl path",
+)
+def test_sample_rocrate_write_succeeds_with_compat_patch(tmp_path: Path) -> None:
+    """Regression: sample.json study/assay XLSX write under arctrl 3.2+."""
+    reset_fable_int32_patch_for_tests()
+    patch_fable_int32_for_openpyxl()
+
+    sample = Path(__file__).resolve().parents[4] / "ro_crates" / "sample.json"
+    arc = ARC.from_rocrate_json_string(sample.read_text(encoding="utf-8"))
+    out = tmp_path / "arc"
+    out.mkdir()
+    arc.Write(str(out))
+    assert (out / "studies" / "AthalianaColdStress" / "isa.study.xlsx").is_file()
+    assert (out / "assays" / "SugarMeasurement" / "isa.assay.xlsx").is_file()

--- a/middleware/api/tests/unit/test_arctrl_compat.py
+++ b/middleware/api/tests/unit/test_arctrl_compat.py
@@ -7,13 +7,14 @@ from pathlib import Path
 
 import pytest
 from arctrl import ARC  # type: ignore[import-untyped]
+from packaging.version import Version
 
 from middleware.api.arc_store.arctrl_compat import (
     patch_fable_int32_for_openpyxl,
     reset_fable_int32_patch_for_tests,
 )
 
-_ARCTRL_VERSION = importlib.metadata.version("arctrl")
+_ARCTRL_VERSION = Version(importlib.metadata.version("arctrl"))
 
 
 def test_patch_fable_int32_divmod_is_idempotent() -> None:
@@ -35,8 +36,8 @@ def test_patch_fable_int32_enables_divmod_with_python_int() -> None:
 
 
 @pytest.mark.skipif(
-    _ARCTRL_VERSION.startswith("3.1."),
-    reason="arctrl 3.1.x Write does not hit the Int32/divmod openpyxl path",
+    Version("3.2") > _ARCTRL_VERSION,
+    reason="arctrl < 3.2 Write does not hit the Int32/divmod openpyxl path",
 )
 def test_sample_rocrate_write_succeeds_with_compat_patch(tmp_path: Path) -> None:
     """Regression: sample.json study/assay XLSX write under arctrl 3.2+."""

--- a/middleware/tools/repro_fable_int32_divmod.py
+++ b/middleware/tools/repro_fable_int32_divmod.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Minimal repro: fable.Int32 breaks openpyxl column letters (arctrl 3.2 Write).
+
+Requires:
+    pip install 'arctrl==3.2.1'
+
+Run:
+    python repro_fable_int32_divmod.py
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+from arctrl import ARC  # type: ignore[import-untyped]
+from fable_library.core import int32  # type: ignore[import-untyped]
+from openpyxl.utils.cell import get_column_letter  # type: ignore[import-untyped]
+
+
+def repro_divmod() -> None:
+    """Reproduce builtins.divmod failing on fable.Int32 (openpyxl column-letter path)."""
+    # openpyxl.utils.cell.get_column_letter does: divmod(col_idx, 26)
+    # Column indices from FsSpreadsheet/arctrl 3.2 are fable.Int32.
+    print("divmod(int32(44), 26) ->", end=" ")
+    print(divmod(int32(44), 26))
+
+
+def repro_openpyxl() -> None:
+    """Reproduce openpyxl get_column_letter failing when given fable.Int32."""
+    print("get_column_letter(int32(44)) ->", end=" ")
+    print(get_column_letter(int32(44)))
+
+
+def repro_arc_write(rocrate_path: str, out_dir: str) -> None:
+    """Write an ARC from a RO-Crate that includes study/assay sheets."""
+    arc = ARC.from_rocrate_json_string(Path(rocrate_path).read_text(encoding="utf-8"))
+    print(f"ARC.Write({out_dir!r}) ...")
+    arc.Write(out_dir)
+    print("Write OK")
+
+
+if __name__ == "__main__":
+    print("arctrl / fable-library Int32 × openpyxl divmod repro\n")
+    try:
+        import importlib.metadata as md
+
+        print("arctrl", md.version("arctrl"))
+        print("fable-library", md.version("fable-library"))
+        print("openpyxl", md.version("openpyxl"))
+        print()
+    except Exception as exc:  # noqa: BLE001
+        print("version lookup failed:", exc)
+
+    try:
+        repro_divmod()
+    except TypeError as exc:
+        print("TypeError:", exc)
+
+    try:
+        repro_openpyxl()
+    except TypeError as exc:
+        print("TypeError:", exc)
+
+    if len(sys.argv) > 1:
+        with tempfile.TemporaryDirectory() as tmp:
+            try:
+                repro_arc_write(sys.argv[1], tmp)
+            except Exception as exc:  # noqa: BLE001
+                print("ARC.Write failed:", exc)
+                raise SystemExit(1) from exc

--- a/middleware/tools/repro_fable_int32_divmod.py
+++ b/middleware/tools/repro_fable_int32_divmod.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python3
 """Minimal repro: fable.Int32 breaks openpyxl column letters (arctrl 3.2 Write).
 
-Requires:
-    pip install 'arctrl==3.2.1'
-
 Run:
-    python repro_fable_int32_divmod.py
+    uv run --with 'arctrl==3.2.1' python repro_fable_int32_divmod.py
 """
 
 from __future__ import annotations

--- a/middleware/tools/rocrate2arc.py
+++ b/middleware/tools/rocrate2arc.py
@@ -21,8 +21,10 @@ def _patch_fable_int32_for_openpyxl() -> None:
         result = divmod(int(other), int(self))  # type: ignore[call-overload]
         return int(result[0]), int(result[1])
 
-    Int32.__divmod__ = divmod_method  # type: ignore[method-assign, assignment]
-    Int32.__rdivmod__ = rdivmod_method  # type: ignore[method-assign, assignment]
+    if "__divmod__" not in Int32.__dict__:
+        Int32.__divmod__ = divmod_method  # type: ignore[method-assign, assignment]
+    if "__rdivmod__" not in Int32.__dict__:
+        Int32.__rdivmod__ = rdivmod_method  # type: ignore[method-assign, assignment]
 
 
 _patch_fable_int32_for_openpyxl()

--- a/middleware/tools/rocrate2arc.py
+++ b/middleware/tools/rocrate2arc.py
@@ -7,7 +7,12 @@ from arctrl import ARC  # type: ignore[import-untyped]
 
 
 def _patch_fable_int32_for_openpyxl() -> None:
-    """Apply openpyxl/fable Int32 divmod shim (tools has no dependency on api)."""
+    """Apply openpyxl/fable Int32 divmod shim (tools has no dependency on api).
+
+    Intentionally duplicated from ``middleware.api.arc_store.arctrl_compat`` so this
+    tool stays free of an ``api`` dependency. Keep in sync; remove both when upstream
+    is fixed (https://github.com/fairagro/m4.2_advanced_middleware_api/issues/339).
+    """
     try:
         from fable_library.core import Int32  # type: ignore[import-untyped]
     except ImportError:

--- a/middleware/tools/rocrate2arc.py
+++ b/middleware/tools/rocrate2arc.py
@@ -6,6 +6,28 @@ import pstats
 from arctrl import ARC  # type: ignore[import-untyped]
 
 
+def _patch_fable_int32_for_openpyxl() -> None:
+    """Apply openpyxl/fable Int32 divmod shim (tools has no dependency on api)."""
+    try:
+        from fable_library.core import Int32  # type: ignore[import-untyped]
+    except ImportError:
+        return
+
+    def divmod_method(self: object, other: object) -> tuple[int, int]:
+        result = divmod(int(self), int(other))  # type: ignore[call-overload]
+        return int(result[0]), int(result[1])
+
+    def rdivmod_method(self: object, other: object) -> tuple[int, int]:
+        result = divmod(int(other), int(self))  # type: ignore[call-overload]
+        return int(result[0]), int(result[1])
+
+    Int32.__divmod__ = divmod_method  # type: ignore[method-assign, assignment]
+    Int32.__rdivmod__ = rdivmod_method  # type: ignore[method-assign, assignment]
+
+
+_patch_fable_int32_for_openpyxl()
+
+
 def rocrate_json_to_arc(rocrate_input_path: str, arc_path: str) -> None:
     """Convert a RO-Crate JSON file to ARC format and save to a file."""
     with open(rocrate_input_path, encoding="utf-8") as f:


### PR DESCRIPTION
openpyxl column-letter generation calls builtins.divmod on fable.Int32
indices from arctrl 3.2 / fable-library, which lacks __divmod__ and breaks
study/assay XLSX writes. Patch Int32 at ArcStore import time.

Co-authored-by: Cursor <cursoragent@cursor.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Monkey-patching a third-party numeric type at import time changes global behavior for all code using fable Int32 in the process, though the change is narrow and tied to a known upstream packaging bug.
> 
> **Overview**
> **Fixes `ARC.Write` failures under arctrl 3.2+** when writing study/assay ISA XLSX files: openpyxl’s column-letter logic calls `divmod` on `fable.Int32` indices, which lack `__divmod__` and previously raised `TypeError`.
> 
> A new **`arctrl_compat`** module monkey-patches `fable_library.core.Int32` with `__divmod__` / `__rdivmod__` (idempotent, skipped if fable is missing). The patch runs at **`arc_store` import time** so API paths that write ARCs get the fix automatically.
> 
> The same shim is **duplicated in `rocrate2arc.py`** so the standalone tool stays independent of the API package. Unit tests cover idempotency, `divmod(Int32, int)`, and a regression write from `sample.json`; a small **`repro_fable_int32_divmod.py`** script documents the upstream issue for manual debugging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95565e67857766847231120469a7c84ee8d464d8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->